### PR TITLE
fix: 修復首次啟動三項隱患並補強 README / copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,75 @@
+# Copilot Instructions — serialwrap
+
+> 本專案文件、註解、commit message 一律使用**繁體中文**。Copilot 回覆也請使用繁體中文。
+
+## 架構
+
+serialwrap 是面向多 Agent UART 協作的 broker 架構，三大元件：
+
+- **`serialwrapd.py`** — singleton daemon，獨占實體 UART。以 asyncio 事件迴圈運行 JSON-RPC Unix socket server（`sw_core/rpc.py`）。所有 UART 讀寫皆經此 daemon。
+- **`serialwrap`**（CLI client）— 子命令式 CLI（`sw_core/cli.py`），透過 Unix socket 發送 JSON-RPC 呼叫（`sw_core/client.py`）。
+- **`serialwrap-mcp`**（`sw_mcp/server.py`）— MCP adapter，將 MCP 工具名稱（如 `serialwrap_submit_command`）透過 `_TOOL_MAP` 轉換為內部 RPC 方法（如 `command.submit`）。已安裝至 Codex 環境作為 MCP server 使用。
+
+### 內部模組對照
+
+```
+sw_core/service.py    SerialwrapService — 頂層調度器，擁有所有子系統，路由 RPC 方法
+sw_core/arbiter.py    CommandArbiter — 每 session 優先佇列，單寫入者保證（每 session 一條 worker thread）
+sw_core/session_manager.py  SessionManager — session 生命週期（DETACHED → ATTACHING → READY）、裝置綁定、alias 解析
+sw_core/uart_io.py    UARTBridge — serial port + PTY bridge，TX/RX 搭配 WAL 記錄
+sw_core/login_fsm.py  ensure_ready() — 平台相依 login FSM（bcm vs prpl 路徑）
+sw_core/wal.py        WalWriter — 雙軌 append-only log：raw.wal.ndjson（機器可讀）+ raw.mirror.log（人類可讀）
+sw_core/device_watcher.py  DeviceWatcher — 輪詢 /dev/serial/by-id/ 偵測 hotplug 事件
+sw_core/config.py     Profile/target YAML 載入：ProfileTemplate → SessionProfile 合併
+sw_core/alias_registry.py  Alias → session_id / by-id 映射
+```
+
+### 核心不變量
+
+- 單 UART 單寫入者 — `CommandArbiter` 透過優先佇列 worker thread 保證每 session 同時只有一條命令執行。
+- 每筆 WAL 事件帶 `seq + timestamp + source + cmd_id + crc32`，確保完整可追溯。
+- Session 狀態機：`DETACHED` → `ATTACHING` → `READY`。僅 `READY` 狀態接受命令。
+- 裝置綁定使用 `/dev/serial/by-id/` 路徑（跨重開機穩定）。同一 `by-id` 裝置重新插入時自動掛回。
+
+### IPC 協定
+
+JSON-RPC over Unix socket（`/tmp/serialwrap/serialwrapd.sock`）。每行一個 JSON 物件，換行分隔。所有回應包含 `"ok": true/false`，錯誤回應包含 `error_code`。
+
+### Profile 系統
+
+`profiles/` 中的 YAML 檔定義 `ProfileTemplate`（login/prompt/UART 參數）與 `targets`（將 template 綁定到 COM slot + 裝置）。Template 與 target 透過 `config.py` 的 `_merge_session()` 合併，target 欄位覆蓋 template 預設值。
+
+## 建置與測試
+
+無建置步驟。純 Python，執行期依賴 `pyyaml` 與 `pyserial`。
+
+```bash
+# 執行全部測試
+python3 -m unittest discover -s tests -v
+
+# 執行單一測試檔
+python3 -m unittest tests.test_wal -v
+
+# 執行單一測試方法
+python3 -m unittest tests.test_wal.TestWal.test_append_and_tail -v
+```
+
+測試框架使用 `unittest`（非 pytest）。E2E 測試（`test_multiagent_e2e.py`）會啟動真實 daemon 搭配 PTY 模擬 target，測試完整流程包含 arbiter 序列化。
+
+## 慣例
+
+- **語言**：Python 3.10+，所有檔案使用 `from __future__ import annotations`。所有函式簽章附型別提示。
+- **Dataclasses**：值物件使用 `frozen=True`（`UartProfile`、`ProfileTemplate`、`SessionProfile`、`DeviceInfo`）。可變執行期狀態使用一般 dataclass（`SessionRuntime`）。
+- **RPC 路由**：`SerialwrapService.rpc()` 為平面 if/elif 分派器，無動態方法註冊。新增 RPC 方法直接加分支。
+- **JSON 輸出**：CLI 與 MCP 一律輸出緊湊 JSON（`separators=(",",":")`）並使用 `ensure_ascii=False`。WAL 使用 `sort_keys=True` 確保穩定序列化。
+- **錯誤模式**：所有 RPC 回應為 `dict[str, Any]`，包含 `ok: bool`，失敗時附 `error_code: str`。例外不跨越 RPC 邊界。
+- **執行緒**：共享狀態使用 `threading.RLock`，停止訊號使用 `threading.Event`，worker 使用 daemon thread。核心不使用 asyncio — 僅 RPC server 使用 asyncio。
+- **文件語言**：註解、docstring、README、規格書一律使用繁體中文。
+- **`serialwrap_lib.py`**：v1 舊版函式庫（tmux/minicom 方式）。v2 daemon 架構（`sw_core/`）為目前主力。
+
+## 安裝
+
+```bash
+./install.sh              # 安裝至 ~/.paul_tools/
+./install.sh /custom/path # 安裝至自訂路徑
+```

