### PR TITLE
fix(serial): 修正 human interactive busy 並新增 op3/passthrough profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ profiles:
       stop_bits: 1
       flow_control: none
       xonxoff: false
-  opi-shell:
+  op3-template:
     platform: shell
     prompt_regex: ".*[$#] $"
     login_regex: "(?mi)^.*login:\\s*$"
@@ -173,6 +173,19 @@ profiles:
     user_env: "SW_OPI_U"
     pass_env: "SW_OPI_P"
     ready_probe: "echo __READY__${nonce}"
+    uart:
+      baud: 115200
+      data_bits: 8
+      parity: N
+      stop_bits: 1
+      flow_control: none
+      xonxoff: false
+  others-template:
+    platform: passthrough
+    prompt_regex: ".*"
+    login_regex: "$^"
+    password_regex: "$^"
+    ready_probe: ""
     uart:
       baud: 115200
       data_bits: 8
@@ -190,13 +203,18 @@ targets:
   - act_no: 3
     com: COM2
     alias: default+3
-    profile: opi-shell
+    profile: op3-template
     device_by_id: /dev/serial/by-id/<target2>
+  - act_no: 4
+    com: COM3
+    alias: default+4
+    profile: others-template
+    device_by_id: /dev/serial/by-id/<target3>
 ```
 
 `prpl-template` 預設改成匹配 `root@prplOS:/#` 這種 prompt prefix，而不是要求 prompt 必須單獨佔一整行。這樣在 prompt 後面立刻接 driver / kernel log 的情況下，line mode 仍能正確收尾；`ready_probe` 也維持最小 `echo __READY__${nonce}`，避免在沒有 `whoami` 的 target 上增加噪音。
 
