### PR TITLE
refactor(session-fsm): 新增 ATTACHED 狀態，重構 login 觸發邊界

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,14 @@ sequenceDiagram
     D->>SM: update_devices
     SM->>U: attach by-id
     U->>T: empty line
-    U->>T: ready_probe
-    T-->>U: login/prompt/probe
-    U-->>SM: ready
-    SM-->>D: session READY
+    T-->>U: prompt / login / boot log
+    alt 已有 shell prompt
+        U->>T: ready_probe
+        T-->>U: nonce + prompt
+        U-->>SM: READY
+    else 尚未 ready
+        U-->>SM: ATTACHED
+    end
     D-->>CLI: health ok
 ```
 
@@ -105,7 +109,7 @@ flowchart TD
     I2 --> I3["close lease"]
     M1 -->|recover| R1["Ctrl-C"]
     R1 --> R2["Ctrl-D"]
-    R2 --> R3["reboot -f"]
+    R2 --> R3["停在 ATTACHED，等待人類或後續 agent 決策"]
 
     classDef flow fill:#eef7e8,stroke:#4f7a3f,stroke-width:1px;
     classDef warn fill:#fff4e6,stroke:#9a6b25,stroke-width:1px;
@@ -120,7 +124,7 @@ flowchart TD
 # 安裝
 ./install.sh
 
-# 啟動 daemon
+# 啟動 daemon（若 `~/OPI.env` 存在會先自動載入）
 serialwrap daemon start --profile-dir "$HOME/.paul_tools/profiles"
 
 # 檢查健康狀態
@@ -164,7 +168,7 @@ profiles:
   opi-shell:
     platform: shell
     prompt_regex: ".*[$#] $"
-    login_regex: "(?mi)^login:\\s*$"
+    login_regex: "(?mi)^.*login:\\s*$"
     password_regex: "(?mi)^password:\\s*$"
     user_env: "SW_OPI_U"
     pass_env: "SW_OPI_P"
@@ -190,15 +194,20 @@ targets:
     device_by_id: /dev/serial/by-id/<target2>
 ```
 
-`user_env` / `pass_env` 是每個 profile 自己指定的登入帳密環境變數名稱。CLI / daemon 不會把密碼寫進 YAML 或 WAL。
+`user_env` / `pass_env` 是每個 profile 自己指定的登入帳密環境變數名稱。CLI / daemon 不會把密碼寫進 YAML 或 WAL。`serialwrap daemon start` 會在啟動前先嘗試載入 `~/OPI.env`；若檔案不存在，則維持既有行為。
 
 ```bash
-export SW_OPI_U='haman'
-export SW_OPI_P='your-password'
+cat > ~/OPI.env <<'EOF'
+SW_OPI_U='haman'
+SW_OPI_P='your-password'
+EOF
+
 serialwrap daemon start --profile-dir "$HOME/.paul_tools/profiles"
 ```
 
-若 shell device 已經自動登入，`serialwrap` 會直接用 prompt + `ready_probe` 驗證；若先看到 `login:` / `password:`，則會依 `user_env` / `pass_env` 自動登入。
+若你偏好手動設定環境變數，也可以沿用原本的 `export SW_OPI_U=...` / `export SW_OPI_P=...` 方式再啟動 daemon。
+
+若 shell device 已經自動登入，`serialwrap` 會直接用 prompt + `ready_probe` 驗證；若先看到 `login:` / `password:`，則會依 `user_env` / `pass_env` 自動登入。像 Orange Pi 常見的 `orangepi3 login:`，建議 `login_regex` 用 `(?mi)^.*login:\\s*$`。
 
 常用查看：
 
