### PR TITLE
refactor(session-fsm): 新增 ATTACHED 狀態並修正 prpl prompt 偵測

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ alias minicom="$INSTALL_DIR/minicom_router.sh"
 profiles:
   prpl-template:
     platform: prpl
-    prompt_regex: ".*# $"
-    ready_probe: "echo __READY__${nonce}; whoami"
+    prompt_regex: "(?m)^root@prplOS:.*# "
+    ready_probe: "echo __READY__${nonce}"
     uart:
       baud: 115200
       data_bits: 8
@@ -193,6 +193,8 @@ targets:
     profile: opi-shell
     device_by_id: /dev/serial/by-id/<target2>
 ```
+
+`prpl-template` 預設改成匹配 `root@prplOS:/#` 這種 prompt prefix，而不是要求 prompt 必須單獨佔一整行。這樣在 prompt 後面立刻接 driver / kernel log 的情況下，line mode 仍能正確收尾；`ready_probe` 也維持最小 `echo __READY__${nonce}`，避免在沒有 `whoami` 的 target 上增加噪音。
 
 `user_env` / `pass_env` 是每個 profile 自己指定的登入帳密環境變數名稱。CLI / daemon 不會把密碼寫進 YAML 或 WAL。`serialwrap daemon start` 會在啟動前先嘗試載入 `~/OPI.env`；若檔案不存在，則維持既有行為。
 

--- a/docs/serialwrap-spec.md
+++ b/docs/serialwrap-spec.md
@@ -478,6 +478,8 @@ flowchart TD
 
 `platform=shell` 可使用 `user_env` / `pass_env` 做 generic shell login。`serialwrap daemon start` 會先嘗試載入 `~/OPI.env`，因此可將 `SW_OPI_U` / `SW_OPI_P` 放在該檔。若裝置 login prompt 會帶 hostname（例如 `orangepi3 login:`），建議 `login_regex` 使用 `(?mi)^.*login:\\s*$`。若裝置已自動登入並直接出現 prompt，daemon 會略過 login 流程，直接做 `ready_probe`。
 
+對 prplOS 這類會把 driver / kernel log 直接接在 prompt 後面的 target，`prompt_regex` 應偏向匹配 prompt prefix，例如 `(?m)^root@prplOS:.*# `，不要只依賴行尾錨點。`ready_probe` 也建議保持最小 `echo __READY__${nonce}`，避免像 `whoami` 這類 target 可能不存在的指令干擾 ready 判定。
+
 ## 14. 驗收標準
 
 - line mode 命令完成後 `stdout` 正確回填

--- a/profiles/default.yaml
+++ b/profiles/default.yaml
@@ -1,10 +1,10 @@
 profiles:
   prpl-template:
     platform: prpl
-    prompt_regex: ".*# $"
+    prompt_regex: "(?m)^root@prplOS:.*# "
     login_regex: "(?mi)^login:\\s*$"
     password_regex: "(?mi)^password:\\s*$"
-    ready_probe: "echo __READY__${nonce}; whoami"
+    ready_probe: "echo __READY__${nonce}"
     uart:
       baud: 115200
       data_bits: 8

--- a/sw_core/config.py
+++ b/sw_core/config.py
@@ -21,11 +21,11 @@ class UartProfile:
 class ProfileTemplate:
     profile_name: str
     platform: str = "prpl"
-    prompt_regex: str = r".*# $"
+    prompt_regex: str = r"(?m)^root@prplOS:.*# "
     login_regex: str = r"(?mi)^login:\\s*$"
     password_regex: str = r"(?mi)^password:\\s*$"
     post_login_cmd: str = ""
-    ready_probe: str = "echo __READY__${nonce}; whoami"
+    ready_probe: str = "echo __READY__${nonce}"
     username: str | None = None
     user_env: str | None = None
     pass_env: str | None = None
@@ -43,11 +43,11 @@ class SessionProfile:
     alias: str
     device_by_id: str
     platform: str
-    prompt_regex: str = r".*# $"
+    prompt_regex: str = r"(?m)^root@prplOS:.*# "
     login_regex: str = r"(?mi)^login:\\s*$"
     password_regex: str = r"(?mi)^password:\\s*$"
     post_login_cmd: str = ""
-    ready_probe: str = "echo __READY__${nonce}; whoami"
+    ready_probe: str = "echo __READY__${nonce}"
     username: str | None = None
     user_env: str | None = None
     pass_env: str | None = None