-`user_env` / `pass_env` 是每個 profile 自己指定的登入帳密環境變數名稱。CLI / daemon 不會把密碼寫進 YAML 或 WAL。`serialwrap daemon start` 會在啟動前先嘗試載入 `~/OPI.env`；若檔案不存在，則維持既有行為。
+`op3-template` 沿用 generic shell login 模型，適合 Orange Pi / Debian shell。`user_env` / `pass_env` 是每個 profile 自己指定的登入帳密環境變數名稱。CLI / daemon 不會把密碼寫進 YAML 或 WAL。`serialwrap daemon start` 會在啟動前先嘗試載入 `~/OPI.env`；若檔案不存在，則維持既有行為。
 
 ```bash
 cat > ~/OPI.env <<'EOF'
@@ -210,6 +228,8 @@ serialwrap daemon start --profile-dir "$HOME/.paul_tools/profiles"
 若你偏好手動設定環境變數，也可以沿用原本的 `export SW_OPI_U=...` / `export SW_OPI_P=...` 方式再啟動 daemon。
 
 若 shell device 已經自動登入，`serialwrap` 會直接用 prompt + `ready_probe` 驗證；若先看到 `login:` / `password:`，則會依 `user_env` / `pass_env` 自動登入。像 Orange Pi 常見的 `orangepi3 login:`，建議 `login_regex` 用 `(?mi)^.*login:\\s*$`。
+
+`others-template` 使用 `platform=passthrough`。attach 時不做 prompt/login/ready 限制，只建立 broker bridge，讓 `ttyUSB` 與 broker 建出的 `ttyPTS` 直接透傳；這類 session 會停在 `ATTACHED`，適合不認識的設備先用 minicom/human console 觀察。
 
 常用查看：
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ minicom -D /dev/ttyUSB0
 - 若 session 只有 `ATTACHED`（bridge 已掛上但尚未 ready），`session console-attach` 仍可進入 brokered minicom；這時 console 會自動拿到 raw human ownership，方便手動登入或觀察 boot/log 狀態。
 - 若要讓某個 console 進入 raw interactive ownership，先 `console-attach` 拿到 `client_id`，再用 `interactive-open --owner human:<client_id>` 開 lease。
 - 常見 human/minicom 互動式命令（例如 `vi`、`vim`、`top`、`htop`、`less`、`menuconfig`）會自動升級成 human interactive ownership，不再因為等不到 shell prompt 而自動觸發 recover / reboot。
+- human interactive ownership 存在時，agent 的 `line` / `background` 命令會在 worker 內等待 ownership 釋放；若超過該命令自己的 timeout，才會回 `SESSION_INTERACTIVE_BUSY`。
 
 手動 console 控制範例：
 

--- a/docs/serialwrap-spec.md
+++ b/docs/serialwrap-spec.md
@@ -143,6 +143,7 @@ sequenceDiagram
 - 非 interactive owner 的 human input 只會緩衝成 line，經 broker queue 執行
 - line-buffered human input 由 broker 提供本地回顯與基本 backspace 行編輯，避免 minicom 看不到鍵入內容
 - 常見 human/minicom 互動式命令（如 `vim`、`top`、`less`、`menuconfig`）可自動升級為 human interactive ownership，避免被誤判為 prompt timeout 故障
+- human interactive ownership 存在時，agent foreground/background 命令不會立即失敗，而是等待 ownership 釋放；若超過該命令 timeout，才回 `SESSION_INTERACTIVE_BUSY`
 - 若 session 僅為 `ATTACHED`，`session.console_attach` 仍可使用，且該 console 會自動拿到 raw human ownership，方便手動登入或觀察 boot/log
 
 ### 5.3 Command record

--- a/docs/serialwrap-spec.md
+++ b/docs/serialwrap-spec.md
@@ -145,6 +145,7 @@ sequenceDiagram
 - 常見 human/minicom 互動式命令（如 `vim`、`top`、`less`、`menuconfig`）可自動升級為 human interactive ownership，避免被誤判為 prompt timeout 故障
 - human interactive ownership 存在時，agent foreground/background 命令不會立即失敗，而是等待 ownership 釋放；若超過該命令 timeout，才回 `SESSION_INTERACTIVE_BUSY`
 - 若 session 僅為 `ATTACHED`，`session.console_attach` 仍可使用，且該 console 會自動拿到 raw human ownership，方便手動登入或觀察 boot/log
+- `platform=passthrough` 的 session attach 後不做 prompt/login/ready 探測，直接停在 `ATTACHED`，供未知設備走純 bridge/passthrough 路徑
 
 ### 5.3 Command record
 
@@ -478,6 +479,8 @@ flowchart TD
 `quiet_window_s` 目前用於 background capture idle finalize。
 
 `platform=shell` 可使用 `user_env` / `pass_env` 做 generic shell login。`serialwrap daemon start` 會先嘗試載入 `~/OPI.env`，因此可將 `SW_OPI_U` / `SW_OPI_P` 放在該檔。若裝置 login prompt 會帶 hostname（例如 `orangepi3 login:`），建議 `login_regex` 使用 `(?mi)^.*login:\\s*$`。若裝置已自動登入並直接出現 prompt，daemon 會略過 login 流程，直接做 `ready_probe`。
+
+`platform=passthrough` 則完全不做 `ready_probe` / login 流程。daemon 只負責建立 UART bridge 與 console PTY，session 會停在 `ATTACHED`，由 human console 或後續人工判斷設備型態。
 
 對 prplOS 這類會把 driver / kernel log 直接接在 prompt 後面的 target，`prompt_regex` 應偏向匹配 prompt prefix，例如 `(?m)^root@prplOS:.*# `，不要只依賴行尾錨點。`ready_probe` 也建議保持最小 `echo __READY__${nonce}`，避免像 `whoami` 這類 target 可能不存在的指令干擾 ready 判定。
 

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@ rm -f "${TARGET_DIR}/serialwrap_lib.py"
 rm -f "${TARGET_DIR}/__pycache__/serialwrap_lib."*.pyc 2>/dev/null || true
 
 DEFAULT_PROFILE_PATH="${TARGET_DIR}/profiles/default.yaml"
-DEFAULT_PLACEHOLDER_BY_ID="/dev/serial/by-id/target0"
+DEFAULT_PLACEHOLDER_BY_ID="/dev/serial/by-id/target3"
 INSTALL_AUTOBIND="${SERIALWRAP_INSTALL_AUTOBIND:-1}"
 
 if [[ "${INSTALL_AUTOBIND}" == "1" && -f "${DEFAULT_PROFILE_PATH}" ]]; then

--- a/profiles/default.yaml
+++ b/profiles/default.yaml
@@ -12,7 +12,7 @@ profiles:
       stop_bits: 1
       flow_control: none
       xonxoff: false
-  opi-shell:
+  op3-template:
     platform: shell
     prompt_regex: ".*[$#] $"
     login_regex: "(?mi)^.*login:\\s*$"
@@ -20,6 +20,19 @@ profiles:
     user_env: "SW_OPI_U"
     pass_env: "SW_OPI_P"
     ready_probe: "echo __READY__${nonce}"