--- a/README.md
+++ b/README.md
@@ -3,29 +3,19 @@
 `serialwrap` 是面向單一 UART/多 Agent 協作的 broker 架構，核心是 `serialwrapd`（常駐仲裁）+ `serialwrap`（CLI client）+ `serialwrap-mcp`（MCP adapter）。
 
 ## 動機
+
 - 解決多 Agent/人類同時操作 UART 時的競爭寫入、回應混線、資料遺失與不可追溯。
 - 提供可機器處理與可人工閱讀的雙軌原始紀錄，滿足除錯、稽核與回放需求。
 - 將 profile 與實體 UART 連接點解耦，讓同一組 login/UART 參數可套用到多個 target。
 
-## 原機（既有方式的限制）
-- 直接多程序開啟 `/dev/ttyUSB*`：無全域仲裁，TX 交錯，RX 難對應。
-- `logread -f`、`tcpdump`、kernel debug 長流模式：沒有明確結束點，舊流程容易誤判。
-- 以手工 minicom 互動為主：可視化有餘，但對多 Agent 任務協同與可追溯不足。
+## 依賴
 
-## 功能
-- 單 UART 單寫入者仲裁（Command Arbiter），避免多來源直接衝突。
-- RAW 事件雙軌保存：
-  - 權威檔：`/tmp/serialwrap/wal/raw.wal.ndjson`
-  - 文字鏡像：`/tmp/serialwrap/wal/raw.mirror.log`
-- `seq + timestamp + source + cmd_id + crc32` 追蹤鏈路，支持完整回溯。
-- Profile/Target 分離：
-  - `profiles`：login/prompt/UART 參數模板（不綁 port）
-  - target binding：以 `/dev/serial/by-id/*` 綁定實體裝置
-- 動態 hotplug：拔除轉 `DETACHED`，同 `by-id` 回插可自動掛回。
-- 人類互動相容：`minicom_router.sh` 優先走 broker PTY，必要時才 raw fallback。
-- MCP 化：提供 `serialwrap-mcp` 供 Agent 透過 stdio 工具介面呼叫。
+- Python 3.10+
+- `pyyaml` — profile YAML 解析
+- `pyserial`（間接需要 `termios`）— UART 控制
 
 ## 架構
+
 ```text
 Agent/CLI ----\
 Agent/MCP -----+--> serialwrapd (RPC + Arbiter) --> UART IO --> Target Shell
@@ -34,73 +24,192 @@ Human/minicom -/              |
                               +--> Mirror (raw.mirror.log)
 ```
 