@@ -95,11 +95,11 @@ def _template_from_dict(name: str, raw: dict[str, Any]) -> ProfileTemplate:
     return ProfileTemplate(
         profile_name=name,
         platform=str(raw.get("platform") or "prpl").strip().lower(),
-        prompt_regex=str(raw.get("prompt_regex") or r".*# $").strip(),
+        prompt_regex=str(raw.get("prompt_regex") or r"(?m)^root@prplOS:.*# "),
         login_regex=str(raw.get("login_regex") or r"(?mi)^login:\\s*$").strip(),
         password_regex=str(raw.get("password_regex") or r"(?mi)^password:\\s*$").strip(),
         post_login_cmd=str(raw.get("post_login_cmd") or "").strip(),
-        ready_probe=str(raw.get("ready_probe") or "echo __READY__${nonce}; whoami").strip(),
+        ready_probe=str(raw.get("ready_probe") or "echo __READY__${nonce}").strip(),
         username=_as_opt_str(raw.get("username")),
         user_env=_as_opt_str(raw.get("user_env") or raw.get("username_env") or raw.get("login_env")),
         pass_env=_as_opt_str(raw.get("pass_env") or raw.get("password_env") or raw.get("pw_env")),
@@ -148,7 +148,7 @@ def _merge_session(template: ProfileTemplate, target: dict[str, Any], *, act_no:
         alias=alias,
         device_by_id=device_by_id,
         platform=str(target.get("platform") or template.platform).strip().lower(),
-        prompt_regex=str(target.get("prompt_regex") or template.prompt_regex).strip(),
+        prompt_regex=str(target.get("prompt_regex") or template.prompt_regex),
         login_regex=str(target.get("login_regex") or template.login_regex).strip(),
         password_regex=str(target.get("password_regex") or template.password_regex).strip(),
         post_login_cmd=str(target.get("post_login_cmd") or template.post_login_cmd).strip(),

--- a/tests/test_config_profiles.py
+++ b/tests/test_config_profiles.py
@@ -39,7 +39,8 @@ class TestConfigProfiles(unittest.TestCase):
                     profiles:
                       prpl-template:
                         platform: prpl
-                        prompt_regex: ".*# $"
+                        prompt_regex: "(?m)^root@prplOS:.*# "
+                        ready_probe: "echo __READY__${nonce}"
                         uart:
                           baud: 115200
                           data_bits: 8
@@ -68,6 +69,10 @@ class TestConfigProfiles(unittest.TestCase):
             self.assertEqual(rows[1].uart.baud, 115200)
             self.assertEqual(rows[0].device_by_id, "/dev/serial/by-id/tty0")
             self.assertEqual(rows[1].device_by_id, "/dev/serial/by-id/tty1")
+            self.assertEqual(rows[0].prompt_regex, r"(?m)^root@prplOS:.*# ")
+            self.assertEqual(rows[1].prompt_regex, r"(?m)^root@prplOS:.*# ")
+            self.assertEqual(rows[0].ready_probe, "echo __READY__${nonce}")
+            self.assertEqual(rows[1].ready_probe, "echo __READY__${nonce}")
 
     def test_shell_profile_loads_short_env_fields(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_multiagent_e2e.py
+++ b/tests/test_multiagent_e2e.py
@@ -38,7 +38,7 @@ class FakeTarget:
         termios.tcsetattr(fd, termios.TCSANOW, attrs)
 
     def start(self) -> None:
-        os.write(self.master_fd, b"boot done\r\n# ")
+        os.write(self.master_fd, b"boot done\r\nroot@prplOS:/# ")
         self._cmd_thread.start()
         self._noise_thread.start()
 
@@ -85,11 +85,11 @@ class FakeTarget:
                 cmd = line.replace(b"\r", b"").decode("utf-8", errors="replace").strip()
                 if not cmd:
                     try:
-                        os.write(self.master_fd, b"# ")
+                        os.write(self.master_fd, b"root@prplOS:/# ")
                     except OSError:
                         return
                     continue
-                out = f"EXEC:{cmd}\r\nRESULT:{cmd}:OK\r\n# ".encode("utf-8")
+                out = f"EXEC:{cmd}\r\nRESULT:{cmd}:OK\r\nroot@prplOS:/# ".encode("utf-8")
                 try:
                     os.write(self.master_fd, out)
                 except OSError:
@@ -152,8 +152,8 @@ class TestMultiAgentE2E(unittest.TestCase):
             profile = f"""profiles:
   prpl-template:
     platform: prpl
-    prompt_regex: ".*# "
-    ready_probe: "echo __READY__${{nonce}}; whoami"
+    prompt_regex: "(?m)^root@prplOS:.*# "
+    ready_probe: "echo __READY__${{nonce}}"
     uart:
       baud: 115200
       data_bits: 8


### PR DESCRIPTION
## 變更內容
- 新增 `ATTACHED` 狀態，重構 attach / login 邊界與 reboot recover 流程
- 調整 `prpl-template` 的 `prompt_regex` 與 `ready_probe`，避免 prompt 後接 driver log 或 target 缺少 `whoami` 時誤判
- 同步更新 `README.md`、`docs/serialwrap-spec.md`、設定預設值與對應測試

## 驗證
- `python3 -m unittest tests.test_config_profiles tests.test_multiagent_e2e -v`