+    uart:
+      baud: 115200
+      data_bits: 8
+      parity: N
+      stop_bits: 1
+      flow_control: none
+      xonxoff: false
+  others-template:
+    platform: passthrough
+    prompt_regex: ".*"
+    login_regex: "$^"
+    password_regex: "$^"
+    ready_probe: ""
     uart:
       baud: 115200
       data_bits: 8
@@ -42,10 +55,10 @@ targets:
   - act_no: 3
     com: COM2
     alias: default+3
-    profile: opi-shell
+    profile: op3-template
     device_by_id: /dev/serial/by-id/target2
   - act_no: 4
     com: COM3
     alias: default+4
-    profile: prpl-template
+    profile: others-template
     device_by_id: /dev/serial/by-id/target3

--- a/sw_core/config.py
+++ b/sw_core/config.py
@@ -78,6 +78,12 @@ def _as_opt_str(v: Any) -> str | None:
     return s if s else None
 
 
+def _as_str_keep_empty(v: Any, default: str) -> str:
+    if v is None:
+        return default
+    return str(v).strip()
+
+
 def _load_uart(raw: Any, default: UartProfile | None = None) -> UartProfile:
     base = default or UartProfile()
     obj = raw if isinstance(raw, dict) else {}
@@ -99,7 +105,7 @@ def _template_from_dict(name: str, raw: dict[str, Any]) -> ProfileTemplate:
         login_regex=str(raw.get("login_regex") or r"(?mi)^login:\\s*$").strip(),
         password_regex=str(raw.get("password_regex") or r"(?mi)^password:\\s*$").strip(),
         post_login_cmd=str(raw.get("post_login_cmd") or "").strip(),
-        ready_probe=str(raw.get("ready_probe") or "echo __READY__${nonce}").strip(),
+        ready_probe=_as_str_keep_empty(raw.get("ready_probe"), "echo __READY__${nonce}"),
         username=_as_opt_str(raw.get("username")),
         user_env=_as_opt_str(raw.get("user_env") or raw.get("username_env") or raw.get("login_env")),
         pass_env=_as_opt_str(raw.get("pass_env") or raw.get("password_env") or raw.get("pw_env")),
@@ -152,7 +158,7 @@ def _merge_session(template: ProfileTemplate, target: dict[str, Any], *, act_no:
         login_regex=str(target.get("login_regex") or template.login_regex).strip(),
         password_regex=str(target.get("password_regex") or template.password_regex).strip(),
         post_login_cmd=str(target.get("post_login_cmd") or template.post_login_cmd).strip(),
-        ready_probe=str(target.get("ready_probe") or template.ready_probe).strip(),
+        ready_probe=_as_str_keep_empty(target.get("ready_probe"), template.ready_probe),
         username=_as_opt_str(target.get("username")) if target.get("username") is not None else template.username,
         user_env=(
             _as_opt_str(target.get("user_env") or target.get("username_env") or target.get("login_env"))

--- a/sw_core/session_manager.py
+++ b/sw_core/session_manager.py
@@ -434,6 +434,7 @@ class SessionManager:
     def _attach_by_id(self, by_id: str) -> None:
         save_needed = False
         require_login = False
+        passthrough_only = False
         with self._lock:
             session = next((s for s in self._sessions.values() if s.profile.device_by_id == by_id), None)
             if session is None:
@@ -449,6 +450,7 @@ class SessionManager:
             dev = self._devices.get(by_id)
             if session is not None:
                 require_login = session.pending_auto_login
+                passthrough_only = session.profile.platform == "passthrough"
         if save_needed:
             self._save_state()
         if session is None or dev is None or session.bridge is not None:
@@ -468,7 +470,10 @@ class SessionManager:
 
         try:
             bridge.start()
-            if require_login:
+            if passthrough_only:
+                ok = False
+                err = None
+            elif require_login:
                 ok, err = ensure_ready(bridge, session.profile)
                 if not ok:
                     bridge.stop()
@@ -1126,7 +1131,10 @@ class SessionManager:
                     "recommended_action": "console_attach",
                 }
             if session.state == "ATTACHED":
-                if session.last_error == "LOGIN_REQUIRED":
+                if session.profile.platform == "passthrough":
+                    classification = "PASSTHROUGH"
+                    recommended_action = "console_attach"
+                elif session.last_error == "LOGIN_REQUIRED":
                     classification = "LOGIN_REQUIRED"
                     recommended_action = "console_attach"
                 elif session.last_error == "REBOOTING":

--- a/sw_core/session_manager.py
+++ b/sw_core/session_manager.py
@@ -621,6 +621,30 @@ class SessionManager:
         if notify_not_ready:
             self._on_detached(session.session_id)
 
+    def _wait_for_human_interactive_release(
+        self,
+        session_id: str,
+        *,
+        timeout_s: float,
+    ) -> tuple[bool, str | None]:
+        deadline = time.monotonic() + timeout_s
+
+        while time.monotonic() < deadline:
+            with self._lock:
+                session = self._sessions.get(session_id)
+                if session is None or session.bridge is None or session.state != "READY":
+                    return False, "SESSION_NOT_READY"
+                if session.recovering:
+                    return False, "SESSION_RECOVERING"
+                lease = self._refresh_interactive_locked(session)
+                if lease is None:
+                    return True, None
+                if not lease.owner.startswith("human:"):
+                    return False, "SESSION_INTERACTIVE_BUSY"
+            time.sleep(0.05)
+
+        return False, "SESSION_INTERACTIVE_BUSY"
+
     def _spawn_reboot_recovery(self, session_id: str, timeout_s: float) -> None:
         def _run() -> None:
             deadline = time.monotonic() + timeout_s
@@ -747,6 +771,7 @@ class SessionManager:
         mode: str = "line",
     ) -> dict[str, Any]:
         normalized_mode = {"fg": "line", "bg": "background"}.get(mode, mode)