-- `serialwrapd.py`：daemon 入口，維持 singleton 與 RPC socket。
-- `sw_core/*`：仲裁、UART、session、login FSM、device watcher、WAL。
-- `sw_mcp/server.py`：MCP adapter（stdio in/out），轉發到 `serialwrapd` RPC。
-- 詳細規格：`/home/paul_chen/arc_prj/ser-dep/docs/serialwrap-spec.md`
+| 元件 | 入口 | 說明 |
+|------|------|------|
+| **daemon** | `serialwrapd.py` | singleton 常駐，獨占實體 UART，提供 JSON-RPC Unix socket |
+| **CLI client** | `serialwrap` → `sw_core/cli.py` | 子命令式 CLI，透過 socket 發送 RPC |
+| **MCP adapter** | `serialwrap-mcp` → `sw_mcp/server.py` | 將 MCP 工具名對應到內部 RPC 方法（`_TOOL_MAP`） |
 
-## 安裝說明
-### 1) 部署
-```bash
-/home/paul_chen/arc_prj/ser-dep/install.sh
-/home/paul_chen/arc_prj/ser-dep/install.sh /home/paul_chen/.paul_tools
+### 內部模組
+
+| 模組 | 職責 |
+|------|------|
+| `sw_core/service.py` | 頂層調度器（`SerialwrapService`），路由所有 RPC 方法 |
+| `sw_core/arbiter.py` | 每 session 優先佇列，單寫入者保證 |
+| `sw_core/session_manager.py` | session 生命週期管理、裝置綁定、alias 解析 |
+| `sw_core/uart_io.py` | serial port + PTY bridge，TX/RX 搭配 WAL 記錄 |
+| `sw_core/login_fsm.py` | 平台相依 login FSM（`bcm` / `prpl` 路徑） |
+| `sw_core/wal.py` | 雙軌 append-only log |
+| `sw_core/device_watcher.py` | 輪詢 `/dev/serial/by-id/` 偵測 hotplug |
+| `sw_core/config.py` | profile YAML 載入：`ProfileTemplate` → `SessionProfile` 合併 |
+| `sw_core/alias_registry.py` | alias → session_id / by-id 映射 |
+
+### Session 狀態機
+
+```text
+DETACHED ──(裝置出現 + attach)──► ATTACHING ──(login FSM 成功)──► READY
+   ▲                                  │                            │
+   │                                  │ (FSM 失敗/例外)            │ (裝置拔除)
+   └──────────────────────────────────┘                            │
+   └───────────────────────────────────────────────────────────────┘
 ```
 
-### 2) Shell 設定（建議）
-```bash
-export PATH="/home/paul_chen/.paul_tools:$PATH"
-alias minicom="/home/paul_chen/.paul_tools/minicom_router.sh"
+- `DETACHED`：未連接或裝置已移除。
+- `ATTACHING`：bridge 已開啟，login FSM 進行中。
+- `READY`：可接受命令。arbiter worker thread 已註冊。
+
+### 啟動流程
+
+```text
+serialwrap daemon start
+  └─ Popen(serialwrapd.py, background)
+       └─ ensure_runtime_dirs()        建立 /tmp/serialwrap/*
+       └─ load_profiles(profile_dir)   載入 profiles/*.yaml
+       └─ SingletonLock.acquire()      flock + socket 排他
+       └─ SerialwrapService(profiles)
+            └─ SessionManager.__init__  讀取 state.json（alias/binding 持久化）
+       └─ service.start()
+            └─ DeviceWatcher.start()   啟動輪詢線程
+            └─ poll_once()             首次掃描 → update_devices → _spawn_attach
+            └─ bootstrap_attach()      確保所有已知裝置嘗試 attach
+       └─ server.start()              建立 Unix socket，開始接受連線
+       └─ stop_event.wait()           阻塞直到 SIGTERM/daemon.stop
+  └─ CLI 等待就緒（health.ping，最多 3 秒）
+       └─ 成功 → 回報 pid + socket（附帶 warnings 如有）
+       └─ daemon 提前退出 → DAEMON_EXITED
+       └─ 超時 → DAEMON_NOT_READY
 ```
 