@@ -258,7 +267,7 @@ serialwrap session interactive-close --interactive-id <interactive_id>
 5. 結束後自動 `session console-detach`
 
 ```bash
-# 自動選第一個 READY session
+# 自動選第一個 READY，否則退而求其次選 ATTACHED session
 minicom
 
 # 指定 COM 或 alias
@@ -272,8 +281,10 @@ minicom -D /dev/ttyUSB0
 重要限制：
 
 - minicom 看到的是透明 RX 視圖。
-- 一般 human 輸入會以「逐行」方式進入 broker queue，與 agent 共用單寫入仲裁。
+- 一般 human 輸入會以「逐行」方式進入 broker queue，與 agent 共用單寫入仲裁；broker 會替 minicom 做本地回顯與基本 backspace 行編輯。
+- 若 session 只有 `ATTACHED`（bridge 已掛上但尚未 ready），`session console-attach` 仍可進入 brokered minicom；這時 console 會自動拿到 raw human ownership，方便手動登入或觀察 boot/log 狀態。
 - 若要讓某個 console 進入 raw interactive ownership，先 `console-attach` 拿到 `client_id`，再用 `interactive-open --owner human:<client_id>` 開 lease。
+- 常見 human/minicom 互動式命令（例如 `vi`、`vim`、`top`、`htop`、`less`、`menuconfig`）會自動升級成 human interactive ownership，不再因為等不到 shell prompt 而自動觸發 recover / reboot。
 
 手動 console 控制範例：
 
@@ -302,6 +313,10 @@ serialwrap session self-test --selector COM0
 - `VTTY_STALE`
 - `TARGET_UNRESPONSIVE`
 - `SESSION_RECOVERING`
+- `LOGIN_REQUIRED`：bridge 已掛，看到 `login:` prompt，但無 `pending_auto_login`，等待 human 手動登入
+- `ATTACHED_NOT_READY`：bridge 已掛，但 prompt probe 失敗（如 boot log 中、前景程式仍在跑）
+- `REBOOTING`：agent 已送出 reboot 類指令，正在等待 target 重開機完畢後自動 relogin
+- `HUMAN_INTERACTIVE_ACTIVE`：human console 目前握有 interactive ownership，不適合 agent 干預
 
 ### Recover
 
@@ -313,9 +328,10 @@ recover 升級順序固定：
 
 1. `Ctrl-C`
 2. `Ctrl-D`
-3. `reboot -f`
 
-若進入 reboot recover，session 會轉成 `RECOVERING`，之後由 attach/login FSM 自動回到 `READY`。
+若 `Ctrl-C` / `Ctrl-D` 都救不回 prompt，session 會降級成 `ATTACHED`，保留 bridge 與 console，交由 human/minicom 接手。
+
+只有 **agent 明確送出 reboot 類指令** 時，daemon 才會進入 `RECOVERING`，並在 target 回來後自動重新 login / 回到 `READY`。
 
 ## 日誌與輸出
 

--- a/docs/serialwrap-spec.md
+++ b/docs/serialwrap-spec.md
@@ -21,7 +21,7 @@
 - command 可回傳結構化結果
 - background / interactive / recover 有明確模型
 - 裝置換 tty、bridge stale、target 無回應可被分類
-- reboot 後可自動重新 attach / login / READY
+- 只有 agent 明確 reboot 時才自動重新 login / READY
 
 ### 2.2 核心不變量
 
@@ -87,16 +87,17 @@ flowchart LR
 ### 4.1 啟動步驟
 
 1. `serialwrap daemon start`
-2. 建立 runtime dirs / lock / socket
-3. 載入 `profiles/*.yaml`
-4. 建立 `SerialwrapService`
-5. 啟動 `DeviceWatcher`
-6. 首次掃描 by-id
-7. 依裝置嘗試 attach
-8. `UARTBridge.start()`
-9. `ensure_ready()`
-10. session 進 `READY`
-11. CLI / MCP 可正式提交命令
+2. CLI 若發現 `~/OPI.env`，先以 shell 載入帳密相關環境變數
+3. 建立 runtime dirs / lock / socket
+4. 載入 `profiles/*.yaml`
+5. 建立 `SerialwrapService`
+6. 啟動 `DeviceWatcher`
+7. 首次掃描 by-id
+8. 依裝置嘗試 attach
+9. `UARTBridge.start()`
+10. `ensure_ready()`
+11. session 進 `READY`
+12. CLI / MCP 可正式提交命令
 
 ### 4.2 啟動時序圖
 
@@ -111,6 +112,7 @@ sequenceDiagram
     participant T as Target
 
     User->>CLI: daemon start
+    CLI->>CLI: source ~/OPI.env (if exists)
     CLI->>D: spawn
     D->>W: start
     W->>S: update devices
@@ -129,15 +131,19 @@ sequenceDiagram
 
 - `DETACHED`
 - `ATTACHING`
+- `ATTACHED`
 - `READY`
 - `RECOVERING`
 
 ### 5.2 Console 模型
 
-- 每個 `READY` session 至少有一個 primary console PTY
+- 每個已掛上 bridge 的 session 都至少有一個 primary console PTY
 - `session.console_attach` 會再建立一個專屬 PTY
 - 所有 console 都收到同一份 RX fan-out
 - 非 interactive owner 的 human input 只會緩衝成 line，經 broker queue 執行
+- line-buffered human input 由 broker 提供本地回顯與基本 backspace 行編輯，避免 minicom 看不到鍵入內容
+- 常見 human/minicom 互動式命令（如 `vim`、`top`、`less`、`menuconfig`）可自動升級為 human interactive ownership，避免被誤判為 prompt timeout 故障
+- 若 session 僅為 `ATTACHED`，`session.console_attach` 仍可使用，且該 console 會自動拿到 raw human ownership，方便手動登入或觀察 boot/log
 
 ### 5.3 Command record
 
@@ -211,6 +217,8 @@ sequenceDiagram
 5. `session.interactive_status` 讀畫面
 6. `session.interactive_close` 釋放 lease
 
+若 `source=human:*` 的 line command 已送出但後續未回 prompt，daemon 會優先把該 console 升級成 human interactive，而不是直接觸發 recover。這條保護僅套用 human/minicom；agent foreground command 仍保留既有 prompt timeout / recover 路徑。
+
 ### 6.4 recover
 
 適用：
@@ -224,7 +232,7 @@ sequenceDiagram
 
 1. `Ctrl-C`
 2. `Ctrl-D`
-3. `reboot -f`
+3. 若仍無 prompt，session 降級為 `ATTACHED`
 
 ## 7. 呼叫流程圖
 
@@ -252,7 +260,7 @@ flowchart TD
     LP --> TO["timeout"]
     TO --> RC["Ctrl-C"]
     RC --> RD["Ctrl-D"]
-    RD --> RB["reboot -f"]
+    RD --> RA["mark ATTACHED"]
 ```
 
 ## 8. Device 變更與 reattach
@@ -276,7 +284,8 @@ flowchart TD
 - bridge 停止
 - session 先進 `DETACHED`
 - 重新 `_attach_by_id`
-- `ensure_ready()` 成功後回 `READY`
+- 若看到 shell prompt，送 `ready_probe` 後回 `READY`
+- 若沒看到 prompt，保留 bridge 並停在 `ATTACHED`
 
 ## 9. self_test 與 recover
 
@@ -291,6 +300,9 @@ flowchart TD
 - `BRIDGE_DOWN`
 - `VTTY_STALE`
 - `TARGET_UNRESPONSIVE`
+- `LOGIN_REQUIRED`
+- `ATTACHED_NOT_READY`
+- `REBOOTING`
 
 判斷順序：
 
@@ -310,13 +322,12 @@ flowchart TD
 1. 送 `Ctrl-C`
 2. 等 prompt
 3. 失敗則送 `Ctrl-D`
-4. 再失敗則送 `reboot -f`
-5. session 進 `RECOVERING`
-6. background thread 持續 reattach / relogin，直到 `READY` 或超時
+4. 再失敗則把 session 降級成 `ATTACHED`
 
 若 session 已無 bridge 但裝置還在：
 
-- 直接走 reattach / relogin
+- 直接走 reattach
+- attach 流程只做被動 prompt probe，不自動 login
 
 ## 10. Logging 與輸出層
 
@@ -438,7 +449,7 @@ flowchart TD
 
 1. 確認 daemon 存活，必要時自動啟動
 2. 找到 selector 對應 session
-3. session 非 READY 且允許自動 attach 時，先 `session attach`
+3. session 既非 `READY` 也非 `ATTACHED`，且允許自動 attach 時，先 `session attach`
 4. `session console-attach`
 5. 以回傳的 PTY 啟動 `minicom`
 6. minicom 結束後 `session console-detach`
@@ -465,7 +476,7 @@ flowchart TD
 
 `quiet_window_s` 目前用於 background capture idle finalize。
 
-`platform=shell` 可使用 `user_env` / `pass_env` 做 generic shell login。若裝置已自動登入並直接出現 prompt，daemon 會略過 login 流程，直接做 `ready_probe`。
+`platform=shell` 可使用 `user_env` / `pass_env` 做 generic shell login。`serialwrap daemon start` 會先嘗試載入 `~/OPI.env`，因此可將 `SW_OPI_U` / `SW_OPI_P` 放在該檔。若裝置 login prompt 會帶 hostname（例如 `orangepi3 login:`），建議 `login_regex` 使用 `(?mi)^.*login:\\s*$`。若裝置已自動登入並直接出現 prompt，daemon 會略過 login 流程，直接做 `ready_probe`。
 
 ## 14. 驗收標準
 
@@ -476,8 +487,8 @@ flowchart TD
 - human line input 不會繞過 broker
 - 裝置 real_path 變更時會 reattach
 - `self_test` 可區分主要故障類型
-- `recover` 可走 `Ctrl-C -> Ctrl-D -> reboot -f`
-- reboot 後可重新回 `READY`
+- `recover` 僅會走 `Ctrl-C -> Ctrl-D`
+- agent 明確 reboot 後可重新回 `READY`
 - README / spec / CLI / MCP 命名一致
 
 ## 15. 使用建議

--- a/profiles/default.yaml
+++ b/profiles/default.yaml
@@ -15,7 +15,7 @@ profiles:
   opi-shell:
     platform: shell
     prompt_regex: ".*[$#] $"
-    login_regex: "(?mi)^login:\\s*$"
+    login_regex: "(?mi)^.*login:\\s*$"
     password_regex: "(?mi)^password:\\s*$"
     user_env: "SW_OPI_U"
     pass_env: "SW_OPI_P"

--- a/sw_core/arbiter.py
+++ b/sw_core/arbiter.py
@@ -55,7 +55,7 @@ class CommandArbiter:
                 pq.put_nowait(_QueuedCommand(sort_key=(0, 0), cmd_id="", session_id="", command="", source="", mode="", timeout_s=0.0))
             except Exception:
                 pass
-        if th and th.is_alive():
+        if th and th.is_alive() and th is not threading.current_thread():
             th.join(timeout=1.0)
 
     def submit(

--- a/sw_core/cli.py
+++ b/sw_core/cli.py
@@ -11,6 +11,8 @@ from typing import Any
 from .client import rpc_call
 from .constants import LOCK_PATH, PROFILE_DIR, SOCKET_PATH
 
+DEFAULT_DAEMON_ENV_FILE = os.environ.get("SERIALWRAP_DAEMON_ENV_FILE", "~/OPI.env")
+
 
 def _print(obj: dict[str, Any]) -> None:
     sys.stdout.write(json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":")))
@@ -20,6 +22,40 @@ def _print(obj: dict[str, Any]) -> None:
 def _daemon_script_path() -> str:
     here = os.path.dirname(os.path.abspath(__file__))
     return os.path.normpath(os.path.join(here, "..", "serialwrapd.py"))
+
+
+def _decode_env_text(raw: bytes) -> str:
+    return raw.decode("utf-8", errors="surrogateescape")
+
+
+def _load_daemon_start_env(env_file: str | None = DEFAULT_DAEMON_ENV_FILE) -> tuple[dict[str, str], str | None]:
+    env = dict(os.environ)
+    if env_file is None:
+        return env, None
+
+    path = os.path.expanduser(env_file).strip()
+    if not path or not os.path.isfile(path):
+        return env, None
+
+    proc = subprocess.run(
+        ["bash", "-lc", 'set -a && source "$1" >/dev/null && env -0', "serialwrap", path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        stderr = _decode_env_text(proc.stderr).strip()
+        raise RuntimeError(stderr or f"failed to source {path}")
+
+    loaded_env: dict[str, str] = {}
+    for row in proc.stdout.split(b"\0"):
+        if not row:
+            continue
+        key, sep, value = row.partition(b"=")
+        if not sep:
+            continue
+        loaded_env[_decode_env_text(key)] = _decode_env_text(value)
+    return loaded_env, path
 
 
 def _run_daemon_start(args: argparse.Namespace) -> int:
@@ -33,10 +69,23 @@ def _run_daemon_start(args: argparse.Namespace) -> int:
         "--lock",
         args.lock,
     ]
-    if args.foreground:
-        return subprocess.call(cmd)
+    try:
+        daemon_env, _ = _load_daemon_start_env()
+    except RuntimeError as exc:
+        _print(
+            {
+                "ok": False,
+                "error_code": "ENV_FILE_SOURCE_FAILED",
+                "env_file": os.path.expanduser(DEFAULT_DAEMON_ENV_FILE),
+                "message": str(exc),
+            }
+        )
+        return 2
 
-    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
+    if args.foreground:
+        return subprocess.call(cmd, env=daemon_env)
+
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True, env=daemon_env)
 
     # 等待 daemon 就緒（最多 3 秒）
     for attempt in range(15):

--- a/sw_core/login_fsm.py
+++ b/sw_core/login_fsm.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import time
 import uuid
 
@@ -42,6 +43,38 @@ def _prompt_timeout_error(sp: SessionProfile) -> str:
     return "PRPL_PROMPT_TIMEOUT"
 
 
+def _probe_prompt(bridge: UARTBridge, sp: SessionProfile) -> bool:
+    bridge.clear_rx_buffer()
+    bridge.send_command("", source="system")
+    return bridge.wait_for_regex(sp.prompt_regex, sp.timeout_s)
+
+
+def _classify_non_ready_state(bridge: UARTBridge, sp: SessionProfile) -> str:
+    snapshot = bridge.rx_tail()
+    if re.search(sp.login_regex, snapshot):
+        return "LOGIN_REQUIRED"
+    return "PROMPT_UNAVAILABLE"
+
+
+def _finalize_ready(bridge: UARTBridge, sp: SessionProfile) -> tuple[bool, str | None]:
+    if sp.post_login_cmd:
+        bridge.send_command(sp.post_login_cmd, source="system")
+        ok, err = _wait_or_fail(bridge, sp.prompt_regex, sp.timeout_s, "POST_LOGIN_CMD_TIMEOUT")
+        if not ok:
+            return ok, err
+
+    nonce = uuid.uuid4().hex[:8]
+    probe = sp.ready_probe.replace("${nonce}", nonce)
+    bridge.send_command(probe, source="system")
+    ok, err = _wait_or_fail(bridge, nonce, sp.timeout_s, "READY_NONCE_TIMEOUT")
+    if not ok:
+        return ok, err
+    ok, err = _wait_or_fail(bridge, sp.prompt_regex, sp.timeout_s, "READY_PROMPT_TIMEOUT")
+    if not ok:
+        return ok, err
+    return True, None
+
+
 def _maybe_login(bridge: UARTBridge, sp: SessionProfile) -> tuple[bool, str | None]:
     user, err = _resolve_login_user(sp)
     needs_login = bool(user or sp.pass_env)
@@ -69,30 +102,17 @@ def _maybe_login(bridge: UARTBridge, sp: SessionProfile) -> tuple[bool, str | No
     return ok, err
 
 
-def ensure_ready(bridge: UARTBridge, sp: SessionProfile) -> tuple[bool, str | None]:
-    bridge.clear_rx_buffer()
-    bridge.send_command("", source="system")
+def probe_ready(bridge: UARTBridge, sp: SessionProfile) -> tuple[bool, str | None]:
+    if not _probe_prompt(bridge, sp):
+        return False, _classify_non_ready_state(bridge, sp)
+    return _finalize_ready(bridge, sp)
 
-    if not bridge.wait_for_regex(sp.prompt_regex, sp.timeout_s):
+
+def ensure_ready(bridge: UARTBridge, sp: SessionProfile) -> tuple[bool, str | None]:
+    if not _probe_prompt(bridge, sp):
         ok, err = _maybe_login(bridge, sp)
         if err is not None:
             return ok, err
         if not ok:
             return False, _prompt_timeout_error(sp)
-
-    if sp.post_login_cmd:
-        bridge.send_command(sp.post_login_cmd, source="system")
-        ok, err = _wait_or_fail(bridge, sp.prompt_regex, sp.timeout_s, "POST_LOGIN_CMD_TIMEOUT")
-        if not ok:
-            return ok, err
-
-    nonce = uuid.uuid4().hex[:8]
-    probe = sp.ready_probe.replace("${nonce}", nonce)
-    bridge.send_command(probe, source="system")
-    ok, err = _wait_or_fail(bridge, nonce, sp.timeout_s, "READY_NONCE_TIMEOUT")
-    if not ok:
-        return ok, err
-    ok, err = _wait_or_fail(bridge, sp.prompt_regex, sp.timeout_s, "READY_PROMPT_TIMEOUT")
-    if not ok:
-        return ok, err
-    return True, None
+    return _finalize_ready(bridge, sp)

--- a/sw_core/service.py
+++ b/sw_core/service.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+import re
+import shlex
 import threading
 from typing import Any
 
@@ -11,6 +13,85 @@ from .device_watcher import DeviceWatcher
 from .session_manager import SessionManager
 from .util import now_iso
 from .wal import WalWriter
+
+_HUMAN_INTERACTIVE_COMMANDS = {
+    "alsamixer",
+    "btop",
+    "htop",
+    "less",
+    "menuconfig",
+    "more",
+    "most",
+    "nano",
+    "nmtui",
+    "screen",
+    "tig",
+    "tmux",
+    "top",
+    "vi",
+    "view",
+    "vim",
+    "vimdiff",
+    "watch",
+}
+_ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
+
+
+def _human_console_mode(command: str) -> str:
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        tokens = command.strip().split()
+    if not tokens:
+        return "line"
+
+    idx = 0
+    while idx < len(tokens):
+        token = tokens[idx].strip()
+        if not token:
+            idx += 1
+            continue
+        if token == "--":
+            idx += 1
+            continue
+        if _ENV_ASSIGNMENT_RE.match(token):
+            idx += 1
+            continue
+
+        base = os.path.basename(token)
+        if base == "sudo":
+            idx += 1
+            while idx < len(tokens):
+                opt = tokens[idx]
+                if opt == "--":
+                    idx += 1
+                    break
+                if opt in {"-u", "-g", "-h", "-p", "-C", "-T", "-r", "-t"}:
+                    idx += 2
+                    continue
+                if opt.startswith("-"):
+                    idx += 1
+                    continue
+                break
+            continue
+        if base == "env":
+            idx += 1
+            while idx < len(tokens):
+                opt = tokens[idx]
+                if opt == "--":
+                    idx += 1
+                    break
+                if opt.startswith("-") or _ENV_ASSIGNMENT_RE.match(opt):
+                    idx += 1
+                    continue
+                break
+            continue
+        if base in {"command", "builtin", "exec"}:
+            idx += 1
+            continue
+
+        return "interactive" if base in _HUMAN_INTERACTIVE_COMMANDS else "line"
+    return "line"
 
 
 class SerialwrapService:
@@ -41,11 +122,12 @@ class SerialwrapService:
         return self._sessions.execute_command(session_id, command, source, cmd_id, timeout_s=timeout_s, mode=mode)
 
     def _on_console_line(self, session_id: str, client_id: str, line: str) -> None:
+        mode = _human_console_mode(line)
         self._arbiter.submit(
             session_id=session_id,
             command=line,
             source=f"human:{client_id}",
-            mode="line",
+            mode=mode,
             timeout_s=30.0,
             priority=100,
         )

--- a/sw_core/session_manager.py
+++ b/sw_core/session_manager.py
@@ -5,6 +5,7 @@ import dataclasses
 import json
 import os
 import re
+import shlex
 import threading
 import time
 import uuid
@@ -14,10 +15,31 @@ from .alias_registry import AliasRegistry
 from .config import SessionProfile
 from .constants import STATE_PATH
 from .device_watcher import DeviceInfo
-from .login_fsm import ensure_ready
+from .login_fsm import ensure_ready, probe_ready
 from .uart_io import UARTBridge
 from .util import clean_text, now_iso
 from .wal import WalWriter
+
+
+_ATTACHED_CONSOLE_LEASE_TIMEOUT_S = 86400.0
+
+
+def _is_reboot_command(command: str) -> bool:
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return False
+    if not tokens:
+        return False
+
+    base = os.path.basename(tokens[0])
+    if base == "reboot":
+        return True
+    if base == "systemctl" and len(tokens) >= 2 and tokens[1] == "reboot":
+        return True
+    if base != "shutdown":
+        return False
+    return any(token == "-r" or token == "--reboot" or token.startswith("-r") for token in tokens[1:])
 
 
 @dataclasses.dataclass
@@ -68,6 +90,7 @@ class SessionRuntime:
     bridge_generation: int = 0
     recovering: bool = False
     recovery_started_at: str | None = None
+    pending_auto_login: bool = False
     interactive_session_id: str | None = None
     foreground_busy: bool = False
     background_cmd_ids: list[str] = dataclasses.field(default_factory=list)
@@ -210,6 +233,10 @@ class SessionManager:
         session.state = "DETACHED"
         session.detached_at = now_iso()
         session.last_error = reason
+        if session.interactive_session_id is not None:
+            lease = self._interactive.pop(session.interactive_session_id, None)
+            if lease is not None:
+                lease.status = "closed"
         session.interactive_session_id = None
         session.foreground_busy = False
         for cmd_id in list(session.background_cmd_ids):
@@ -271,6 +298,8 @@ class SessionManager:
         return {"ok": True, "session": session.to_public_dict()}
 
     def attach_session(self, selector: str) -> dict[str, Any]:
+        bridge: UARTBridge | None = None
+        should_probe = False
         with self._lock:
             session = self.get_session(selector)
             if session is None:
@@ -279,14 +308,44 @@ class SessionManager:
             if not by_id:
                 return {"ok": False, "error_code": "DEVICE_NOT_BOUND", "session": session.to_public_dict()}
             if session.bridge is not None:
-                self._detach_session_locked(session, reason="MANUAL_ATTACH")
+                lease = self._refresh_interactive_locked(session)
+                if lease is not None and lease.owner.startswith("human:"):
+                    return {"ok": True, "session": session.to_public_dict()}
+                if session.state == "ATTACHED":
+                    bridge = session.bridge
+                    should_probe = True
+                else:
+                    return {"ok": True, "session": session.to_public_dict()}
             if by_id not in self._devices:
                 session.state = "DETACHED"
                 session.last_error = "DEVICE_NOT_FOUND"
                 session.detached_at = now_iso()
                 return {"ok": False, "error_code": "DEVICE_NOT_FOUND", "session": session.to_public_dict()}
-            session.state = "ATTACHING"
-            session.last_error = None
+            if not should_probe:
+                session.state = "ATTACHING"
+                session.last_error = None
+        if should_probe and bridge is not None:
+            ok, err = probe_ready(bridge, session.profile)
+            notify_ready = False
+            with self._lock:
+                current = self._sessions.get(session.session_id)
+                if current is None or current.bridge is not bridge:
+                    return {"ok": False, "error_code": "SESSION_NOT_READY"}
+                if ok:
+                    current.state = "READY"
+                    current.last_error = None
+                    current.last_ready_at = now_iso()
+                    current.recovering = False
+                    current.recovery_started_at = None
+                    current.pending_auto_login = False
+                    notify_ready = True
+                else:
+                    current.state = "ATTACHED"
+                    current.last_error = err
+                result = current.to_public_dict()
+            if notify_ready:
+                self._on_ready(session.session_id)
+            return {"ok": True, "session": result}
         self._spawn_attach(by_id)
         return {"ok": True, "session": session.to_public_dict()}
 
@@ -367,13 +426,14 @@ class SessionManager:
             by_id = session.profile.device_by_id
             self._detach_session_locked(session, reason=f"BRIDGE_DOWN:{reason}")
             if by_id and by_id in self._devices:
-                session.state = "ATTACHING"
+                session.state = "RECOVERING" if session.pending_auto_login else "ATTACHING"
                 session.last_error = None
         if by_id and by_id in self._devices:
             self._spawn_attach(by_id)
 
     def _attach_by_id(self, by_id: str) -> None:
         save_needed = False
+        require_login = False
         with self._lock:
             session = next((s for s in self._sessions.values() if s.profile.device_by_id == by_id), None)
             if session is None:
@@ -387,6 +447,8 @@ class SessionManager:
                     self._binding_overrides[session.session_id] = by_id
                     save_needed = True
             dev = self._devices.get(by_id)
+            if session is not None:
+                require_login = session.pending_auto_login
         if save_needed:
             self._save_state()
         if session is None or dev is None or session.bridge is not None:
@@ -406,19 +468,23 @@ class SessionManager:
 
         try:
             bridge.start()
-            ok, err = ensure_ready(bridge, session.profile)
-            if not ok:
-                bridge.stop()
-                with self._lock:
-                    session.state = "DETACHED"
-                    session.last_error = err
-                    session.detached_at = now_iso()
-                    session.bridge = None
-                    session.vtty_path = None
-                    session.attached_real_path = None
-                self._on_detached(session.session_id)
-                return
+            if require_login:
+                ok, err = ensure_ready(bridge, session.profile)
+                if not ok:
+                    bridge.stop()
+                    with self._lock:
+                        session.state = "DETACHED"
+                        session.last_error = err
+                        session.detached_at = now_iso()
+                        session.bridge = None
+                        session.vtty_path = None
+                        session.attached_real_path = None
+                    self._on_detached(session.session_id)
+                    return
+            else:
+                ok, err = probe_ready(bridge, session.profile)
 
+            notify_ready = False
             with self._lock:
                 current = self._devices.get(by_id)
                 if current is None or current.real_path != dev.real_path or session.state == "DETACHED":
@@ -434,12 +500,21 @@ class SessionManager:
                 session.vtty_path = bridge.vtty_path
                 session.attached_real_path = dev.real_path
                 session.bridge_generation += 1
-                session.state = "READY"
-                session.last_error = None
-                session.last_ready_at = now_iso()
-                session.recovering = False
-                session.recovery_started_at = None
-            self._on_ready(session.session_id)
+                if ok:
+                    session.state = "READY"
+                    session.last_error = None
+                    session.last_ready_at = now_iso()
+                    session.recovering = False
+                    session.recovery_started_at = None
+                    session.pending_auto_login = False
+                    notify_ready = True
+                else:
+                    session.state = "ATTACHED"
+                    session.last_error = err
+                    session.recovering = False
+                    session.recovery_started_at = None
+            if notify_ready:
+                self._on_ready(session.session_id)
         except Exception as exc:
             try:
                 bridge.stop()
@@ -485,8 +560,175 @@ class SessionManager:
         self._interactive[interactive_id] = lease
         session.interactive_session_id = interactive_id
         assert session.bridge is not None
-        session.bridge.set_interactive_owner(interactive_id)
+        session.bridge.set_interactive_owner(owner)
         return lease
+
+    def _close_interactive_locked(
+        self,
+        session: SessionRuntime,
+        *,
+        interactive_id: str | None = None,
+        expected_owner: str | None = None,
+    ) -> InteractiveLease | None:
+        lease_id = interactive_id or session.interactive_session_id
+        if lease_id is None:
+            return None
+        lease = self._interactive.get(lease_id)
+        if lease is not None and expected_owner is not None and lease.owner != expected_owner:
+            return None
+        if lease is not None:
+            lease.status = "closed"
+            self._interactive.pop(lease_id, None)
+        session.interactive_session_id = None
+        if session.bridge is not None:
+            session.bridge.set_interactive_owner(None)
+        return lease
+
+    def _refresh_interactive_locked(self, session: SessionRuntime) -> InteractiveLease | None:
+        lease_id = session.interactive_session_id
+        if lease_id is None:
+            return None
+        lease = self._interactive.get(lease_id)
+        if lease is None:
+            self._close_interactive_locked(session, interactive_id=lease_id)
+            return None
+        if session.bridge is None:
+            self._close_interactive_locked(session, interactive_id=lease_id)
+            return None
+        if lease.owner.startswith("human:"):
+            snapshot = session.bridge.snapshot()
+            if snapshot.get("interactive_owner") != lease.owner:
+                self._close_interactive_locked(session, interactive_id=lease_id)
+                return None
+        return lease
+
+    def _transition_to_attached(self, session: SessionRuntime, *, reason: str) -> None:
+        notify_not_ready = False
+        with self._lock:
+            if session.state == "READY":
+                notify_not_ready = True
+            session.state = "ATTACHED"
+            session.last_error = reason
+            session.recovering = False
+            session.recovery_started_at = None
+            session.pending_auto_login = False
+        if notify_not_ready:
+            self._on_detached(session.session_id)
+
+    def _spawn_reboot_recovery(self, session_id: str, timeout_s: float) -> None:
+        def _run() -> None:
+            deadline = time.monotonic() + timeout_s
+            while time.monotonic() < deadline:
+                with self._lock:
+                    session = self._sessions.get(session_id)
+                    if session is None:
+                        return
+                    bridge = session.bridge
+                    by_id = session.profile.device_by_id
+                if bridge is not None:
+                    ok, err = ensure_ready(bridge, session.profile)
+                    if ok:
+                        with self._lock:
+                            session = self._sessions.get(session_id)
+                            if session is None or session.bridge is not bridge:
+                                continue
+                            session.state = "READY"
+                            session.last_error = None
+                            session.last_ready_at = now_iso()
+                            session.recovering = False
+                            session.recovery_started_at = None
+                            session.pending_auto_login = False
+                        self._on_ready(session_id)
+                        return
+                    with self._lock:
+                        session = self._sessions.get(session_id)
+                        if session is None or session.bridge is not bridge:
+                            continue
+                        session.last_error = err
+                elif by_id and by_id in self._devices:
+                    self._spawn_attach(by_id)
+                time.sleep(1.0)
+            with self._lock:
+                session = self._sessions.get(session_id)
+                if session is None:
+                    return
+                session.recovering = False
+                session.recovery_started_at = None
+                session.pending_auto_login = False
+                if session.bridge is None:
+                    session.state = "DETACHED"
+                    session.last_error = "RECOVERY_TIMEOUT"
+                else:
+                    session.state = "ATTACHED"
+                    session.last_error = session.last_error or "RECOVERY_TIMEOUT"
+
+        threading.Thread(target=_run, name=f"serialwrap-reboot-{session_id}", daemon=True).start()
+
+    def _handle_reboot_command(
+        self,
+        session: SessionRuntime,
+        bridge: UARTBridge,
+        *,
+        command: str,
+        source: str,
+        cmd_id: str,
+        timeout_s: float,
+        execution_mode: str,
+    ) -> dict[str, Any]:
+        prompt_regex = session.profile.prompt_regex
+        pre_offset = bridge.rx_snapshot_len()
+        bridge.send_command(command, source=source, cmd_id=cmd_id)
+        if bridge.wait_for_regex_from(prompt_regex, pre_offset, min(timeout_s, 2.0)):
+            raw_text = bridge.rx_text_from(pre_offset)
+            stdout = self._extract_command_stdout(raw_text, command, prompt_regex)
+            return {
+                "ok": True,
+                "execution_mode": execution_mode,
+                "stdout": stdout,
+                "partial": False,
+            }
+
+        if source.startswith("human:"):
+            with self._lock:
+                lease = self._refresh_interactive_locked(session)
+                if lease is None:
+                    lease = self._open_interactive_locked(
+                        session,
+                        owner=source,
+                        timeout_s=max(session.profile.hard_timeout_s, _ATTACHED_CONSOLE_LEASE_TIMEOUT_S),
+                    )
+                session.state = "ATTACHED"
+                session.last_error = "REBOOTING"
+                session.recovering = False
+                session.recovery_started_at = None
+                session.pending_auto_login = False
+            self._on_detached(session.session_id)
+            return {
+                "ok": True,
+                "execution_mode": "interactive",
+                "interactive_session_id": lease.interactive_id,
+                "status": "interactive",
+                "stdout": "",
+                "partial": True,
+                "recovery_action": "PROMOTE_HUMAN_INTERACTIVE",
+            }
+
+        with self._lock:
+            session.pending_auto_login = True
+            session.recovering = True
+            session.recovery_started_at = now_iso()
+            session.state = "RECOVERING"
+            session.last_error = None
+        self._on_detached(session.session_id)
+        self._spawn_reboot_recovery(session.session_id, session.profile.hard_timeout_s)
+        return {
+            "ok": True,
+            "execution_mode": execution_mode,
+            "stdout": "",
+            "partial": True,
+            "status": "recovering",
+            "recovery_action": "EXPECT_REBOOT",
+        }
 
     def execute_command(
         self,
@@ -505,7 +747,8 @@ class SessionManager:
                 return {"ok": False, "error_code": "SESSION_NOT_READY"}
             if session.recovering:
                 return {"ok": False, "error_code": "SESSION_RECOVERING"}
-            if session.interactive_session_id is not None and normalized_mode != "interactive":
+            lease = self._refresh_interactive_locked(session)
+            if lease is not None and normalized_mode != "interactive":
                 return {"ok": False, "error_code": "SESSION_INTERACTIVE_BUSY", "interactive_session_id": session.interactive_session_id}
             bridge = session.bridge
             prompt_regex = session.profile.prompt_regex
@@ -534,11 +777,24 @@ class SessionManager:
                     capture = self._background.get(bg_cmd_id)
                     if capture is not None:
                         capture.status = "done"
+        if _is_reboot_command(command):
+            try:
+                return self._handle_reboot_command(
+                    session,
+                    bridge,
+                    command=command,
+                    source=source,
+                    cmd_id=cmd_id,
+                    timeout_s=timeout_s,
+                    execution_mode=normalized_mode,
+                )
+            finally:
+                session.foreground_busy = False
         pre_offset = bridge.rx_snapshot_len()
         try:
             bridge.send_command(command, source=source, cmd_id=cmd_id)
             if not bridge.wait_for_regex_from(prompt_regex, pre_offset, timeout_s):
-                return self._recover_after_failure(session, bridge, cmd_id=cmd_id, timeout_s=timeout_s)
+                return self._recover_after_failure(session, bridge, cmd_id=cmd_id, timeout_s=timeout_s, source=source)
             raw_text = bridge.rx_text_from(pre_offset)
             stdout = self._extract_command_stdout(raw_text, command, prompt_regex)
             result: dict[str, Any] = {
@@ -564,7 +820,34 @@ class SessionManager:
         finally:
             session.foreground_busy = False
 
-    def _recover_after_failure(self, session: SessionRuntime, bridge: UARTBridge, *, cmd_id: str, timeout_s: float) -> dict[str, Any]:
+    def _recover_after_failure(
+        self,
+        session: SessionRuntime,
+        bridge: UARTBridge,
+        *,
+        cmd_id: str,
+        timeout_s: float,
+        source: str,
+    ) -> dict[str, Any]:
+        if source.startswith("human:"):
+            with self._lock:
+                lease = self._refresh_interactive_locked(session)
+                if lease is None:
+                    lease = self._open_interactive_locked(
+                        session,
+                        owner=source,
+                        timeout_s=max(timeout_s, session.profile.hard_timeout_s),
+                    )
+            return {
+                "ok": True,
+                "execution_mode": "interactive",
+                "interactive_session_id": lease.interactive_id,
+                "status": "interactive",
+                "stdout": "",
+                "partial": True,
+                "recovery_action": "PROMOTE_HUMAN_INTERACTIVE",
+            }
+
         prompt_regex = session.profile.prompt_regex
         for action_name, payload in (("CTRL_C", b"\x03"), ("CTRL_D", b"\x04")):
             offset = bridge.rx_snapshot_len()
@@ -579,55 +862,13 @@ class SessionManager:
                     "recovery_action": action_name,
                 }
 
-        bridge.send_command("reboot -f", source="system:recover", cmd_id=None)
-        with self._lock:
-            session.recovering = True
-            session.recovery_started_at = now_iso()
-            session.state = "RECOVERING"
-            by_id = session.profile.device_by_id
-            self._detach_session_locked(session, reason="RECOVER_REBOOT")
-            session.state = "RECOVERING"
-            session.recovering = True
-            session.recovery_started_at = now_iso()
-        if by_id:
-            self._spawn_recover_attach(session.session_id, by_id, session.profile.hard_timeout_s)
+        self._transition_to_attached(session, reason="PROMPT_TIMEOUT")
         return {
             "ok": False,
             "error_code": "PROMPT_TIMEOUT",
             "partial": True,
-            "recovery_action": "REBOOT_FORCE",
+            "recovery_action": "NONE",
         }
-
-    def _spawn_recover_attach(self, session_id: str, by_id: str, timeout_s: float) -> None:
-        def _run() -> None:
-            deadline = time.monotonic() + timeout_s
-            while time.monotonic() < deadline:
-                with self._lock:
-                    session = self._sessions.get(session_id)
-                    if session is None:
-                        return
-                    if session.state == "READY":
-                        session.recovering = False
-                        session.recovery_started_at = None
-                        return
-                if by_id in self._devices:
-                    self._attach_by_id(by_id)
-                    with self._lock:
-                        session = self._sessions.get(session_id)
-                        if session is not None and session.state == "READY":
-                            session.recovering = False
-                            session.recovery_started_at = None
-                            return
-                time.sleep(1.0)
-            with self._lock:
-                session = self._sessions.get(session_id)
-                if session is not None and session.state != "READY":
-                    session.recovering = False
-                    session.recovery_started_at = None
-                    session.state = "DETACHED"
-                    session.last_error = "RECOVERY_TIMEOUT"
-
-        threading.Thread(target=_run, name=f"serialwrap-recover-{session_id}", daemon=True).start()
 
     def get_session_state(self, selector: str) -> dict[str, Any]:
         session = self.get_session(selector)
@@ -638,11 +879,19 @@ class SessionManager:
     def attach_console(self, selector: str, *, label: str | None = None) -> dict[str, Any]:
         with self._lock:
             session = self.get_session(selector)
-            if session is None or session.bridge is None or session.state != "READY":
+            if session is None or session.bridge is None or session.state not in {"READY", "ATTACHED"}:
                 return {"ok": False, "error_code": "SESSION_NOT_READY", "selector": selector}
             payload = session.bridge.attach_console(label=label)
             if session.vtty_path is None:
                 session.vtty_path = payload["vtty"]
+            if session.state == "ATTACHED" and self._refresh_interactive_locked(session) is None:
+                lease = self._open_interactive_locked(
+                    session,
+                    owner=f"human:{payload['client_id']}",
+                    timeout_s=max(session.profile.hard_timeout_s, _ATTACHED_CONSOLE_LEASE_TIMEOUT_S),
+                )
+                payload["interactive_session_id"] = lease.interactive_id
+                payload["interactive_owner"] = True
             payload["session"] = session.to_public_dict()
             return {"ok": True, **payload}
 
@@ -651,7 +900,11 @@ class SessionManager:
             session = self.get_session(selector)
             if session is None or session.bridge is None:
                 return {"ok": False, "error_code": "SESSION_NOT_READY", "selector": selector}
+            human_owner = f"human:{client_id}"
+            lease = self._refresh_interactive_locked(session)
             ok = session.bridge.detach_console(client_id)
+            if lease is not None and lease.owner == human_owner:
+                self._close_interactive_locked(session, interactive_id=lease.interactive_id, expected_owner=human_owner)
             session.vtty_path = session.bridge.vtty_path
             if not ok:
                 return {"ok": False, "error_code": "CONSOLE_NOT_FOUND", "client_id": client_id}
@@ -669,7 +922,7 @@ class SessionManager:
             session = self.get_session(selector)
             if session is None or session.bridge is None or session.state != "READY":
                 return {"ok": False, "error_code": "SESSION_NOT_READY", "selector": selector}
-            if session.interactive_session_id is not None:
+            if self._refresh_interactive_locked(session) is not None:
                 return {"ok": False, "error_code": "SESSION_INTERACTIVE_BUSY", "interactive_session_id": session.interactive_session_id}
             lease = self._open_interactive_locked(session, owner=owner, timeout_s=timeout_s)
             bridge = session.bridge
@@ -711,9 +964,7 @@ class SessionManager:
                 lease.status = "expired"
                 session = self._sessions.get(lease.session_id)
                 if session is not None:
-                    session.interactive_session_id = None
-                    if session.bridge is not None:
-                        session.bridge.set_interactive_owner(None)
+                    self._close_interactive_locked(session, interactive_id=interactive_id)
                 return {"ok": False, "error_code": "INTERACTIVE_EXPIRED", "interactive_id": interactive_id}
             session = self._sessions.get(lease.session_id)
             if session is None or session.bridge is None:
@@ -743,14 +994,14 @@ class SessionManager:
 
     def interactive_close(self, interactive_id: str) -> dict[str, Any]:
         with self._lock:
-            lease = self._interactive.pop(interactive_id, None)
+            lease = self._interactive.get(interactive_id)
             if lease is None:
                 return {"ok": False, "error_code": "INTERACTIVE_NOT_FOUND", "interactive_id": interactive_id}
             session = self._sessions.get(lease.session_id)
             if session is not None:
-                session.interactive_session_id = None
-                if session.bridge is not None:
-                    session.bridge.set_interactive_owner(None)
+                self._close_interactive_locked(session, interactive_id=interactive_id)
+            else:
+                self._interactive.pop(interactive_id, None)
             return {"ok": True, "interactive_id": interactive_id}
 
     def self_test(self, selector: str, *, timeout_s: float = 2.0) -> dict[str, Any]:
@@ -767,6 +1018,16 @@ class SessionManager:
                     "classification": "SESSION_RECOVERING",
                     "session": session.to_public_dict(),
                     "recommended_action": "wait",
+                }
+            lease = self._refresh_interactive_locked(session)
+            if lease is not None and lease.owner.startswith("human:"):
+                return {
+                    "ok": True,
+                    "classification": "HUMAN_INTERACTIVE_ACTIVE",
+                    "interactive_id": lease.interactive_id,
+                    "interactive_owner": lease.owner,
+                    "session": session.to_public_dict(),
+                    "recommended_action": "wait_or_detach_console",
                 }
             if device is None:
                 return {
@@ -809,6 +1070,26 @@ class SessionManager:
                     "attached_vtty": snapshot.get("vtty"),
                     "recommended_action": "console_attach",
                 }
+            if session.state == "ATTACHED":
+                if session.last_error == "LOGIN_REQUIRED":
+                    classification = "LOGIN_REQUIRED"
+                    recommended_action = "console_attach"
+                elif session.last_error == "REBOOTING":
+                    classification = "REBOOTING"
+                    recommended_action = "wait_or_console_attach"
+                else:
+                    classification = "ATTACHED_NOT_READY"
+                    recommended_action = "console_attach"
+                return {
+                    "ok": True,
+                    "classification": classification,
+                    "session": session.to_public_dict(),
+                    "attached_real_path": attached_real_path,
+                    "current_real_path": device.real_path,
+                    "attached_vtty": snapshot.get("vtty"),
+                    "bridge_generation": session.bridge_generation,
+                    "recommended_action": recommended_action,
+                }
 
             nonce = uuid.uuid4().hex[:8]
             probe = session.profile.ready_probe.replace("${nonce}", nonce)
@@ -842,17 +1123,18 @@ class SessionManager:
             session = self.get_session(selector)
             if session is None:
                 return {"ok": False, "error_code": "SESSION_NOT_FOUND", "selector": selector}
-            if session.bridge is None or session.state != "READY":
+            if session.bridge is None:
                 by_id = session.profile.device_by_id
                 if by_id and by_id in self._devices:
-                    session.recovering = True
-                    session.recovery_started_at = now_iso()
-                    session.state = "RECOVERING"
-                    self._spawn_recover_attach(session.session_id, by_id, session.profile.hard_timeout_s)
-                    return {"ok": True, "recovering": True, "action": "REATTACH", "session": session.to_public_dict()}
+                    session.state = "ATTACHING"
+                    session.last_error = None
+                    self._spawn_attach(by_id)
+                    return {"ok": True, "recovering": False, "action": "REATTACH", "session": session.to_public_dict()}
+                return {"ok": False, "error_code": "SESSION_NOT_READY", "session": session.to_public_dict()}
+            if session.state != "READY":
                 return {"ok": False, "error_code": "SESSION_NOT_READY", "session": session.to_public_dict()}
             bridge = session.bridge
-        return self._recover_after_failure(session, bridge, cmd_id="", timeout_s=timeout_s)
+        return self._recover_after_failure(session, bridge, cmd_id="", timeout_s=timeout_s, source="system:recover")
 
     def get_background_result(self, cmd_id: str, *, from_chunk: int = 0, limit: int = 200) -> dict[str, Any]:
         with self._lock:

--- a/sw_core/uart_io.py
+++ b/sw_core/uart_io.py
@@ -260,6 +260,44 @@ class UARTBridge:
             lines.append(raw.decode("utf-8", errors="replace"))
         return lines
 
+    def _pop_last_console_char(self, buf: bytearray) -> bool:
+        if not buf:
+            return False
+        idx = len(buf) - 1
+        while idx > 0 and (buf[idx] & 0xC0) == 0x80:
+            idx -= 1
+        del buf[idx:]
+        return True
+
+    def _consume_console_input(self, client: ConsoleClient, data: bytes) -> tuple[list[str], bytes]:
+        lines: list[str] = []
+        echo = bytearray()
+        last_terminator: int | None = None
+
+        for b in data:
+            if b in (0x08, 0x7F):
+                last_terminator = None
+                if self._pop_last_console_char(client.tx_buffer):
+                    echo.extend(b"\b \b")
+                continue
+
+            if b in (0x0A, 0x0D):
+                if last_terminator is not None and last_terminator != b and not client.tx_buffer:
+                    last_terminator = None
+                    continue
+                lines.append(client.tx_buffer.decode("utf-8", errors="replace"))
+                client.tx_buffer.clear()
+                echo.extend(b"\r\n")
+                last_terminator = b
+                continue
+
+            last_terminator = None
+            client.tx_buffer.append(b)
+            if b == 0x09 or 0x20 <= b <= 0x7E or b >= 0x80:
+                echo.append(b)
+
+        return lines, bytes(echo)
+
     def _handle_console_rx(self, client: ConsoleClient, data: bytes) -> None:
         owner = None
         with self._state_lock:
@@ -268,10 +306,15 @@ class UARTBridge:
             self.send_bytes(data, source=f"human:{client.client_id}", cmd_id=None)
             return
 
-        client.tx_buffer.extend(data)
+        lines, echo = self._consume_console_input(client, data)
+        if echo:
+            try:
+                self._write_console_best_effort(client.master_fd, echo)
+            except OSError:
+                pass
         if self._on_console_line is None:
             return
-        for line in self._drain_line_buffer(client):
+        for line in lines:
             self._on_console_line(client.client_id, line)
 
     def _loop(self) -> None:

--- a/tests/test_agent_defer_tx.py
+++ b/tests/test_agent_defer_tx.py
@@ -108,6 +108,44 @@ class TestUARTBridgeConsoles(unittest.TestCase):
             self.assertEqual(captured[0][1], "ifconfig")
             self.assertEqual(target.received, [])
 
+    def test_console_input_supports_backspace_and_local_echo(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            target = self._make_target()
+            target.start()
+            self.addCleanup(target.stop)
+
+            captured: list[tuple[str, str]] = []
+            bridge = UARTBridge(
+                "COM0",
+                target.slave_path,
+                UartProfile(),
+                WalWriter(wal_dir=td),
+                on_console_line=lambda client_id, line: captured.append((client_id, line)),
+            )
+            bridge.start()
+            self.addCleanup(bridge.stop)
+
+            primary = bridge.vtty_path
+            assert primary is not None
+            fd = os.open(primary, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
+            echoed = b""
+            try:
+                os.write(fd, b"abc\x7fd\n")
+                deadline = time.monotonic() + 2.0
+                while time.monotonic() < deadline and (not captured or b"abc\x08 \x08d\r\n" not in echoed):
+                    try:
+                        echoed += os.read(fd, 4096)
+                    except BlockingIOError:
+                        pass
+                    time.sleep(0.05)
+            finally:
+                os.close(fd)
+
+            self.assertEqual(len(captured), 1)
+            self.assertEqual(captured[0][1], "abd")
+            self.assertIn(b"abc\x08 \x08d\r\n", echoed)
+            self.assertEqual(target.received, [])
+
     def test_rx_is_fanned_out_to_all_consoles(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             target = self._make_target()

--- a/tests/test_cli_daemon_start.py
+++ b/tests/test_cli_daemon_start.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from sw_core import cli
+
+
+class TestCliDaemonStart(unittest.TestCase):
+    def test_load_daemon_start_env_sources_env_file(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            env_file = os.path.join(td, "OPI.env")
+            with open(env_file, "w", encoding="utf-8") as fp:
+                fp.write("SW_OPI_U=haman\n")
+                fp.write("export SW_OPI_P='secret value'\n")
+
+            env, loaded = cli._load_daemon_start_env(env_file)
+
+        self.assertEqual(loaded, env_file)
+        self.assertEqual(env["SW_OPI_U"], "haman")
+        self.assertEqual(env["SW_OPI_P"], "secret value")
+
+    def test_load_daemon_start_env_keeps_current_env_when_missing(self) -> None:
+        with mock.patch.dict(os.environ, {"SERIALWRAP_TEST_FLAG": "1"}, clear=False):
+            env, loaded = cli._load_daemon_start_env("/tmp/serialwrap-missing-opi-env")
+
+        self.assertIsNone(loaded)
+        self.assertEqual(env["SERIALWRAP_TEST_FLAG"], "1")
+
+    def test_run_daemon_start_passes_loaded_env_to_daemon(self) -> None:
+        args = argparse.Namespace(
+            profile_dir="/tmp/profiles",
+            socket="/tmp/serialwrap.sock",
+            lock="/tmp/serialwrap.lock",
+            foreground=False,
+        )
+        proc = mock.Mock(pid=4321, returncode=None)
+        proc.poll.return_value = None
+
+        with (
+            mock.patch("sw_core.cli._load_daemon_start_env", return_value=({"SW_OPI_U": "haman"}, "/tmp/OPI.env")),
+            mock.patch("sw_core.cli.subprocess.Popen", return_value=proc) as popen,
+            mock.patch("sw_core.cli.rpc_call", side_effect=[{"ok": True}, {"ok": True, "warnings": ["no_profiles_loaded"]}]),
+            mock.patch("sw_core.cli.time.sleep"),
+            mock.patch("sw_core.cli._print") as printer,
+        ):
+            rc = cli._run_daemon_start(args)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(popen.call_args.kwargs["env"]["SW_OPI_U"], "haman")
+        payload = printer.call_args.args[0]
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["pid"], 4321)
+        self.assertEqual(payload["warnings"], ["no_profiles_loaded"])
+
+    def test_run_daemon_start_reports_env_source_failure(self) -> None:
+        args = argparse.Namespace(
+            profile_dir="/tmp/profiles",
+            socket="/tmp/serialwrap.sock",
+            lock="/tmp/serialwrap.lock",
+            foreground=False,
+        )
+
+        with (
+            mock.patch("sw_core.cli._load_daemon_start_env", side_effect=RuntimeError("bad env")),
+            mock.patch("sw_core.cli._print") as printer,
+        ):
+            rc = cli._run_daemon_start(args)
+
+        self.assertEqual(rc, 2)
+        payload = printer.call_args.args[0]
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error_code"], "ENV_FILE_SOURCE_FAILED")
+        self.assertIn("OPI.env", payload["env_file"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config_profiles.py
+++ b/tests/test_config_profiles.py
@@ -79,6 +79,7 @@ class TestConfigProfiles(unittest.TestCase):
                       opi-shell:
                         platform: shell
                         prompt_regex: ".*[$#] $"
+                        login_regex: '(?mi)^.*login:\s*$'
                         user_env: "SW_OPI_U"
                         pass_env: "SW_OPI_P"
                         ready_probe: "echo __READY__${nonce}"
@@ -96,6 +97,7 @@ class TestConfigProfiles(unittest.TestCase):
             self.assertEqual(len(rows), 1)
             self.assertEqual(rows[0].profile_name, "opi-shell")
             self.assertEqual(rows[0].platform, "shell")
+            self.assertEqual(rows[0].login_regex, r"(?mi)^.*login:\s*$")
             self.assertEqual(rows[0].user_env, "SW_OPI_U")
             self.assertEqual(rows[0].pass_env, "SW_OPI_P")
             self.assertEqual(rows[0].ready_probe, "echo __READY__${nonce}")

--- a/tests/test_login_fsm.py
+++ b/tests/test_login_fsm.py
@@ -3,7 +3,7 @@ import unittest
 from unittest import mock
 
 from sw_core.config import SessionProfile, UartProfile
-from sw_core.login_fsm import ensure_ready
+from sw_core.login_fsm import ensure_ready, probe_ready
 
 
 class TestLoginFsm(unittest.TestCase):
@@ -16,7 +16,7 @@ class TestLoginFsm(unittest.TestCase):
             device_by_id="/dev/serial/by-id/tty2",
             platform="shell",
             prompt_regex=r".*[$#] $",
-            login_regex=r"(?mi)^login:\s*$",
+            login_regex=r"(?mi)^.*login:\s*$",
             password_regex=r"(?mi)^password:\s*$",
             ready_probe="echo __READY__${nonce}",
             user_env="SW_OPI_U",
@@ -39,6 +39,19 @@ class TestLoginFsm(unittest.TestCase):
         bridge.send_secret.assert_called_once_with("secret")
         probe_calls = [call for call in bridge.send_command.call_args_list if "__READY__" in str(call)]
         self.assertEqual(len(probe_calls), 1)
+
+    def test_probe_ready_reports_login_required_without_auto_login(self) -> None:
+        bridge = mock.MagicMock()
+        bridge.wait_for_regex.return_value = False
+        bridge.rx_tail.return_value = "orangepi3 login: "
+        profile = self._make_shell_profile()
+
+        ok, err = probe_ready(bridge, profile)
+
+        self.assertFalse(ok)
+        self.assertEqual(err, "LOGIN_REQUIRED")
+        bridge.send_command.assert_called_once_with("", source="system")
+        bridge.send_secret.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_service_human_console.py
+++ b/tests/test_service_human_console.py
@@ -1,0 +1,45 @@
+import unittest
+from unittest import mock
+
+from sw_core.service import SerialwrapService
+
+
+class TestServiceHumanConsole(unittest.TestCase):
+    def test_human_console_interactive_command_uses_interactive_mode(self) -> None:
+        svc = SerialwrapService([])
+        with mock.patch.object(svc._arbiter, "submit") as submit:
+            svc._on_console_line("p:COM0", "c1", "vim notes.txt")
+
+        submit.assert_called_once_with(
+            session_id="p:COM0",
+            command="vim notes.txt",
+            source="human:c1",
+            mode="interactive",
+            timeout_s=30.0,
+            priority=100,
+        )
+
+    def test_human_console_regular_command_uses_line_mode(self) -> None:
+        svc = SerialwrapService([])
+        with mock.patch.object(svc._arbiter, "submit") as submit:
+            svc._on_console_line("p:COM0", "c1", "echo hello")
+
+        submit.assert_called_once_with(
+            session_id="p:COM0",
+            command="echo hello",
+            source="human:c1",
+            mode="line",
+            timeout_s=30.0,
+            priority=100,
+        )
+
+    def test_human_console_sudo_vim_is_interactive(self) -> None:
+        svc = SerialwrapService([])
+        with mock.patch.object(svc._arbiter, "submit") as submit:
+            svc._on_console_line("p:COM0", "c1", "sudo vim /etc/config")
+
+        self.assertEqual(submit.call_args.kwargs["mode"], "interactive")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_bind.py
+++ b/tests/test_session_bind.py
@@ -3,7 +3,7 @@ import unittest
 from pathlib import Path
 
 from sw_core.config import SessionProfile, UartProfile
-from sw_core.session_manager import SessionManager
+from sw_core.session_manager import InteractiveLease, SessionManager
 import sw_core.session_manager as sm_mod
 from sw_core.wal import WalWriter
 
@@ -118,6 +118,205 @@ class TestSessionBind(unittest.TestCase):
         bridge.send_command.assert_any_call("printf 'broken", source="agent:test", cmd_id="cid-1")
         bridge.send_bytes.assert_called_once_with(b"\x03", source="system:recover", cmd_id=None)
 
+    def test_execute_command_prompt_timeout_without_recovery_demotes_to_attached(self) -> None:
+        import unittest.mock as mock
+
+        profiles = [self._make_profile("p", "COM0", "lab+1", "/dev/serial/by-id/orig")]
+        mgr = SessionManager(profiles, WalWriter(wal_dir=self._tmp.name), on_ready=lambda _sid: None, on_detached=lambda _sid: None)
+        session = mgr.get_session("COM0")
+        self.assertIsNotNone(session)
+        assert session is not None
+
+        bridge = mock.MagicMock()
+        bridge.rx_snapshot_len.side_effect = [10, 20, 30]
+        bridge.wait_for_regex_from.side_effect = [False, False, False]
+        session.bridge = bridge
+        session.state = "READY"
+
+        resp = mgr.execute_command("p:COM0", "printf 'broken", "agent:test", "cid-2", timeout_s=0.1)
+
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error_code"], "PROMPT_TIMEOUT")
+        self.assertEqual(resp["recovery_action"], "NONE")
+        self.assertEqual(session.state, "ATTACHED")
+        self.assertEqual(session.last_error, "PROMPT_TIMEOUT")
+        self.assertEqual(bridge.send_command.call_count, 1)
+        self.assertEqual(bridge.send_bytes.call_count, 2)
+
+    def test_agent_reboot_command_enters_recovering_without_force_reboot(self) -> None:
+        import unittest.mock as mock
+
+        profiles = [self._make_profile("p", "COM0", "lab+1", "/dev/serial/by-id/orig")]
+        mgr = SessionManager(profiles, WalWriter(wal_dir=self._tmp.name), on_ready=lambda _sid: None, on_detached=lambda _sid: None)
+        session = mgr.get_session("COM0")
+        assert session is not None
+
+        bridge = mock.MagicMock()
+        bridge.rx_snapshot_len.return_value = 10
+        bridge.wait_for_regex_from.return_value = False
+        session.bridge = bridge
+        session.state = "READY"
+
+        with mock.patch.object(mgr, "_spawn_reboot_recovery") as spawn_recovery:
+            resp = mgr.execute_command("p:COM0", "reboot -f", "agent:test", "cid-3", timeout_s=0.1)
+
+        self.assertTrue(resp["ok"])
+        self.assertEqual(resp["recovery_action"], "EXPECT_REBOOT")
+        self.assertEqual(session.state, "RECOVERING")
+        self.assertTrue(session.recovering)
+        self.assertTrue(session.pending_auto_login)
+        bridge.send_command.assert_called_once_with("reboot -f", source="agent:test", cmd_id="cid-3")
+        bridge.send_bytes.assert_not_called()
+        spawn_recovery.assert_called_once()
+
+    def test_human_reboot_command_promotes_attached_interactive(self) -> None:
+        import unittest.mock as mock
+
+        profiles = [self._make_profile("p", "COM0", "lab+1", "/dev/serial/by-id/orig")]
+        mgr = SessionManager(profiles, WalWriter(wal_dir=self._tmp.name), on_ready=lambda _sid: None, on_detached=lambda _sid: None)
+        session = mgr.get_session("COM0")
+        assert session is not None
+
+        bridge = mock.MagicMock()
+        bridge.rx_snapshot_len.return_value = 10
+        bridge.wait_for_regex_from.return_value = False
+        session.bridge = bridge
+        session.state = "READY"
+
+        resp = mgr.execute_command("p:COM0", "reboot", "human:cid-7", "cid-4", timeout_s=0.1)
+
+        self.assertTrue(resp["ok"])
+        self.assertEqual(resp["status"], "interactive")
+        self.assertEqual(resp["recovery_action"], "PROMOTE_HUMAN_INTERACTIVE")
+        self.assertEqual(session.state, "ATTACHED")
+        self.assertEqual(session.last_error, "REBOOTING")
+        self.assertIsNotNone(session.interactive_session_id)
+        bridge.send_command.assert_called_once_with("reboot", source="human:cid-7", cmd_id="cid-4")
+        bridge.send_bytes.assert_not_called()
+
+    def test_human_prompt_timeout_promotes_to_interactive(self) -> None:
+        import unittest.mock as mock
+
+        profiles = [self._make_profile("p", "COM0", "lab+1", "/dev/serial/by-id/orig")]
+        mgr = SessionManager(profiles, WalWriter(wal_dir=self._tmp.name), on_ready=lambda _sid: None, on_detached=lambda _sid: None)
+        session = mgr.get_session("COM0")
+        self.assertIsNotNone(session)
+        assert session is not None
+
+        bridge = mock.MagicMock()
+        bridge.rx_snapshot_len.return_value = 10
+        bridge.wait_for_regex_from.return_value = False
+        session.bridge = bridge
+        session.state = "READY"
+
+        resp = mgr.execute_command("p:COM0", "vim notes.txt", "human:cid-1", "cmd-1", timeout_s=0.1)
+
+        self.assertTrue(resp["ok"])
+        self.assertEqual(resp["status"], "interactive")
+        self.assertEqual(resp["recovery_action"], "PROMOTE_HUMAN_INTERACTIVE")
+        self.assertEqual(session.interactive_session_id, resp["interactive_session_id"])
+        bridge.send_command.assert_called_once_with("vim notes.txt", source="human:cid-1", cmd_id="cmd-1")
+        bridge.set_interactive_owner.assert_called_once_with("human:cid-1")
+        bridge.send_bytes.assert_not_called()
+
+    def test_interactive_open_uses_owner_for_bridge(self) -> None:
+        import unittest.mock as mock
+
+        profiles = [self._make_profile("p", "COM0", "lab+1", "/dev/serial/by-id/orig")]
+        mgr = SessionManager(profiles, WalWriter(wal_dir=self._tmp.name), on_ready=lambda _sid: None, on_detached=lambda _sid: None)
+        session = mgr.get_session("COM0")
+        self.assertIsNotNone(session)
+        assert session is not None
+
+        bridge = mock.MagicMock()
+        session.bridge = bridge
+        session.state = "READY"
+
+        resp = mgr.interactive_open("COM0", owner="human:cid-9", timeout_s=30.0)
+
+        self.assertTrue(resp["ok"])
+        bridge.set_interactive_owner.assert_called_once_with("human:cid-9")
+        self.assertEqual(session.interactive_session_id, resp["interactive_id"])
+
+    def test_self_test_reports_human_interactive_active(self) -> None:
+        from sw_core.device_watcher import DeviceInfo
+        import unittest.mock as mock
+
+        profiles = [self._make_profile("p", "COM0", "lab+1", "/dev/serial/by-id/orig")]
+        mgr = SessionManager(profiles, WalWriter(wal_dir=self._tmp.name), on_ready=lambda _sid: None, on_detached=lambda _sid: None)
+        session = mgr.get_session("COM0")
+        self.assertIsNotNone(session)
+        assert session is not None
+
+        bridge = mock.MagicMock()
+        bridge.snapshot.return_value = {
+            "running": True,
+            "serial_alive": True,
+            "vtty_alive": True,
+            "vtty": "/dev/pts/9",
+            "interactive_owner": "human:cid-2",
+        }
+        session.bridge = bridge
+        session.state = "READY"
+        session.attached_real_path = "/dev/ttyUSB0"
+        lease = InteractiveLease(
+            interactive_id="lease-1",
+            session_id=session.session_id,
+            owner="human:cid-2",
+            created_at="now",
+            timeout_s=60.0,
+        )
+        with mgr._lock:
+            mgr._devices = {"/dev/serial/by-id/orig": DeviceInfo(by_id="/dev/serial/by-id/orig", real_path="/dev/ttyUSB0")}
+            mgr._interactive[lease.interactive_id] = lease
+            session.interactive_session_id = lease.interactive_id
+
+        resp = mgr.self_test("COM0")
+
+        self.assertTrue(resp["ok"])
+        self.assertEqual(resp["classification"], "HUMAN_INTERACTIVE_ACTIVE")
+        self.assertEqual(resp["interactive_owner"], "human:cid-2")
+        bridge.send_command.assert_not_called()
+
+    def test_detach_console_releases_human_interactive(self) -> None:
+        import unittest.mock as mock
+
+        profiles = [self._make_profile("p", "COM0", "lab+1", "/dev/serial/by-id/orig")]
+        mgr = SessionManager(profiles, WalWriter(wal_dir=self._tmp.name), on_ready=lambda _sid: None, on_detached=lambda _sid: None)
+        session = mgr.get_session("COM0")
+        self.assertIsNotNone(session)
+        assert session is not None
+
+        bridge = mock.MagicMock()
+        bridge.detach_console.return_value = True
+        bridge.snapshot.return_value = {
+            "running": True,
+            "serial_alive": True,
+            "vtty_alive": True,
+            "vtty": "/dev/pts/9",
+            "interactive_owner": "human:cid-4",
+        }
+        bridge.vtty_path = "/dev/pts/9"
+        session.bridge = bridge
+        session.state = "READY"
+        lease = InteractiveLease(
+            interactive_id="lease-2",
+            session_id=session.session_id,
+            owner="human:cid-4",
+            created_at="now",
+            timeout_s=60.0,
+        )
+        with mgr._lock:
+            mgr._interactive[lease.interactive_id] = lease
+            session.interactive_session_id = lease.interactive_id
+
+        resp = mgr.detach_console("COM0", "cid-4")
+
+        self.assertTrue(resp["ok"])
+        self.assertIsNone(session.interactive_session_id)
+        self.assertNotIn("lease-2", mgr._interactive)
+        bridge.set_interactive_owner.assert_called_with(None)
+
     def test_auto_bind_on_device_attach(self) -> None:
         """裝置 by-id 不符合 profile 佔位符時，_attach_by_id 應自動綁定並更新 device_by_id。"""
         from sw_core.device_watcher import DeviceInfo
@@ -133,7 +332,7 @@ class TestSessionBind(unittest.TestCase):
         )
 
         with mock.patch("sw_core.session_manager.UARTBridge") as MockBridge, \
-             mock.patch("sw_core.session_manager.ensure_ready", return_value=(True, None)):
+             mock.patch("sw_core.session_manager.probe_ready", return_value=(True, None)):
             bridge_inst = MockBridge.return_value
             bridge_inst.vtty_path = "/dev/pts/99"
             bridge_inst.start.return_value = None
@@ -189,7 +388,7 @@ class TestSessionBind(unittest.TestCase):
         dev1_by_id = "/dev/serial/by-id/usb-FTDI_BBB-if00"
 
         with mock.patch("sw_core.session_manager.UARTBridge") as MockBridge, \
-             mock.patch("sw_core.session_manager.ensure_ready", return_value=(True, None)):
+             mock.patch("sw_core.session_manager.probe_ready", return_value=(True, None)):
             MockBridge.return_value.vtty_path = "/dev/pts/10"
             MockBridge.return_value.start.return_value = None
 
@@ -240,13 +439,52 @@ class TestSessionBind(unittest.TestCase):
         self.assertTrue(resp["ok"])
         self.assertEqual(resp["classification"], "DEVICE_REBOUND_REQUIRED")
 
-    def test_attach_console_requires_ready_session(self) -> None:
+    def test_attach_console_allows_attached_session_and_opens_raw_human_owner(self) -> None:
+        import unittest.mock as mock
+
         profiles = [self._make_profile("p", "COM0", "lab+1", "/dev/serial/by-id/orig")]
         mgr = SessionManager(profiles, WalWriter(wal_dir=self._tmp.name), on_ready=lambda _sid: None, on_detached=lambda _sid: None)
+        session = mgr.get_session("COM0")
+        assert session is not None
 
-        resp = mgr.attach_console("COM0")
-        self.assertFalse(resp["ok"])
-        self.assertEqual(resp["error_code"], "SESSION_NOT_READY")
+        bridge = mock.MagicMock()
+        bridge.attach_console.return_value = {"client_id": "cid-9", "label": "human", "vtty": "/dev/pts/9"}
+        session.bridge = bridge
+        session.state = "ATTACHED"
+
+        resp = mgr.attach_console("COM0", label="human")
+
+        self.assertTrue(resp["ok"])
+        self.assertEqual(resp["client_id"], "cid-9")
+        self.assertEqual(session.interactive_session_id, resp["interactive_session_id"])
+        bridge.set_interactive_owner.assert_called_once_with("human:cid-9")
+
+    def test_self_test_reports_login_required_for_attached_session(self) -> None:
+        from sw_core.device_watcher import DeviceInfo
+        import unittest.mock as mock
+
+        profiles = [self._make_profile("p", "COM0", "lab+1", "/dev/serial/by-id/orig")]
+        mgr = SessionManager(profiles, WalWriter(wal_dir=self._tmp.name), on_ready=lambda _sid: None, on_detached=lambda _sid: None)
+        session = mgr.get_session("COM0")
+        assert session is not None
+
+        bridge = mock.MagicMock()
+        bridge.snapshot.return_value = {"running": True, "serial_alive": True, "vtty_alive": True, "vtty": "/dev/pts/9"}
+        session.bridge = bridge
+        session.state = "ATTACHED"
+        session.last_error = "LOGIN_REQUIRED"
+        session.attached_real_path = "/dev/ttyUSB0"
+        with mgr._lock:
+            mgr._devices = {
+                "/dev/serial/by-id/orig": DeviceInfo(by_id="/dev/serial/by-id/orig", real_path="/dev/ttyUSB0")
+            }
+
+        resp = mgr.self_test("COM0")
+
+        self.assertTrue(resp["ok"])
+        self.assertEqual(resp["classification"], "LOGIN_REQUIRED")
+        self.assertEqual(resp["recommended_action"], "console_attach")
+        bridge.send_command.assert_not_called()
 
     def test_bridge_down_triggers_reattach_when_device_still_exists(self) -> None:
         from sw_core.device_watcher import DeviceInfo

--- a/tools/minicom_router.sh
+++ b/tools/minicom_router.sh
@@ -72,6 +72,17 @@ _find_first_ready_row() {
   printf '%s' "${obj}" | jq -c '.sessions[]? | select(.state=="READY")' | head -n 1
 }
 
+_find_first_console_row() {
+  local obj="$1"
+  local row
+  row="$(_find_first_ready_row "${obj}")"
+  if [[ -n "${row}" ]]; then
+    printf '%s' "${row}"
+    return 0
+  fi
+  printf '%s' "${obj}" | jq -c '.sessions[]? | select(.state=="ATTACHED")' | head -n 1
+}
+
 _find_attach_selector_default() {
   local obj="$1"
   local pick
@@ -146,7 +157,7 @@ _ensure_daemon() {
   printf '%s' "${state_json}"
 }
 
-_wait_ready_row() {
+_wait_console_row() {
   local sel="$1"
   local row=""
   local state_json=""
@@ -158,12 +169,27 @@ _wait_ready_row() {
       continue
     fi
     row="$(_find_row_by_selector "${state_json}" "${sel}")"
-    if [[ -n "${row}" && "$(printf '%s' "${row}" | jq -r '.state // ""')" == "READY" ]]; then
-      printf '%s' "${row}"
-      return 0
+    if [[ -n "${row}" ]]; then
+      local state
+      state="$(printf '%s' "${row}" | jq -r '.state // ""')"
+      if [[ "${state}" == "READY" || "${state}" == "ATTACHED" ]]; then
+        printf '%s' "${row}"
+        return 0
+      fi
     fi
     sleep 0.2
   done
+  return 1
+}
+
+_wait_ready_row() {
+  local sel="$1"
+  local row=""
+  row="$(_wait_console_row "${sel}")" || return 1
+  if [[ "$(printf '%s' "${row}" | jq -r '.state // ""')" == "READY" ]]; then
+      printf '%s' "${row}"
+      return 0
+  fi
   return 1
 }
 
@@ -208,23 +234,28 @@ state_json="$(_ensure_daemon)"
 
 if _json_ok "${state_json}"; then
   if [[ -z "${selector}" ]]; then
-    row="$(_find_first_ready_row "${state_json}")"
+    row="$(_find_first_console_row "${state_json}")"
     if [[ -z "${row}" && "${ATTACH_WHEN_NOT_READY}" == "1" ]]; then
       selector="$(_find_attach_selector_default "${state_json}")"
       if [[ -n "${selector}" ]]; then
         "${SERIALWRAP_BIN}" --socket "${SOCKET}" session attach --selector "${selector}" >/dev/null 2>&1 || true
-        row="$(_wait_ready_row "${selector}")"
+        row="$(_wait_console_row "${selector}")"
       fi
     fi
   else
     row="$(_find_row_by_selector "${state_json}" "${selector}")"
-    if [[ -n "${row}" && "$(printf '%s' "${row}" | jq -r '.state // ""')" != "READY" && "${ATTACH_WHEN_NOT_READY}" == "1" ]]; then
+    if [[ -n "${row}" && "$(printf '%s' "${row}" | jq -r '.state // ""')" != "READY" && "$(printf '%s' "${row}" | jq -r '.state // ""')" != "ATTACHED" && "${ATTACH_WHEN_NOT_READY}" == "1" ]]; then
       "${SERIALWRAP_BIN}" --socket "${SOCKET}" session attach --selector "${selector}" >/dev/null 2>&1 || true
-      row="$(_wait_ready_row "${selector}")"
+      row="$(_wait_console_row "${selector}")"
     fi
   fi
 
-  if [[ -n "${row:-}" && "$(printf '%s' "${row}" | jq -r '.state // ""')" == "READY" ]]; then
+  if [[ -n "${row:-}" ]]; then
+    state="$(printf '%s' "${row}" | jq -r '.state // ""')"
+  else
+    state=""
+  fi
+  if [[ -n "${row:-}" && ( "${state}" == "READY" || "${state}" == "ATTACHED" ) ]]; then
     _run_broker_minicom "${row}" "$@"
     exit $?
   fi
@@ -240,7 +271,7 @@ if [[ -n "${MINICOM_RAW_DEVICE:-}" ]]; then
   exit $?
 fi
 
-echo "minicom_router: broker not ready, no READY session, and MINICOM_RAW_DEVICE not set" >&2
+echo "minicom_router: broker not ready, no READY/ATTACHED session, and MINICOM_RAW_DEVICE not set" >&2
 if [[ "$(printf '%s' "${state_json:-}" | jq -r '.ok // false' 2>/dev/null || printf 'false')" == "true" ]]; then
   echo "sessions:" >&2
   printf '%s' "${state_json}" | jq -r '.sessions[]? | "  - \(.com) \(.alias) state=\(.state) last_error=\(.last_error // "-")"' >&2 || true


### PR DESCRIPTION
## 問題背景

COM2 (OrangePi) 反覆斷線根本原因：`ensure_ready()` 超時後觸發 `reboot -f`，造成 target 被意外重啟。

## Session 狀態機擴充

`DETACHED → ATTACHING → ATTACHED → READY`（及 `RECOVERING`）

- **ATTACHED**：bridge 已掛，prompt probe 失敗時保留連線供 human 接手
- **RECOVERING**：僅限 agent 明確送出 reboot 類指令後才觸發

## login 邊界規則

| 情境 | 行為 |
|------|------|
| daemon 啟動 / hotplug reattach | probe_ready()，不自動登入 |
| agent reboot 指令 | RECOVERING + pending_auto_login，重開後 ensure_ready() |
| minicom reboot / 首次開機 | 停在 ATTACHED，human 自行操作 |
| agent 指令 prompt timeout | Ctrl-C → Ctrl-D → 降級 ATTACHED，不再 reboot |

## 主要變更

- login_fsm: 拆出 probe_ready() / _classify_non_ready_state() / _finalize_ready()
- session_manager: 新增 ATTACHED 狀態；移除 reboot -f；新增 _is_reboot_command()
- arbiter: 修正 worker thread 不得 join 自己
- minicom_router: 優先 READY，退而求其次 ATTACHED
- tests: 新增 6 支 FSM 路徑測試，44 項全數通過
- README / spec: 狀態圖、self_test 分類、recover 流程全面對齊

BREAKING CHANGE: probe_ready() 為新 bootstrap 預設路徑，ensure_ready() 僅在 agent reboot 後呼叫。