+        wait_for_human_interactive = False
         with self._lock:
             session = self._sessions.get(session_id)
             if session is None or session.bridge is None or session.state != "READY":
@@ -755,9 +780,33 @@ class SessionManager:
                 return {"ok": False, "error_code": "SESSION_RECOVERING"}
             lease = self._refresh_interactive_locked(session)
             if lease is not None and normalized_mode != "interactive":
-                return {"ok": False, "error_code": "SESSION_INTERACTIVE_BUSY", "interactive_session_id": session.interactive_session_id}
+                if not source.startswith("human:") and lease.owner.startswith("human:"):
+                    wait_for_human_interactive = True
+                else:
+                    return {"ok": False, "error_code": "SESSION_INTERACTIVE_BUSY", "interactive_session_id": session.interactive_session_id}
             bridge = session.bridge
             prompt_regex = session.profile.prompt_regex
+
+        if wait_for_human_interactive:
+            wait_ok, wait_error = self._wait_for_human_interactive_release(session_id, timeout_s=timeout_s)
+            if not wait_ok:
+                with self._lock:
+                    current = self._sessions.get(session_id)
+                    result = {"ok": False, "error_code": wait_error or "SESSION_INTERACTIVE_BUSY"}
+                    if current is not None and current.interactive_session_id is not None:
+                        result["interactive_session_id"] = current.interactive_session_id
+                    return result
+            with self._lock:
+                session = self._sessions.get(session_id)
+                if session is None or session.bridge is None or session.state != "READY":
+                    return {"ok": False, "error_code": "SESSION_NOT_READY"}
+                if session.recovering:
+                    return {"ok": False, "error_code": "SESSION_RECOVERING"}
+                lease = self._refresh_interactive_locked(session)
+                if lease is not None:
+                    return {"ok": False, "error_code": "SESSION_INTERACTIVE_BUSY", "interactive_session_id": session.interactive_session_id}
+                bridge = session.bridge
+                prompt_regex = session.profile.prompt_regex
 
         if normalized_mode == "interactive":
             with self._lock:

--- a/sw_core/session_manager.py
+++ b/sw_core/session_manager.py
@@ -596,6 +596,12 @@ class SessionManager:
             self._close_interactive_locked(session, interactive_id=lease_id)
             return None
         if lease.owner.startswith("human:"):
+            client_id = lease.owner.split(":", 1)[1]
+            if not session.bridge.console_has_external_peer(client_id):
+                session.bridge.detach_console(client_id)
+                session.vtty_path = session.bridge.vtty_path
+                self._close_interactive_locked(session, interactive_id=lease_id)
+                return None
             snapshot = session.bridge.snapshot()
             if snapshot.get("interactive_owner") != lease.owner:
                 self._close_interactive_locked(session, interactive_id=lease_id)

--- a/sw_core/uart_io.py
+++ b/sw_core/uart_io.py
@@ -315,7 +315,9 @@ class UARTBridge:
                     continue
                 lines.append(client.tx_buffer.decode("utf-8", errors="replace"))
                 client.tx_buffer.clear()