-### 3) 啟動 daemon
-```bash
-/home/paul_chen/.paul_tools/serialwrap daemon start --profile-dir /home/paul_chen/.paul_tools/profiles
-/home/paul_chen/.paul_tools/serialwrap daemon status
+### WAL 雙軌記錄
+
+| 檔案 | 格式 | 用途 |
+|------|------|------|
+| `/tmp/serialwrap/wal/raw.wal.ndjson` | NDJSON（base64 payload） | 機器可讀權威記錄 |
+| `/tmp/serialwrap/wal/raw.mirror.log` | 純文字 | 人類可讀鏡像 |
+
+每筆記錄包含：`seq`、`mono_ts_ns`、`wall_ts`、`com`、`dir`、`source`、`cmd_id`、`len`、`crc32`、`payload_b64`。
+WAL 檔案達 64 MiB 自動 rotate。
+
+### 環境變數
+
+| 變數 | 預設值 | 說明 |
+|------|--------|------|
+| `SERIALWRAP_STATE_DIR` | `/tmp/serialwrap` | 狀態目錄（WAL、state.json） |
+| `SERIALWRAP_RUN_DIR` | 同 `STATE_DIR` | lock/socket 目錄 |
+| `SERIALWRAP_PROFILE_DIR` | `<安裝目錄>/profiles` | profile YAML 目錄 |
+| `SERIALWRAP_BY_ID_DIR` | `/dev/serial/by-id` | 裝置搜尋目錄 |
+
+### Profile 系統
+
+`profiles/*.yaml` 定義 `ProfileTemplate`（login/prompt/UART 參數模板）與 `targets`（將 template 綁定到 COM slot + 裝置）。target 欄位覆蓋 template 預設值。
+
+```yaml
+profiles:
+  prpl-template:
+    platform: prpl
+    prompt_regex: ".*# $"
+    uart:
+      baud: 115200
+
+targets:
+  - act_no: 1
+    com: COM0
+    alias: default+1
+    profile: prpl-template
+    device_by_id: /dev/serial/by-id/target0
 ```
 
-## 使用說明（Help）
+## 安裝
+
+```bash
+# 預設安裝至 ~/.paul_tools/
+./install.sh
+
+# 指定安裝目錄
+./install.sh /path/to/install
+```
+
+安裝後建議設定 shell：
+
+```bash
+export INSTALL_DIR="$HOME/.paul_tools"   # 或你指定的路徑
+export PATH="$INSTALL_DIR:$PATH"
+alias minicom="$INSTALL_DIR/minicom_router.sh"
+```
+
+## 啟動 daemon
+
+```bash
+serialwrap daemon start --profile-dir "$INSTALL_DIR/profiles"
+serialwrap daemon status
+```
+
+## 使用說明
+
 ### CLI help
+
 ```bash
-/home/paul_chen/.paul_tools/serialwrap --help
-/home/paul_chen/.paul_tools/serialwrap daemon --help
-/home/paul_chen/.paul_tools/serialwrap session --help
-/home/paul_chen/.paul_tools/serialwrap cmd --help
-/home/paul_chen/.paul_tools/serialwrap log --help
+serialwrap --help
+serialwrap daemon --help
+serialwrap session --help
+serialwrap cmd --help
+serialwrap log --help
 ```
 
 ### 常用操作流程
-```bash
-# 1) 看裝置/Session
-/home/paul_chen/.paul_tools/serialwrap device list
-/home/paul_chen/.paul_tools/serialwrap session list
 
-# 2) 綁定目標並 attach（只需首次或換線）
-/home/paul_chen/.paul_tools/serialwrap session bind --selector COM0 --device-by-id /dev/serial/by-id/<target-by-id>
-/home/paul_chen/.paul_tools/serialwrap session attach --selector COM0
+```bash
+# 1) 查看裝置與 Session
+serialwrap device list
+serialwrap session list
+
+# 2) 綁定目標並 attach（首次或換線時）
+serialwrap session bind --selector COM0 --device-by-id /dev/serial/by-id/<target-by-id>
+serialwrap session attach --selector COM0
 
 # 3) 下命令與查結果
-/home/paul_chen/.paul_tools/serialwrap cmd submit --selector COM0 --source agent:test --cmd "ifconfig"
-/home/paul_chen/.paul_tools/serialwrap cmd status --cmd-id <cmd_id>
+serialwrap cmd submit --selector COM0 --source agent:test --cmd "ifconfig"
+serialwrap cmd status --cmd-id <cmd_id>
 
 # 4) 追蹤輸出與原始資料
-/home/paul_chen/.paul_tools/serialwrap log tail-text --selector COM0 --from-seq 0 --limit 200
-/home/paul_chen/.paul_tools/serialwrap log tail-raw  --selector COM0 --from-seq 0 --limit 200
-/home/paul_chen/.paul_tools/serialwrap wal export --from-seq 0 --limit 500
+serialwrap log tail-text --selector COM0 --from-seq 0 --limit 200
+serialwrap log tail-raw  --selector COM0 --from-seq 0 --limit 200
+serialwrap wal export --from-seq 0 --limit 500
 ```
 
-### MCP help 與單次呼叫
+### MCP 呼叫
+
 ```bash
-/home/paul_chen/.paul_tools/serialwrap-mcp --help
-/home/paul_chen/.paul_tools/serialwrap-mcp --tool serialwrap_get_health --params "{}"
-/home/paul_chen/.paul_tools/serialwrap-mcp --tool serialwrap_list_sessions --params "{}"
-/home/paul_chen/.paul_tools/serialwrap-mcp --tool serialwrap_submit_command --params "{\"selector\":\"COM0\",\"cmd\":\"echo hello\",\"source\":\"agent:mcp\"}"
+serialwrap-mcp --help
+serialwrap-mcp --tool serialwrap_get_health --params "{}"
+serialwrap-mcp --tool serialwrap_list_sessions --params "{}"
+serialwrap-mcp --tool serialwrap_submit_command \
+  --params '{"selector":"COM0","cmd":"echo hello","source":"agent:mcp"}'
 ```
 
 ### minicom 互動
+
 ```bash
 # 自動選 READY session 的 broker PTY
 minicom
 
 # 指定 session/com/alias
-/home/paul_chen/.paul_tools/minicom_router.sh COM0
+minicom_router.sh COM0
 ```
+
+## 測試
+
+```bash
+# 全部測試
+python3 -m unittest discover -s tests -v
+
+# 單一測試檔
+python3 -m unittest tests.test_wal -v
+
+# 單一測試方法
+python3 -m unittest tests.test_wal.TestWal.test_append_and_tail -v
+```
+
+## 規格書
+
+詳細設計規格見 `docs/serialwrap-spec.md`。

--- a/sw_core/cli.py
+++ b/sw_core/cli.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from typing import Any
 
 from .client import rpc_call
@@ -36,8 +37,25 @@ def _run_daemon_start(args: argparse.Namespace) -> int:
         return subprocess.call(cmd)
 
     proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
-    _print({"ok": True, "pid": proc.pid, "socket": args.socket})
-    return 0
+
+    # 等待 daemon 就緒（最多 3 秒）
+    for attempt in range(15):
+        time.sleep(0.2)
+        if proc.poll() is not None:
+            _print({"ok": False, "error_code": "DAEMON_EXITED", "pid": proc.pid, "returncode": proc.returncode})
+            return 2
+        resp = rpc_call(args.socket, "health.ping", {}, timeout_s=0.5)
+        if resp.get("ok"):
+            result: dict[str, Any] = {"ok": True, "pid": proc.pid, "socket": args.socket}
+            health = rpc_call(args.socket, "health.status", {}, timeout_s=1.0)
+            warnings = health.get("warnings")
+            if warnings:
+                result["warnings"] = warnings
+            _print(result)
+            return 0
+
+    _print({"ok": False, "error_code": "DAEMON_NOT_READY", "pid": proc.pid})
+    return 2
 
 
 def _run_daemon_stop(args: argparse.Namespace) -> int:

--- a/sw_core/service.py
+++ b/sw_core/service.py
@@ -19,6 +19,7 @@ class SerialwrapService:
         self._lock = threading.RLock()
         self._running = False
         self._started_at: str | None = None
+        self._profile_count = len(profiles)
 
         self._arbiter = CommandArbiter(self._send_cb)
         self._sessions = SessionManager(profiles, self._wal, on_ready=self._on_ready, on_detached=self._on_detached)
@@ -59,16 +60,26 @@ class SerialwrapService:
 
     def health(self) -> dict[str, Any]:
         with self._lock:
-            return {
+            sessions = self._sessions.list_sessions()
+            devices = self._sessions.list_devices()
+            warnings: list[str] = []
+            if self._profile_count == 0:
+                warnings.append("no_profiles_loaded")
+            if not devices:
+                warnings.append("no_devices_found")
+            result: dict[str, Any] = {
                 "ok": True,
                 "pid": os.getpid(),
                 "running": self._running,
                 "started_at": self._started_at,
-                "sessions": len(self._sessions.list_sessions()),
-                "devices": len(self._sessions.list_devices()),
+                "sessions": len(sessions),
+                "devices": len(devices),
                 "wal_path": self._wal.wal_path,
                 "mirror_path": self._wal.mirror_path,
             }
+            if warnings:
+                result["warnings"] = warnings
+            return result
 
     def _resolve_session_id(self, selector: str) -> tuple[str | None, dict[str, Any] | None]:
         state = self._sessions.get_session_state(selector)

--- a/sw_core/session_manager.py
+++ b/sw_core/session_manager.py
@@ -324,11 +324,22 @@ class SessionManager:
                 self._on_detached(session.session_id)
                 return
 
-            session.bridge = bridge
-            session.vtty_path = bridge.vtty_path
-            session.state = "READY"
-            session.last_error = None
-            session.last_ready_at = now_iso()
+            # 持鎖重新驗證裝置是否仍存在，避免與 _detach_by_id 競態
+            with self._lock:
+                if by_id not in self._devices or session.state == "DETACHED":
+                    bridge.stop()
+                    session.state = "DETACHED"
+                    session.last_error = "DEVICE_REMOVED_DURING_ATTACH"
+                    session.detached_at = now_iso()
+                    session.bridge = None
+                    session.vtty_path = None
+                    return
+
+                session.bridge = bridge
+                session.vtty_path = bridge.vtty_path
+                session.state = "READY"
+                session.last_error = None
+                session.last_ready_at = now_iso()
             self._on_ready(session.session_id)
         except Exception as exc:
             try:


### PR DESCRIPTION
## 修復內容

### 隱患 1：daemon start 就緒探測（`sw_core/cli.py`）
啟動後等待 `health.ping` 確認 daemon 就緒（最多 3 秒），取代原本直接回傳 PID。
- daemon 提前退出 → `DAEMON_EXITED`
- 超時未就緒 → `DAEMON_NOT_READY`

### 隱患 2：attach/detach 競態（`sw_core/session_manager.py`）
`_attach_by_id` 完成 `ensure_ready` 後，持鎖重新驗證裝置是否仍在 `_devices` 中。
避免裝置在 attach 過程中被拔除時，session 被錯誤覆寫為 `READY`。

### 隱患 3：health warnings（`sw_core/service.py`）
`health.status` 回應新增 `warnings` 欄位：
- `no_profiles_loaded` — 無 profile 被載入
- `no_devices_found` — 無裝置被偵測到

`daemon start` 就緒探測成功後，若有 warnings 一併轉發給使用者。

## README 補強
- 移除寫死的絕對路徑，改用相對路徑 / `$INSTALL_DIR`
- 新增：依賴說明、環境變數、Session 狀態機、啟動流程圖、測試指令、Profile 範例
- 新增 `.github/copilot-instructions.md`

## 測試
全部 15 個既有測試通過，無回歸。