### PR TITLE
fix(serialwrap): 修復 open issues 11-16 的 session 穩定性

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,8 @@ serialwrap cmd result-tail --cmd-id <cmd_id> --from-chunk 0 --limit 200
 
 `background` capture 會在 quiet window 到期，或新的前景/互動命令開始時封口。
 
+若命令在 prompt timeout 路徑失敗，`cmd result-tail` 仍會保留 terminal `status` / `error_code`，並盡量回傳已緩衝的 partial chunk，不再直接掉成 `CMD_NOT_FOUND`。
+
 ### 3. `interactive`
 
 適用 `menuconfig`、`top`、`vi` 等需要持續送按鍵的場景。
@@ -470,6 +472,7 @@ minicom -D /dev/ttyUSB0
 - **`console-attach` 在 `ATTACHED` 或 `READY` 狀態下，會自動授予第一個 human console raw interactive ownership**，不需手動 `interactive-open`。所有按鍵（包含方向鍵、Tab、ESC 序列）即時透傳到 UART，操作體感與直接 minicom 一致。
 - 若 agent 在 human interactive 期間提交命令，daemon 會暫時掛起（suspend）human raw mode → 執行 agent 命令 → 完成後自動恢復（resume）。Human 在 agent 執行期間的按鍵會累積在 deferred buffer，agent 完成後 flush 到 UART。
 - 第二個以後的 minicom console 因為 interactive lease 已存在，仍走 line-buffer 模式（broker 提供本地回顯與 backspace 行編輯）。
+- bridge rebuild / reattach 時，broker 會盡量保留既有 console PTY 與 human ownership，避免既有 minicom 掛到 stale `/dev/pts/*`。
 - 若要保留舊版「完整 terminal transcript」行為，可顯式設定 `MINICOM_CAPTURE_WRAPPER=1`，此時 wrapper 會改用 `script -qef` 包一層 PTY；但這可能增加 human 體感延遲。
 - 常見 human/minicom 互動式命令（例如 `vi`、`vim`、`top`、`htop`、`less`、`menuconfig`）會自動升級成 human interactive ownership，不再因為等不到 shell prompt 而自動觸發 recover / reboot。
 - 若直接打 `minicom` 沒有走 broker，先用 `type -a minicom` 檢查目前 shell 是否先命中 `~/.paul_tools/minicom`；若仍是 `/usr/bin/minicom`，代表 shell PATH 尚未把 wrapper 放到前面。