-                echo.extend(b"\r\n")
+                # Commit the local line visually without adding an extra blank
+                # line before the target shell echoes the submitted command.
+                echo.extend(b"\r")
                 last_terminator = b
                 continue
 

--- a/sw_core/uart_io.py
+++ b/sw_core/uart_io.py
@@ -184,6 +184,34 @@ class UARTBridge:
             except OSError:
                 pass
 
+    def _client_has_external_peer_locked(self, client: ConsoleClient) -> bool:
+        self_pid = os.getpid()
+        try:
+            pids = os.listdir("/proc")
+        except OSError:
+            # Be conservative when procfs is unavailable.
+            return True
+
+        for pid_text in pids:
+            if not pid_text.isdigit():
+                continue
+            pid = int(pid_text)
+            if pid == self_pid:
+                continue
+            fd_dir = os.path.join("/proc", pid_text, "fd")
+            try:
+                fd_names = os.listdir(fd_dir)
+            except OSError:
+                continue
+            for fd_name in fd_names:
+                try:
+                    target = os.readlink(os.path.join(fd_dir, fd_name))
+                except OSError:
+                    continue
+                if target == client.slave_path:
+                    return True
+        return False
+
     def _drop_console_client(self, client_id: str) -> None:
         with self._state_lock:
             client = self._clients.pop(client_id, None)
@@ -461,6 +489,13 @@ class UARTBridge:
                 }
                 for client in sorted(self._clients.values(), key=lambda row: (row.label, row.client_id))
             ]
+
+    def console_has_external_peer(self, client_id: str) -> bool:
+        with self._state_lock:
+            client = self._clients.get(client_id)
+            if client is None:
+                return False
+            return self._client_has_external_peer_locked(client)
 
     def set_interactive_owner(self, owner: str | None) -> None:
         with self._state_lock:

--- a/tests/test_agent_defer_tx.py
+++ b/tests/test_agent_defer_tx.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import pty
 import select
+import subprocess
 import tempfile
 import threading
 import time
@@ -222,6 +223,42 @@ class TestUARTBridgeConsoles(unittest.TestCase):
 
             self.assertEqual(len(captured), 1)
             self.assertEqual(captured[0][1], "echo still-works")
+
+    def test_console_external_peer_tracking(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            target = self._make_target()
+            target.start()
+            self.addCleanup(target.stop)
+
+            bridge = UARTBridge("COM0", target.slave_path, UartProfile(), WalWriter(wal_dir=td))
+            bridge.start()
+            self.addCleanup(bridge.stop)
+
+            attached = bridge.attach_console(label="observer")
+            client_id = attached["client_id"]
+
+            self.assertFalse(bridge.console_has_external_peer(client_id))
+
+            proc = subprocess.Popen(
+                [
+                    os.environ.get("PYTHON", "python3"),
+                    "-c",
+                    "import os, sys, time; fd = os.open(sys.argv[1], os.O_RDWR | os.O_NOCTTY); time.sleep(1.5); os.close(fd)",
+                    attached["vtty"],
+                ]
+            )
+            try:
+                deadline = time.monotonic() + 2.0
+                while time.monotonic() < deadline and not bridge.console_has_external_peer(client_id):
+                    time.sleep(0.05)
+                self.assertTrue(bridge.console_has_external_peer(client_id))
+            finally:
+                proc.wait(timeout=3.0)
+
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline and bridge.console_has_external_peer(client_id):
+                time.sleep(0.05)
+            self.assertFalse(bridge.console_has_external_peer(client_id))
 
 
 if __name__ == "__main__":

--- a/tests/test_agent_defer_tx.py
+++ b/tests/test_agent_defer_tx.py
@@ -133,7 +133,7 @@ class TestUARTBridgeConsoles(unittest.TestCase):
             try:
                 os.write(fd, b"abc\x7fd\n")
                 deadline = time.monotonic() + 2.0
-                while time.monotonic() < deadline and (not captured or b"abc\x08 \x08d\r\n" not in echoed):
+                while time.monotonic() < deadline and (not captured or b"abc\x08 \x08d\r" not in echoed):
                     try:
                         echoed += os.read(fd, 4096)
                     except BlockingIOError:
@@ -144,7 +144,7 @@ class TestUARTBridgeConsoles(unittest.TestCase):
 
             self.assertEqual(len(captured), 1)
             self.assertEqual(captured[0][1], "abd")
-            self.assertIn(b"abc\x08 \x08d\r\n", echoed)
+            self.assertIn(b"abc\x08 \x08d\r", echoed)
             self.assertEqual(target.received, [])
 
     def test_rx_is_fanned_out_to_all_consoles(self) -> None:

--- a/tests/test_config_profiles.py
+++ b/tests/test_config_profiles.py
@@ -81,7 +81,7 @@ class TestConfigProfiles(unittest.TestCase):
                 textwrap.dedent(
                     """
                     profiles:
-                      opi-shell:
+                      op3-template:
                         platform: shell
                         prompt_regex: ".*[$#] $"
                         login_regex: '(?mi)^.*login:\s*$'
@@ -92,7 +92,7 @@ class TestConfigProfiles(unittest.TestCase):
                       - act_no: 3
                         com: COM2
                         alias: shell+3
-                        profile: opi-shell
+                        profile: op3-template
                         device_by_id: /dev/serial/by-id/tty2
                     """
                 ),
@@ -100,12 +100,42 @@ class TestConfigProfiles(unittest.TestCase):
             )
             rows = load_profiles(td)
             self.assertEqual(len(rows), 1)