@@ -513,12 +516,13 @@ serialwrap session self-test --selector COM0
 serialwrap session recover --selector COM0
 ```
 
-recover 升級順序固定：
+recover 行為分成三種：
 
-1. `Ctrl-C`
-2. `Ctrl-D`
+1. `ATTACHED` 且 bridge 仍存活：先直接 re-probe 現有 bridge，成功就回 `READY`
+2. `READY`：走 `Ctrl-C` → `Ctrl-D`
+3. bridge 已不存在但裝置還在：直接 reattach
 
-若 `Ctrl-C` / `Ctrl-D` 都救不回 prompt，session 會降級成 `ATTACHED`，保留 bridge 與 console，交由 human/minicom 接手。
+若 `READY` 路徑中的 `Ctrl-C` / `Ctrl-D` 都救不回 prompt，session 會降級成 `ATTACHED`，保留 bridge 與 console，交由 human/minicom 接手。
 
 只有 **agent 明確送出 reboot 類指令** 時，daemon 才會進入 `RECOVERING`，並在 target 回來後自動重新 login / 回到 `READY`。
 

--- a/docs/serialwrap-spec.md
+++ b/docs/serialwrap-spec.md
@@ -341,7 +341,13 @@ flowchart TD
 
 ### 9.2 `session.recover`
 
-若 session 仍有可用 bridge：
+若 session 狀態為 `ATTACHED` 且 bridge 仍在：
+
+- 直接對現有 bridge 做 re-probe
+- 成功則回到 `READY`
+- 失敗則保留 `ATTACHED`，並把失敗原因留在 `last_error`
+
+若 session 狀態為 `READY` 且 bridge 仍有可用：
 
 1. 送 `Ctrl-C`
 2. 等 prompt
@@ -572,12 +578,13 @@ targets:
 
 - line mode 命令完成後 `stdout` 正確回填
 - background mode 可用 `result-tail` 取得後續 chunk
+- prompt timeout 後 `result-tail` 仍可查 terminal status / error_code 與已緩衝 chunk
 - interactive lease 可建立、送 key、關閉
 - 多 console attach 可同時收到 RX
 - human input 在 line-buffer 模式下經 broker 排隊；raw interactive 模式直接透傳 UART
 - 裝置 real_path 變更時會 reattach
 - `self_test` 可區分主要故障類型
-- `recover` 僅會走 `Ctrl-C -> Ctrl-D`
+- `recover` 會先對 `ATTACHED` bridge 做 re-probe；`READY` 才走 `Ctrl-C -> Ctrl-D`
 - agent 明確 reboot 後可重新回 `READY`
 - README / spec / CLI / MCP 命名一致
 

--- a/sw_core/session_manager.py
+++ b/sw_core/session_manager.py
@@ -17,7 +17,7 @@ from .config import SessionProfile
 from .constants import LOG_DIR, STATE_PATH
 from .device_watcher import DeviceInfo
 from .login_fsm import ensure_ready, probe_ready
-from .uart_io import UARTBridge
+from .uart_io import PreservedConsoles, UARTBridge
 from .util import clean_text, now_iso
 from .wal import WalWriter
 
@@ -53,6 +53,7 @@ class BackgroundCapture:
     chunks: list[str] = dataclasses.field(default_factory=list)
     last_seq: int = 0
     status: str = "active"
+    error_code: str | None = None
     last_activity_mono: float = dataclasses.field(default_factory=time.monotonic)
 
     def maybe_finalize(self) -> None:
@@ -107,11 +108,19 @@ class SessionRuntime:
     foreground_busy: bool = False
     background_cmd_ids: list[str] = dataclasses.field(default_factory=list)
     active_capture: SessionCapture | None = None
+    retained_consoles: PreservedConsoles | None = None
+    retained_human_owner: str | None = None
+    retained_human_timeout_s: float | None = None
 
     def to_public_dict(self) -> dict[str, Any]:
         console_count = 0
         if self.bridge is not None:
             console_count = len(self.bridge.list_consoles())
+        elif self.retained_consoles is not None:
+            console_count = len(self.retained_consoles.clients)
+        vtty_path = self.vtty_path
+        if vtty_path is None and self.retained_consoles is not None:
+            vtty_path = self.retained_consoles.primary_vtty()
         return {
             "session_id": self.session_id,
             "profile": self.profile.profile_name,
@@ -124,7 +133,7 @@ class SessionRuntime:
             "last_error": self.last_error,
             "detached_at": self.detached_at,
             "last_ready_at": self.last_ready_at,
-            "vtty": self.vtty_path,
+            "vtty": vtty_path,
             "attached_real_path": self.attached_real_path,
             "bridge_generation": self.bridge_generation,
             "recovering": self.recovering,
@@ -245,11 +254,66 @@ class SessionManager:
             return {"ok": False, "error_code": "ALIAS_NOT_FOUND", "alias": alias}
         return {"ok": True, "alias": alias}
 
+    def _store_retained_consoles_locked(
+        self,
+        session: SessionRuntime,
+        preserved: PreservedConsoles | None,
+        *,
+        human_owner: str | None = None,
+        human_timeout_s: float | None = None,
+    ) -> None:
+        if not isinstance(preserved, PreservedConsoles) or not preserved.clients:
+            session.retained_consoles = None
+            session.retained_human_owner = None
+            session.retained_human_timeout_s = None
+            session.vtty_path = None
+            return
+        session.retained_consoles = preserved
+        session.vtty_path = preserved.primary_vtty()
+        session.retained_human_owner = None
+        session.retained_human_timeout_s = None
+        if human_owner is None or not human_owner.startswith("human:"):
+            return
+        client_id = human_owner.split(":", 1)[1]
+        if client_id and preserved.has_client(client_id):
+            session.retained_human_owner = human_owner
+            session.retained_human_timeout_s = human_timeout_s
+
+    def _restore_retained_human_console_locked(self, session: SessionRuntime) -> None:
+        owner = session.retained_human_owner
+        timeout_s = session.retained_human_timeout_s
+        session.retained_human_owner = None
+        session.retained_human_timeout_s = None
+        if owner is None or session.bridge is None or not owner.startswith("human:"):
+            return
+        client_id = owner.split(":", 1)[1]
+        if not client_id or not session.bridge.has_console(client_id):
+            return
+        if self._refresh_interactive_locked(session) is None:
+            self._open_interactive_locked(
+                session,
+                owner=owner,
+                timeout_s=timeout_s or max(session.profile.hard_timeout_s, _ATTACHED_CONSOLE_LEASE_TIMEOUT_S),
+            )
+
     def _detach_session_locked(self, session: SessionRuntime, *, reason: str) -> None:
+        preserved = session.retained_consoles
+        retained_human_owner = session.retained_human_owner
+        retained_human_timeout_s = session.retained_human_timeout_s
+        if session.interactive_session_id is not None:
+            lease = self._interactive.get(session.interactive_session_id)
+            if lease is not None and lease.owner.startswith("human:"):
+                retained_human_owner = lease.owner
+                retained_human_timeout_s = lease.timeout_s
         if session.bridge is not None:
-            session.bridge.stop()
+            preserved = session.bridge.stop(preserve_consoles=True)
             session.bridge = None
-        session.vtty_path = None
+        self._store_retained_consoles_locked(
+            session,
+            preserved,
+            human_owner=retained_human_owner,
+            human_timeout_s=retained_human_timeout_s,
+        )
         session.attached_real_path = None
         session.state = "DETACHED"
         session.detached_at = now_iso()
@@ -347,34 +411,7 @@ class SessionManager:
                 session.state = "ATTACHING"
                 session.last_error = None
         if should_probe and bridge is not None:
-            if session.profile.login_regex:
-                auth = resolve_session_auth(session.profile)
-                if auth.username and auth.password:
-                    ok, err = ensure_ready(bridge, session.profile, auth=auth)
-                else:
-                    ok, err = probe_ready(bridge, session.profile)
-            else:
-                ok, err = probe_ready(bridge, session.profile)
-            notify_ready = False
-            with self._lock:
-                current = self._sessions.get(session.session_id)
-                if current is None or current.bridge is not bridge:
-                    return {"ok": False, "error_code": "SESSION_NOT_READY"}
-                if ok:
-                    current.state = "READY"
-                    current.last_error = None
-                    current.last_ready_at = now_iso()
-                    current.recovering = False
-                    current.recovery_started_at = None
-                    current.pending_auto_login = False
-                    notify_ready = True
-                else:
-                    current.state = "ATTACHED"
-                    current.last_error = err
-                result = current.to_public_dict()
-            if notify_ready:
-                self._on_ready(session.session_id)
-            return {"ok": True, "session": result}
+            return self._probe_existing_bridge(session, bridge)
         self._spawn_attach(by_id)
         return {"ok": True, "session": session.to_public_dict()}
 
@@ -382,10 +419,25 @@ class SessionManager:
         with self._lock:
             return [{"by_id": by_id, "real_path": dev.real_path} for by_id, dev in sorted(self._devices.items())]
 
+    def _mark_missing_devices_locked(self) -> None:
+        missing_at = now_iso()
+        for session in self._sessions.values():
+            by_id = session.profile.device_by_id
+            if not by_id or session.bridge is not None:
+                continue
+            if by_id in self._devices:
+                continue
+            session.state = "DETACHED"
+            if session.last_error is None:
+                session.last_error = "DEVICE_NOT_FOUND"
+            if session.detached_at is None:
+                session.detached_at = missing_at
+
     def update_devices(self, devices: dict[str, DeviceInfo]) -> None:
         with self._lock:
             prev = self._devices
             self._devices = dict(devices)
+            self._mark_missing_devices_locked()
 
         changed = sorted(
             by_id for by_id in set(prev.keys()) & set(devices.keys())
@@ -472,6 +524,43 @@ class SessionManager:
         if by_id and by_id in self._devices:
             self._spawn_attach(by_id)
 
+    def _probe_existing_bridge(self, session: SessionRuntime, bridge: UARTBridge) -> dict[str, Any]:
+        if session.profile.platform == "passthrough":
+            current = self._sessions.get(session.session_id)
+            if current is None or current.bridge is not bridge:
+                return {"ok": False, "error_code": "SESSION_NOT_READY"}
+            return {"ok": True, "session": current.to_public_dict()}
+
+        if session.profile.login_regex:
+            auth = resolve_session_auth(session.profile)
+            if auth.username and auth.password:
+                ok, err = ensure_ready(bridge, session.profile, auth=auth)
+            else:
+                ok, err = probe_ready(bridge, session.profile)
+        else:
+            ok, err = probe_ready(bridge, session.profile)
+
+        notify_ready = False
+        with self._lock:
+            current = self._sessions.get(session.session_id)
+            if current is None or current.bridge is not bridge:
+                return {"ok": False, "error_code": "SESSION_NOT_READY"}
+            current.recovering = False
+            current.recovery_started_at = None
+            current.pending_auto_login = False
+            if ok:
+                current.state = "READY"
+                current.last_error = None
+                current.last_ready_at = now_iso()
+                notify_ready = True
+            else:
+                current.state = "ATTACHED"
+                current.last_error = err
+            result = current.to_public_dict()
+        if notify_ready:
+            self._on_ready(session.session_id)
+        return {"ok": True, "session": result}
+
     def _attach_by_id(self, by_id: str) -> None:
         save_needed = False
         with self._lock:
@@ -492,7 +581,12 @@ class SessionManager:
             if session is None:
                 return
             dev = self._devices.get(by_id)
-            if dev is None or session.bridge is not None or session.profile.device_by_id != by_id:
+            if dev is None:
+                session.state = "DETACHED"
+                session.last_error = "DEVICE_NOT_FOUND"
+                session.detached_at = now_iso()
+                return
+            if session.bridge is not None or session.profile.device_by_id != by_id:
                 return
             session.state = "ATTACHING"
             session.last_error = None
@@ -502,6 +596,7 @@ class SessionManager:
             require_login = session.pending_auto_login or bool(profile.login_regex)
             passthrough_only = profile.platform == "passthrough"
             real_path = dev.real_path
+            preserved_consoles = session.retained_consoles if isinstance(session.retained_consoles, PreservedConsoles) else None
 
         bridge = UARTBridge(
             profile.com,
@@ -511,6 +606,7 @@ class SessionManager:
             on_console_line=lambda client_id, line, sid=session_id: self._on_bridge_console_line(sid, client_id, line),
             on_rx_data=lambda data, sid=session_id: self._on_bridge_rx(sid, data),
             on_bridge_down=lambda reason, sid=session_id: self._handle_bridge_down(sid, bridge, reason),
+            preserved_consoles=preserved_consoles,
         )
 
         try:
@@ -523,13 +619,18 @@ class SessionManager:
                 if auth.username and auth.password:
                     ok, err = ensure_ready(bridge, profile, auth=auth)
                     if not ok:
-                        bridge.stop()
+                        preserved = bridge.stop(preserve_consoles=True)
                         with self._lock:
+                            self._store_retained_consoles_locked(
+                                session,
+                                preserved,
+                                human_owner=session.retained_human_owner,
+                                human_timeout_s=session.retained_human_timeout_s,
+                            )
                             session.state = "DETACHED"
                             session.last_error = err
                             session.detached_at = now_iso()
                             session.bridge = None
-                            session.vtty_path = None
                             session.attached_real_path = None
                         self._on_detached(session.session_id)
                         return
@@ -543,18 +644,24 @@ class SessionManager:
             with self._lock:
                 current = self._devices.get(by_id)
                 if current is None or current.real_path != real_path or session.state == "DETACHED" or session.bridge_generation != gen_before:
-                    bridge.stop()
+                    preserved = bridge.stop(preserve_consoles=True)
+                    self._store_retained_consoles_locked(
+                        session,
+                        preserved,
+                        human_owner=session.retained_human_owner,
+                        human_timeout_s=session.retained_human_timeout_s,
+                    )
                     session.state = "DETACHED"
                     session.last_error = "DEVICE_REMOVED_DURING_ATTACH"
                     session.detached_at = now_iso()
                     session.bridge = None
-                    session.vtty_path = None
                     session.attached_real_path = None
                     return
                 session.bridge = bridge
                 session.vtty_path = bridge.vtty_path
                 session.attached_real_path = real_path
                 session.bridge_generation += 1
+                session.retained_consoles = None
                 if ok:
                     session.state = "READY"
                     session.last_error = None
@@ -568,19 +675,25 @@ class SessionManager:
                     session.last_error = err
                     session.recovering = False
                     session.recovery_started_at = None
+                self._restore_retained_human_console_locked(session)
             if notify_ready:
                 self._on_ready(session.session_id)
         except Exception as exc:
             try:
-                bridge.stop()
+                preserved = bridge.stop(preserve_consoles=True)
             except Exception:
-                pass
+                preserved = None
             with self._lock:
+                self._store_retained_consoles_locked(
+                    session,
+                    preserved,
+                    human_owner=session.retained_human_owner,
+                    human_timeout_s=session.retained_human_timeout_s,
+                )
                 session.state = "DETACHED"
                 session.last_error = f"ATTACH_FAILED:{type(exc).__name__}"
                 session.detached_at = now_iso()
                 session.bridge = None
-                session.vtty_path = None
                 session.attached_real_path = None
             self._on_detached(session.session_id)
 
@@ -750,6 +863,34 @@ class SessionManager:
 
         threading.Thread(target=_run, name=f"serialwrap-reboot-{session_id}", daemon=True).start()
 
+    def _set_terminal_capture_locked(
+        self,
+        session: SessionRuntime,
+        *,
+        cmd_id: str,
+        chunks: list[str] | None = None,
+        error_code: str | None = None,
+    ) -> None:
+        if not cmd_id:
+            return
+        capture = self._background.get(cmd_id)
+        if capture is None:
+            capture = BackgroundCapture(
+                cmd_id=cmd_id,
+                session_id=session.session_id,
+                from_seq=self._wal.current_seq + 1,
+                quiet_window_s=session.profile.quiet_window_s,
+                created_at=now_iso(),
+                last_seq=self._wal.current_seq,
+            )
+            self._background[cmd_id] = capture
+        if chunks:
+            capture.chunks.extend(chunk for chunk in chunks if chunk)
+        capture.last_seq = self._wal.current_seq
+        capture.last_activity_mono = time.monotonic()
+        capture.status = "error" if error_code else "done"
+        capture.error_code = error_code
+
     def _handle_reboot_command(
         self,
         session: SessionRuntime,
@@ -910,7 +1051,16 @@ class SessionManager:
         try:
             bridge.send_command(command, source=source, cmd_id=cmd_id)
             if not bridge.wait_for_regex_from(prompt_regex, pre_offset, timeout_s):
-                return self._recover_after_failure(session, bridge, cmd_id=cmd_id, timeout_s=timeout_s, source=source)
+                return self._recover_after_failure(
+                    session,
+                    bridge,
+                    cmd_id=cmd_id,
+                    timeout_s=timeout_s,
+                    source=source,
+                    command=command,
+                    prompt_regex=prompt_regex,
+                    pre_offset=pre_offset,
+                )
             raw_text = bridge.rx_text_from(pre_offset)
             stdout = self._extract_command_stdout(raw_text, command, prompt_regex)
             result: dict[str, Any] = {
@@ -945,6 +1095,9 @@ class SessionManager:
         cmd_id: str,
         timeout_s: float,
         source: str,
+        command: str,
+        prompt_regex: str,
+        pre_offset: int,
     ) -> dict[str, Any]:
         if source.startswith("human:"):
             with self._lock:
@@ -965,12 +1118,18 @@ class SessionManager:
                 "recovery_action": "PROMOTE_HUMAN_INTERACTIVE",
             }
 
-        prompt_regex = session.profile.prompt_regex
         for action_name, payload in (("CTRL_C", b"\x03"), ("CTRL_D", b"\x04")):
             offset = bridge.rx_snapshot_len()
             bridge.send_bytes(payload, source="system:recover", cmd_id=None)
             if bridge.wait_for_regex_from(prompt_regex, offset, min(timeout_s, 2.0)):
-                stdout = self._extract_command_stdout(bridge.rx_text_from(offset), "", prompt_regex)
+                stdout = self._extract_command_stdout(bridge.rx_text_from(pre_offset), command, prompt_regex)
+                with self._lock:
+                    self._set_terminal_capture_locked(
+                        session,
+                        cmd_id=cmd_id,
+                        chunks=[stdout] if stdout else None,
+                        error_code="PROMPT_TIMEOUT_RECOVERED",
+                    )
                 return {
                     "ok": False,
                     "error_code": "PROMPT_TIMEOUT_RECOVERED",
@@ -979,6 +1138,14 @@ class SessionManager:
                     "recovery_action": action_name,
                 }
 
+        partial_stdout = clean_text(bridge.rx_text_from(pre_offset))
+        with self._lock:
+            self._set_terminal_capture_locked(
+                session,
+                cmd_id=cmd_id,
+                chunks=[partial_stdout] if partial_stdout else None,
+                error_code="PROMPT_TIMEOUT",
+            )
         self._transition_to_attached(session, reason="PROMPT_TIMEOUT")
         return {
             "ok": False,
@@ -1239,6 +1406,7 @@ class SessionManager:
             }
 
     def recover_session(self, selector: str, *, timeout_s: float = 2.0) -> dict[str, Any]:
+        reprobe = False
         with self._lock:
             session = self.get_session(selector)
             if session is None:
@@ -1251,10 +1419,38 @@ class SessionManager:
                     self._spawn_attach(by_id)
                     return {"ok": True, "recovering": False, "action": "REATTACH", "session": session.to_public_dict()}
                 return {"ok": False, "error_code": "SESSION_NOT_READY", "session": session.to_public_dict()}
-            if session.state != "READY":
+            if session.state == "ATTACHED":
+                bridge = session.bridge
+                reprobe = True
+            elif session.state != "READY":
                 return {"ok": False, "error_code": "SESSION_NOT_READY", "session": session.to_public_dict()}
-            bridge = session.bridge
-        return self._recover_after_failure(session, bridge, cmd_id="", timeout_s=timeout_s, source="system:recover")
+            else:
+                bridge = session.bridge
+        if reprobe:
+            result = self._probe_existing_bridge(session, bridge)
+            if not result.get("ok"):
+                return result
+            recovered = result["session"]["state"] == "READY"
+            payload: dict[str, Any] = {
+                "ok": True,
+                "recovering": False,
+                "action": "REPROBE",
+                "recovered": recovered,
+                "session": result["session"],
+            }
+            if not recovered:
+                payload["error_code"] = result["session"].get("last_error") or "SESSION_NOT_READY"
+            return payload
+        return self._recover_after_failure(
+            session,
+            bridge,
+            cmd_id="",
+            timeout_s=timeout_s,
+            source="system:recover",
+            command="",
+            prompt_regex=session.profile.prompt_regex,
+            pre_offset=bridge.rx_snapshot_len(),
+        )
 
     def get_background_result(self, cmd_id: str, *, from_chunk: int = 0, limit: int = 200) -> dict[str, Any]:
         with self._lock:
@@ -1268,6 +1464,7 @@ class SessionManager:
                 "ok": True,
                 "cmd_id": cmd_id,
                 "status": capture.status,
+                "error_code": capture.error_code,
                 "from_seq": capture.from_seq,
                 "last_seq": capture.last_seq,
                 "from_chunk": from_chunk,

--- a/sw_core/uart_io.py
+++ b/sw_core/uart_io.py
@@ -40,6 +40,29 @@ class ConsoleClient:
     tx_buffer: bytearray = dataclasses.field(default_factory=bytearray)
 
 
+@dataclasses.dataclass
+class PreservedConsoles:
+    clients: dict[str, ConsoleClient]
+    primary_client_id: str | None
+
+    def primary_vtty(self) -> str | None:
+        if self.primary_client_id is None:
+            return None
+        client = self.clients.get(self.primary_client_id)
+        return client.slave_path if client is not None else None
+
+    def has_client(self, client_id: str) -> bool:
+        return client_id in self.clients
+
+
+def _close_console_client_fds(client: ConsoleClient) -> None:
+    for fd in (client.master_fd, client.slave_fd):
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
 class UARTBridge:
     def __init__(
         self,
@@ -51,6 +74,7 @@ class UARTBridge:
         on_console_line: Callable[[str, str], None] | None = None,
         on_rx_data: Callable[[bytes], None] | None = None,
         on_bridge_down: Callable[[str], None] | None = None,
+        preserved_consoles: PreservedConsoles | None = None,
     ) -> None:
         self.com = com
         self.device_path = device_path
@@ -69,6 +93,7 @@ class UARTBridge:
         self._rx_lock = threading.Lock()
         self._rx_text = ""
         self._rx_max_chars = 131072
+        self._preserved_consoles = preserved_consoles
         self._clients: dict[str, ConsoleClient] = {}
         self._interactive_owner: str | None = None
         self._agent_active: bool = False
@@ -150,28 +175,47 @@ class UARTBridge:
         self._configure_serial(serial_fd)
         self._set_nonblock(serial_fd)
 
-        primary = self._create_console_client("primary")
         with self._state_lock:
+            preserved = self._preserved_consoles
+            self._preserved_consoles = None
+            if preserved is not None and preserved.clients:
+                clients = dict(preserved.clients)
+                primary_client_id = preserved.primary_client_id if preserved.primary_client_id in clients else None
+                if primary_client_id is None:
+                    next_client = next(iter(clients.values()), None)
+                    primary_client_id = next_client.client_id if next_client is not None else None
+            else:
+                primary = self._create_console_client("primary")
+                clients = {primary.client_id: primary}
+                primary_client_id = primary.client_id
             self._serial_fd = serial_fd
-            self._clients = {primary.client_id: primary}
-            self._primary_client_id = primary.client_id
+            self._clients = clients
+            self._primary_client_id = primary_client_id
 
         self._stop_event.clear()
         self._thread = threading.Thread(target=self._loop, name=f"serialwrap-uart-{self.com}", daemon=True)
         self._thread.start()
 
-    def stop(self) -> None:
+    def stop(self, *, preserve_consoles: bool = False) -> PreservedConsoles | None:
         self._stop_event.set()
         if self._thread and self._thread.is_alive() and threading.current_thread() is not self._thread:
             self._thread.join(timeout=2.0)
 
+        preserved: PreservedConsoles | None = None
         with self._state_lock:
             serial_fd = self._serial_fd
-            clients = list(self._clients.values())
+            if preserve_consoles and self._clients:
+                preserved = PreservedConsoles(clients=dict(self._clients), primary_client_id=self._primary_client_id)
+                clients_to_close: list[ConsoleClient] = []
+            else:
+                clients_to_close = list(self._clients.values())
             self._serial_fd = None
             self._clients = {}
             self._primary_client_id = None
             self._interactive_owner = None
+            self._suspended_owner = None
+            self._agent_active = False
+            self._deferred_buffers.clear()
 
         if serial_fd is not None:
             try:
@@ -179,15 +223,12 @@ class UARTBridge:
             except OSError:
                 pass
 
-        for client in clients:
+        for client in clients_to_close:
             self._close_console_client(client)
+        return preserved
 
     def _close_console_client(self, client: ConsoleClient) -> None:
-        for fd in (client.master_fd, client.slave_fd):
-            try:
-                os.close(fd)
-            except OSError:
-                pass
+        _close_console_client_fds(client)
 
     def _client_has_external_peer_locked(self, client: ConsoleClient) -> bool:
         self_pid = os.getpid()
@@ -545,6 +586,10 @@ class UARTBridge:
             if client is None:
                 return False
             return self._client_has_external_peer_locked(client)
+
+    def has_console(self, client_id: str) -> bool:
+        with self._state_lock:
+            return client_id in self._clients
 
     def set_interactive_owner(self, owner: str | None) -> None:
         with self._state_lock:

--- a/tests/test_agent_defer_tx.py
+++ b/tests/test_agent_defer_tx.py
@@ -260,6 +260,58 @@ class TestUARTBridgeConsoles(unittest.TestCase):
                 time.sleep(0.05)
             self.assertFalse(bridge.console_has_external_peer(client_id))
 
+    def test_bridge_restart_reuses_existing_console_vttys(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            target = self._make_target()
+            target.start()
+            self.addCleanup(target.stop)
+
+            bridge = UARTBridge("COM0", target.slave_path, UartProfile(), WalWriter(wal_dir=td))
+            bridge.start()
+
+            primary = bridge.vtty_path
+            attached = bridge.attach_console(label="observer")
+            assert primary is not None
+
+            fd_primary = os.open(primary, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
+            fd_second = os.open(attached["vtty"], os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
+            try:
+                preserved = bridge.stop(preserve_consoles=True)
+                restarted = UARTBridge(
+                    "COM0",
+                    target.slave_path,
+                    UartProfile(),
+                    WalWriter(wal_dir=td),
+                    preserved_consoles=preserved,
+                )
+                restarted.start()
+                self.addCleanup(restarted.stop)
+
+                self.assertEqual(restarted.vtty_path, primary)
+                consoles = {row["client_id"]: row["vtty"] for row in restarted.list_consoles()}
+                self.assertEqual(consoles[attached["client_id"]], attached["vtty"])
+
+                target.emit(b"after-restart\r\n# ")
+                deadline = time.monotonic() + 2.0
+                primary_data = b""
+                second_data = b""
+                while time.monotonic() < deadline and (not primary_data or not second_data):
+                    try:
+                        primary_data += os.read(fd_primary, 4096)
+                    except BlockingIOError:
+                        pass
+                    try:
+                        second_data += os.read(fd_second, 4096)
+                    except BlockingIOError:
+                        pass
+                    time.sleep(0.05)
+            finally:
+                os.close(fd_primary)
+                os.close(fd_second)
+
+            self.assertIn(b"after-restart", primary_data)
+            self.assertIn(b"after-restart", second_data)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_bad_command_recovery.py
+++ b/tests/test_bad_command_recovery.py
@@ -58,7 +58,7 @@ class TestBadCommandRecovery(unittest.TestCase):
         # Ctrl-C 後第二次 = True（prompt 回來）
         bridge.rx_snapshot_len.side_effect = [10, 20]
         bridge.wait_for_regex_from.side_effect = [False, True]
-        bridge.rx_text_from.return_value = "$ "
+        bridge.rx_text_from.return_value = "partial line\n$ "
 
         resp = mgr.execute_command("p:COM0", "cat", "agent:test", "cid-bad1", timeout_s=0.1)
 
@@ -69,6 +69,11 @@ class TestBadCommandRecovery(unittest.TestCase):
         bridge.send_bytes.assert_any_call(b"\x03", source="system:recover", cmd_id=None)
         # session 仍為 READY（recover 成功）
         self.assertEqual(session.state, "READY")
+        tail = mgr.get_background_result("cid-bad1")
+        self.assertTrue(tail["ok"])
+        self.assertEqual(tail["status"], "error")
+        self.assertEqual(tail["error_code"], "PROMPT_TIMEOUT_RECOVERED")
+        self.assertEqual(tail["chunks"], ["partial line"])
 
     def test_partial_output_hang_recover_then_next_command_works(self) -> None:
         """target 只回一半輸出就停 → timeout → recover → 下一個命令正常完成。"""
@@ -142,6 +147,7 @@ class TestBadCommandRecovery(unittest.TestCase):
         # 全部 wait_for_regex = False（連 Ctrl-C 後也沒回 prompt）
         bridge.rx_snapshot_len.side_effect = [10, 20, 30]
         bridge.wait_for_regex_from.side_effect = [False, False, False]
+        bridge.rx_text_from.return_value = "partial output only"
 
         resp = mgr.execute_command("p:COM0", "totally-broken", "agent:test", "cid-stuck", timeout_s=0.1)
 
@@ -151,6 +157,11 @@ class TestBadCommandRecovery(unittest.TestCase):
         # session 降級到 ATTACHED
         self.assertEqual(session.state, "ATTACHED")
         self.assertEqual(session.last_error, "PROMPT_TIMEOUT")
+        tail = mgr.get_background_result("cid-stuck")
+        self.assertTrue(tail["ok"])
+        self.assertEqual(tail["status"], "error")
+        self.assertEqual(tail["error_code"], "PROMPT_TIMEOUT")
+        self.assertEqual(tail["chunks"], ["partial output only"])
 
 
 if __name__ == "__main__":

--- a/tests/test_resilience_hotplug.py
+++ b/tests/test_resilience_hotplug.py
@@ -89,6 +89,24 @@ class TestDeviceHotplug(unittest.TestCase):
             mgr.update_devices(device)
             mock_attach.assert_called_with(by_id)
 
+    def test_missing_bound_device_sets_detached_diagnostic(self) -> None:
+        """已綁定但目前不存在的裝置，update_devices 應留下 DEVICE_NOT_FOUND 診斷。"""
+        by_id = "/dev/serial/by-id/missing"
+        profile = _make_profile(by_id=by_id)
+        mgr = SessionManager(
+            [profile], WalWriter(wal_dir=self._tmp.name),
+            on_ready=lambda _: None, on_detached=lambda _: None,
+        )
+        session = mgr.get_session("COM0")
+        assert session is not None
+
+        with mock.patch.object(mgr, "_spawn_attach"):
+            mgr.update_devices({})
+
+        self.assertEqual(session.state, "DETACHED")
+        self.assertEqual(session.last_error, "DEVICE_NOT_FOUND")
+        self.assertIsNotNone(session.detached_at)
+
     def test_device_realpath_change_triggers_reattach(self) -> None:
         """同一 by_id 但 real_path 變更（重新列舉），應 detach + reattach。"""
         by_id = "/dev/serial/by-id/dev0"
@@ -151,6 +169,71 @@ class TestDeviceHotplug(unittest.TestCase):
         result = mgr.recover_session("COM0")
         self.assertFalse(result["ok"])
         self.assertEqual(result["error_code"], "SESSION_NOT_READY")
+
+    def test_recover_session_attached_reprobes_to_ready(self) -> None:
+        """ATTACHED + bridge 存活時，recover 應直接 re-probe 回 READY。"""
+        by_id = "/dev/serial/by-id/dev0"
+        profile = _make_profile(by_id=by_id)
+        mgr = SessionManager(
+            [profile], WalWriter(wal_dir=self._tmp.name),
+            on_ready=lambda _: None, on_detached=lambda _: None,
+        )
+        session = mgr.get_session("COM0")
+        assert session is not None
+        session.state = "ATTACHED"
+        session.last_error = "PROMPT_TIMEOUT"
+        session.bridge = mock.MagicMock()
+
+        with mock.patch("sw_core.session_manager.probe_ready", return_value=(True, None)) as probe_ready:
+            result = mgr.recover_session("COM0")
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["action"], "REPROBE")
+        self.assertTrue(result["recovered"])
+        self.assertEqual(result["session"]["state"], "READY")
+        self.assertIsNone(result["session"]["last_error"])
+        probe_ready.assert_called_once_with(session.bridge, session.profile)
+
+    def test_recover_session_attached_failed_reprobe_stays_attached(self) -> None:
+        """ATTACHED re-probe 失敗時，recover 應保留 ATTACHED 並回傳明確錯誤。"""
+        by_id = "/dev/serial/by-id/dev0"
+        profile = _make_profile(by_id=by_id)
+        mgr = SessionManager(
+            [profile], WalWriter(wal_dir=self._tmp.name),
+            on_ready=lambda _: None, on_detached=lambda _: None,
+        )
+        session = mgr.get_session("COM0")
+        assert session is not None
+        session.state = "ATTACHED"
+        session.last_error = "PROMPT_TIMEOUT"
+        session.bridge = mock.MagicMock()
+
+        with mock.patch("sw_core.session_manager.probe_ready", return_value=(False, "PROMPT_TIMEOUT")):
+            result = mgr.recover_session("COM0")
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["action"], "REPROBE")
+        self.assertFalse(result["recovered"])
+        self.assertEqual(result["error_code"], "PROMPT_TIMEOUT")
+        self.assertEqual(result["session"]["state"], "ATTACHED")
+        self.assertEqual(result["session"]["last_error"], "PROMPT_TIMEOUT")
+
+    def test_attach_by_id_missing_device_sets_last_error(self) -> None:
+        """_attach_by_id 早退遇到缺裝置時，不應留下 last_error=None。"""
+        by_id = "/dev/serial/by-id/missing"
+        profile = _make_profile(by_id=by_id)
+        mgr = SessionManager(
+            [profile], WalWriter(wal_dir=self._tmp.name),
+            on_ready=lambda _: None, on_detached=lambda _: None,
+        )
+        session = mgr.get_session("COM0")
+        assert session is not None
+
+        mgr._attach_by_id(by_id)
+
+        self.assertEqual(session.state, "DETACHED")
+        self.assertEqual(session.last_error, "DEVICE_NOT_FOUND")
+        self.assertIsNotNone(session.detached_at)
 
 
 if __name__ == "__main__":

--- a/tests/test_session_bind.py
+++ b/tests/test_session_bind.py
@@ -131,6 +131,7 @@ class TestSessionBind(unittest.TestCase):
         bridge = mock.MagicMock()
         bridge.rx_snapshot_len.side_effect = [10, 20, 30]
         bridge.wait_for_regex_from.side_effect = [False, False, False]
+        bridge.rx_text_from.return_value = "partial output"
         session.bridge = bridge
         session.state = "READY"
 
@@ -688,6 +689,63 @@ class TestSessionBind(unittest.TestCase):
         self.assertIsNone(session.bridge)
         self.assertIsNone(session.vtty_path)
         spawn_attach.assert_called_once_with("/dev/serial/by-id/orig")
+
+    def test_attach_reuses_preserved_consoles_and_restores_human_owner(self) -> None:
+        from sw_core.device_watcher import DeviceInfo
+        from sw_core.uart_io import ConsoleClient, PreservedConsoles
+        import time
+        import unittest.mock as mock
+
+        profiles = [self._make_profile("p", "COM0", "lab+1", "/dev/serial/by-id/orig")]
+        mgr = SessionManager(profiles, WalWriter(wal_dir=self._tmp.name), on_ready=lambda _sid: None, on_detached=lambda _sid: None)
+        session = mgr.get_session("COM0")
+        assert session is not None
+
+        preserved = PreservedConsoles(
+            clients={
+                "cid-1": ConsoleClient(
+                    client_id="cid-1",
+                    label="minicom:1",
+                    master_fd=-1,
+                    slave_fd=-1,
+                    slave_path="/dev/pts/55",
+                    attached_at=time.time(),
+                )
+            },
+            primary_client_id="cid-1",
+        )
+        session.bridge = mock.MagicMock()
+        session.bridge.stop.return_value = preserved
+        session.state = "READY"
+        lease = InteractiveLease(
+            interactive_id="lease-1",
+            session_id=session.session_id,
+            owner="human:cid-1",
+            created_at="now",
+            timeout_s=90.0,
+        )
+        with mgr._lock:
+            mgr._interactive[lease.interactive_id] = lease
+            session.interactive_session_id = lease.interactive_id
+            mgr._devices = {
+                "/dev/serial/by-id/orig": DeviceInfo(by_id="/dev/serial/by-id/orig", real_path="/dev/ttyUSB0")
+            }
+
+        mgr._detach_session_locked(session, reason="BRIDGE_DOWN:TEST")
+        self.assertEqual(session.vtty_path, "/dev/pts/55")
+        self.assertEqual(session.to_public_dict()["console_count"], 1)
+
+        with mock.patch("sw_core.session_manager.UARTBridge") as MockBridge, \
+             mock.patch("sw_core.session_manager.probe_ready", return_value=(True, None)):
+            MockBridge.return_value.start.return_value = None
+            MockBridge.return_value.vtty_path = "/dev/pts/55"
+            MockBridge.return_value.has_console.return_value = True
+            mgr._attach_by_id("/dev/serial/by-id/orig")
+
+        self.assertIsNone(session.retained_consoles)
+        self.assertIsNotNone(session.interactive_session_id)
+        MockBridge.return_value.set_interactive_owner.assert_called_once_with("human:cid-1")
+        self.assertEqual(MockBridge.call_args.kwargs["preserved_consoles"].primary_vtty(), "/dev/pts/55")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要
- 修復 bridge rebuild 後 human console 掛到 stale PTY 的問題，保留既有 console PTY 與 human ownership
- 讓 ATTACHED session 的 recover 先做 re-probe，並讓 prompt timeout 命令保留 terminal result-tail
- 補上缺裝置時的 `DEVICE_NOT_FOUND` 診斷，並同步更新 README / spec

## 測試
- `python3 -m unittest discover -s tests -v`

## 對應 issue
- closes #11
- closes #14
- closes #15
- closes #16