-            self.assertEqual(rows[0].profile_name, "opi-shell")
+            self.assertEqual(rows[0].profile_name, "op3-template")
             self.assertEqual(rows[0].platform, "shell")
             self.assertEqual(rows[0].login_regex, r"(?mi)^.*login:\s*$")
             self.assertEqual(rows[0].user_env, "SW_OPI_U")
             self.assertEqual(rows[0].pass_env, "SW_OPI_P")
             self.assertEqual(rows[0].ready_probe, "echo __READY__${nonce}")
+
+    def test_passthrough_profile_loads_without_ready_constraints(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "others.yaml"
+            p.write_text(
+                textwrap.dedent(
+                    """
+                    profiles:
+                      others-template:
+                        platform: passthrough
+                        prompt_regex: ".*"
+                        login_regex: "$^"
+                        password_regex: "$^"
+                        ready_probe: ""
+                    targets:
+                      - act_no: 4
+                        com: COM3
+                        alias: others+4
+                        profile: others-template
+                        device_by_id: /dev/serial/by-id/tty3
+                    """
+                ),
+                encoding="utf-8",
+            )
+            rows = load_profiles(td)
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0].profile_name, "others-template")
+            self.assertEqual(rows[0].platform, "passthrough")
+            self.assertEqual(rows[0].prompt_regex, ".*")
+            self.assertEqual(rows[0].ready_probe, "")
 
 
 if __name__ == "__main__":

--- a/tests/test_session_bind.py
+++ b/tests/test_session_bind.py
@@ -317,6 +317,41 @@ class TestSessionBind(unittest.TestCase):
         self.assertNotIn("lease-2", mgr._interactive)
         bridge.set_interactive_owner.assert_called_with(None)
 
+    def test_refresh_interactive_releases_stale_human_console(self) -> None:
+        import unittest.mock as mock
+
+        profiles = [self._make_profile("p", "COM0", "lab+1", "/dev/serial/by-id/orig")]
+        mgr = SessionManager(profiles, WalWriter(wal_dir=self._tmp.name), on_ready=lambda _sid: None, on_detached=lambda _sid: None)
+        session = mgr.get_session("COM0")
+        self.assertIsNotNone(session)
+        assert session is not None
+
+        bridge = mock.MagicMock()
+        bridge.console_has_external_peer.return_value = False
+        bridge.detach_console.return_value = True
+        bridge.vtty_path = "/dev/pts/9"
+        session.bridge = bridge
+        session.state = "READY"
+
+        lease = InteractiveLease(
+            interactive_id="lease-stale",
+            session_id=session.session_id,
+            owner="human:cid-stale",
+            created_at="now",
+            timeout_s=60.0,
+        )
+        with mgr._lock:
+            mgr._interactive[lease.interactive_id] = lease
+            session.interactive_session_id = lease.interactive_id
+
+        refreshed = mgr._refresh_interactive_locked(session)
+
+        self.assertIsNone(refreshed)
+        self.assertIsNone(session.interactive_session_id)
+        self.assertNotIn("lease-stale", mgr._interactive)
+        bridge.detach_console.assert_called_once_with("cid-stale")
+        bridge.set_interactive_owner.assert_called_with(None)
+
     def test_auto_bind_on_device_attach(self) -> None:
         """裝置 by-id 不符合 profile 佔位符時，_attach_by_id 應自動綁定並更新 device_by_id。"""
         from sw_core.device_watcher import DeviceInfo

--- a/tests/test_session_bind.py
+++ b/tests/test_session_bind.py
@@ -1,5 +1,6 @@
 import tempfile
 import unittest
+import dataclasses
 from pathlib import Path
 
 from sw_core.config import SessionProfile, UartProfile
@@ -589,6 +590,70 @@ class TestSessionBind(unittest.TestCase):
 
         self.assertTrue(resp["ok"])
         self.assertEqual(resp["classification"], "LOGIN_REQUIRED")
+        self.assertEqual(resp["recommended_action"], "console_attach")
+        bridge.send_command.assert_not_called()
+
+    def test_passthrough_attach_skips_prompt_probe_and_stays_attached(self) -> None:
+        from sw_core.device_watcher import DeviceInfo
+        import unittest.mock as mock
+        import time
+
+        profiles = [self._make_profile("p", "COM0", "lab+1", "/dev/serial/by-id/orig")]
+        profiles[0] = dataclasses.replace(profiles[0], platform="passthrough", ready_probe="")
+        mgr = SessionManager(profiles, WalWriter(wal_dir=self._tmp.name), on_ready=lambda _sid: None, on_detached=lambda _sid: None)
+
+        with (
+            mock.patch("sw_core.session_manager.UARTBridge") as MockBridge,
+            mock.patch("sw_core.session_manager.probe_ready") as probe_ready,
+            mock.patch("sw_core.session_manager.ensure_ready") as ensure_ready,
+        ):
+            MockBridge.return_value.vtty_path = "/dev/pts/9"
+            MockBridge.return_value.start.return_value = None
+            mgr.update_devices(
+                {
+                    "/dev/serial/by-id/orig": DeviceInfo(
+                        by_id="/dev/serial/by-id/orig",
+                        real_path="/dev/ttyUSB0",
+                    )
+                }
+            )
+            for _ in range(40):
+                session = mgr.get_session("COM0")
+                if session is not None and session.state == "ATTACHED":
+                    break
+                time.sleep(0.05)
+
+        session = mgr.get_session("COM0")
+        assert session is not None
+        self.assertEqual(session.state, "ATTACHED")
+        self.assertIsNone(session.last_error)
+        probe_ready.assert_not_called()
+        ensure_ready.assert_not_called()
+
+    def test_self_test_reports_passthrough_for_attached_session(self) -> None:
+        from sw_core.device_watcher import DeviceInfo
+        import unittest.mock as mock
+
+        profiles = [self._make_profile("p", "COM0", "lab+1", "/dev/serial/by-id/orig")]
+        mgr = SessionManager(profiles, WalWriter(wal_dir=self._tmp.name), on_ready=lambda _sid: None, on_detached=lambda _sid: None)
+        session = mgr.get_session("COM0")
+        assert session is not None
+        session.profile = dataclasses.replace(session.profile, platform="passthrough", ready_probe="")
+
+        bridge = mock.MagicMock()
+        bridge.snapshot.return_value = {"running": True, "serial_alive": True, "vtty_alive": True, "vtty": "/dev/pts/9"}
+        session.bridge = bridge
+        session.state = "ATTACHED"
+        session.attached_real_path = "/dev/ttyUSB0"
+        with mgr._lock:
+            mgr._devices = {
+                "/dev/serial/by-id/orig": DeviceInfo(by_id="/dev/serial/by-id/orig", real_path="/dev/ttyUSB0")
+            }
+
+        resp = mgr.self_test("COM0")
+
+        self.assertTrue(resp["ok"])
+        self.assertEqual(resp["classification"], "PASSTHROUGH")
         self.assertEqual(resp["recommended_action"], "console_attach")
         bridge.send_command.assert_not_called()
 

--- a/tests/test_session_bind.py
+++ b/tests/test_session_bind.py
@@ -352,6 +352,77 @@ class TestSessionBind(unittest.TestCase):
         bridge.detach_console.assert_called_once_with("cid-stale")
         bridge.set_interactive_owner.assert_called_with(None)
 
+    def test_agent_command_waits_for_human_interactive_release(self) -> None:
+        import unittest.mock as mock
+
+        profiles = [self._make_profile("p", "COM0", "lab+1", "/dev/serial/by-id/orig")]
+        mgr = SessionManager(profiles, WalWriter(wal_dir=self._tmp.name), on_ready=lambda _sid: None, on_detached=lambda _sid: None)
+        session = mgr.get_session("COM0")
+        self.assertIsNotNone(session)
+        assert session is not None
+
+        bridge = mock.MagicMock()
+        bridge.console_has_external_peer.side_effect = [True, False]
+        bridge.snapshot.return_value = {"interactive_owner": "human:cid-wait"}
+        bridge.detach_console.return_value = True
+        bridge.vtty_path = "/dev/pts/9"
+        bridge.rx_snapshot_len.return_value = 10
+        bridge.wait_for_regex_from.return_value = True
+        bridge.rx_text_from.return_value = "RESULT:ifconfig:OK\nroot@prplOS:/# "
+        session.bridge = bridge
+        session.state = "READY"
+
+        lease = InteractiveLease(
+            interactive_id="lease-wait",
+            session_id=session.session_id,
+            owner="human:cid-wait",
+            created_at="now",
+            timeout_s=60.0,
+        )
+        with mgr._lock:
+            mgr._interactive[lease.interactive_id] = lease
+            session.interactive_session_id = lease.interactive_id
+
+        resp = mgr.execute_command("p:COM0", "ifconfig", "agent:test", "cmd-wait", timeout_s=0.2)
+
+        self.assertTrue(resp["ok"])
+        self.assertEqual(resp["stdout"], "RESULT:ifconfig:OK")
+        bridge.send_command.assert_called_once_with("ifconfig", source="agent:test", cmd_id="cmd-wait")
+        self.assertIsNone(session.interactive_session_id)
+
+    def test_agent_command_times_out_when_human_interactive_persists(self) -> None:
+        import unittest.mock as mock
+
+        profiles = [self._make_profile("p", "COM0", "lab+1", "/dev/serial/by-id/orig")]
+        mgr = SessionManager(profiles, WalWriter(wal_dir=self._tmp.name), on_ready=lambda _sid: None, on_detached=lambda _sid: None)
+        session = mgr.get_session("COM0")
+        self.assertIsNotNone(session)
+        assert session is not None
+
+        bridge = mock.MagicMock()
+        bridge.console_has_external_peer.return_value = True
+        bridge.snapshot.return_value = {"interactive_owner": "human:cid-busy"}
+        session.bridge = bridge
+        session.state = "READY"
+
+        lease = InteractiveLease(
+            interactive_id="lease-busy",
+            session_id=session.session_id,
+            owner="human:cid-busy",
+            created_at="now",
+            timeout_s=60.0,
+        )
+        with mgr._lock:
+            mgr._interactive[lease.interactive_id] = lease
+            session.interactive_session_id = lease.interactive_id
+
+        resp = mgr.execute_command("p:COM0", "ifconfig", "agent:test", "cmd-busy", timeout_s=0.1)
+
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error_code"], "SESSION_INTERACTIVE_BUSY")
+        self.assertEqual(resp["interactive_session_id"], "lease-busy")
+        bridge.send_command.assert_not_called()
+
     def test_auto_bind_on_device_attach(self) -> None:
         """裝置 by-id 不符合 profile 佔位符時，_attach_by_id 應自動綁定並更新 device_by_id。"""
         from sw_core.device_watcher import DeviceInfo


### PR DESCRIPTION
## 變更內容
- 修正 stale human interactive lease 未釋放，minicom 關閉後不再殘留 `SESSION_INTERACTIVE_BUSY`
- agent 命令遇到 human interactive ownership 時改為等待釋放；超過命令 timeout 才回 `SESSION_INTERACTIVE_BUSY`
- 新增 `op3-template` 與 `others-template`，將 Orange Pi shell profile 正規化為 `COM2`
- `platform=passthrough` 的未知設備 attach 後不做 prompt/login/ready 限制，直接走 ttyUSB/ttyPTS bridge
- `install.sh` 的單一未知 UART auto-bind 預設改落到 `others-template`
- 調整 line-buffered human local echo 的 Enter 回顯，避免 minicom 畫面多一個空白行

## 驗證
- `python3 -m unittest -v tests.test_config_profiles tests.test_session_bind tests.test_login_fsm tests.test_agent_defer_tx tests.test_service_human_console`
- 真機驗證：`COM2/default+3` 已切到 `op3-template` 並回 `classification=OK`
- 真機驗證：minicom 關閉後 stale human interactive lease 會自動清除
- 真機驗證：line-buffered local echo 不再造成多餘空白行
