### PR TITLE
feat: wal.reset / wal.current_seq API 與 session.bind 冪等化

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,24 @@ serialwrap log tail-raw  --selector COM0 --from-seq 0 --limit 200
 serialwrap wal export --from-seq 0 --limit 500
 ```
 
+### WAL 管理
+
+```bash
+# 輪替現有 WAL 並重設 seq（daemon 不重啟，console 不斷線）
+serialwrap wal reset
+
+# 查詢目前 WAL seq（不需讀檔，無 race condition）
+serialwrap wal current-seq
+```
+
+`wal.reset` 會將現有 `raw.wal.ndjson` 與 `raw.mirror.log` 改名為 `*.{timestamp}` 歸檔，然後重新從 seq 0 開始寫入。此操作**不影響任何已連線的 console PTY**。
+
+### session.bind 冪等行為
+
+當 session 已綁定同一 `device_by_id` 且狀態為 `READY` 或 `ATTACHED` 時，重複呼叫 `session.bind` 不會 detach 現有 bridge 或銷毀 console PTY。回傳值包含 `"already_bound": true`。
+
+這使得外部 orchestrator（如 testpilot）可以安全地呼叫 `session bind` 而不必擔心打斷 human console。
+
 說明：
 
 - `log tail-text` 偏向人類閱讀，不輸出 metadata header。
@@ -630,6 +648,8 @@ serialwrap wal export --from-seq 0 --limit 500
 | `serialwrap_log_stop` | `session.log_stop` |
 | `serialwrap_log_status` | `session.log_status` |
 | `serialwrap_clear_session` | `session.clear` |
+| `serialwrap_wal_reset` | `wal.reset` |
+| `serialwrap_wal_current_seq` | `wal.current_seq` |
 
 ### Legacy alias
 

--- a/sw_core/cli.py
+++ b/sw_core/cli.py
@@ -302,6 +302,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_we.add_argument("--from-seq", type=int, default=0)
     p_we.add_argument("--to-seq", type=int, default=0)
     p_we.add_argument("--limit", type=int, default=1000)
+    wal_sub.add_parser("reset")
+    wal_sub.add_parser("current-seq")
 
     return p
 
@@ -432,6 +434,12 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.cmd == "wal" and args.wal_cmd == "export":
         return _run_rpc(args, "wal.range", {"from_seq": args.from_seq, "to_seq": args.to_seq, "limit": args.limit})
+
+    if args.cmd == "wal" and args.wal_cmd == "reset":
+        return _run_rpc(args, "wal.reset", {})
+
+    if args.cmd == "wal" and args.wal_cmd == "current-seq":
+        return _run_rpc(args, "wal.current_seq", {})
 
     _print({"ok": False, "error_code": "INVALID_ARGS"})
     return 2

--- a/sw_core/service.py
+++ b/sw_core/service.py
@@ -410,6 +410,12 @@ class SerialwrapService:
                 rows = [r for r in rows if int(r.get("seq", 0)) <= to_seq]
             return {"ok": True, "records": rows}
 
+        if method == "wal.reset":
+            return self._wal.reset()
+
+        if method == "wal.current_seq":
+            return {"ok": True, "seq": self._wal.current_seq}
+
         if method == "session.log_start":
             selector = str(params.get("selector") or params.get("session_id") or params.get("com") or params.get("alias") or "")
             if not selector:

--- a/sw_core/session_manager.py
+++ b/sw_core/session_manager.py
@@ -415,6 +415,13 @@ class SessionManager:
                         "device_by_id": device_by_id,
                         "session_id": other.session_id,
                     }
+            # 冪等：已綁定同 device 且 bridge 存在且 READY/ATTACHED → 不 detach
+            if (
+                session.bridge is not None
+                and session.profile.device_by_id == device_by_id
+                and session.state in ("READY", "ATTACHED")
+            ):
+                return {"ok": True, "already_bound": True, "session": session.to_public_dict()}
             if session.bridge is not None:
                 self._detach_session_locked(session, reason="REBOUND")
             session.profile = dataclasses.replace(session.profile, device_by_id=device_by_id)

--- a/sw_core/wal.py
+++ b/sw_core/wal.py
@@ -108,6 +108,23 @@ class WalWriter:
                 mirror_fp.write(to_printable(payload))
         return record
 
+    def reset(self) -> dict[str, Any]:
+        """輪替現有 WAL 檔案並重設 seq 計數器。不需重啟 daemon。"""
+        with self._lock:
+            prev_seq = self._seq
+            ts = time.strftime("%Y%m%d-%H%M%S", time.gmtime())
+            for path in (self._wal_path, self._mirror_path):
+                if os.path.exists(path) and os.path.getsize(path) > 0:
+                    dst = f"{path}.{ts}"
+                    os.replace(path, dst)
+            dir_fd = os.open(self._wal_dir, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+            self._seq = 0
+            return {"ok": True, "previous_seq": prev_seq, "rotated_suffix": ts}
+
     def tail_raw(self, *, from_seq: int = 0, com: str | None = None, limit: int = 200) -> list[dict[str, Any]]:
         out: list[dict[str, Any]] = []
         if not os.path.exists(self._wal_path):

--- a/sw_mcp/server.py
+++ b/sw_mcp/server.py
@@ -33,6 +33,8 @@ _TOOL_MAP = {
     "serialwrap_log_start": "session.log_start",
     "serialwrap_log_stop": "session.log_stop",
     "serialwrap_log_status": "session.log_status",
+    "serialwrap_wal_reset": "wal.reset",
+    "serialwrap_wal_current_seq": "wal.current_seq",
 }
 
 

--- a/tests/test_human_agent_coexist.py
+++ b/tests/test_human_agent_coexist.py
@@ -1,0 +1,481 @@
+"""S6 整合測試：human console (tmux/minicom) + agent 共存驗證。
+
+使用 FakeTarget (PTY) 模擬 UART target，啟動真實 daemon，
+再透過 tmux 模擬 human console，驗證：
+- wal.reset 不破壞 console 連線
+- wal.current_seq 一致性
+- session.bind 冪等不斷線
+- agent 命令在 human console 開啟時正常執行且可見
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import pty
+import select
+import shutil
+import subprocess
+import tempfile
+import termios
+import threading
+import time
+import unittest
+from typing import Any
+
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[1]
+SERIALWRAP = str(ROOT_DIR / "serialwrap")
+SERIALWRAPD = str(ROOT_DIR / "serialwrapd.py")
+
+
+class FakeTarget:
+    """PTY 假 target，回應 prpl 風格 prompt 並 echo 命令。"""
+
+    def __init__(self) -> None:
+        self.master_fd, self.slave_fd = pty.openpty()
+        self._configure_slave(self.slave_fd)
+        self.slave_path = os.ttyname(self.slave_fd)
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+
+    def _configure_slave(self, fd: int) -> None:
+        attrs = termios.tcgetattr(fd)
+        attrs[0] = 0
+        attrs[1] = 0
+        attrs[2] = termios.CREAD | termios.CLOCAL | termios.CS8
+        attrs[3] = 0
+        attrs[6][termios.VMIN] = 1
+        attrs[6][termios.VTIME] = 0
+        termios.tcsetattr(fd, termios.TCSANOW, attrs)
+
+    def start(self) -> None:
+        os.write(self.master_fd, b"boot done\r\nroot@prplOS:/# ")
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=3.0)
+        for fd in (self.master_fd, self.slave_fd):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+    def _loop(self) -> None:
+        buf = b""
+        while not self._stop.is_set():
+            try:
+                rlist, _, _ = select.select([self.master_fd], [], [], 0.2)
+            except OSError:
+                return
+            if self.master_fd not in rlist:
+                continue
+            try:
+                chunk = os.read(self.master_fd, 4096)
+            except (BlockingIOError, OSError):
+                return
+            if not chunk:
+                return
+            buf += chunk
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                cmd = line.strip()
+                if not cmd:
+                    continue
+                if cmd.startswith(b"echo __READY__"):
+                    reply = cmd[5:] + b"\r\n"
+                else:
+                    reply = cmd + b": ok\r\n"
+                try:
+                    os.write(self.master_fd, reply + b"root@prplOS:/# ")
+                except OSError:
+                    return
+
+
+class TestHumanAgentCoexist(unittest.TestCase):
+    """tmux + FakeTarget + daemon 模擬完整 human+agent 共存場景。"""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # 確認 tmux 可用
+        try:
+            subprocess.run(["tmux", "-V"], capture_output=True, check=True, timeout=5)
+        except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            raise unittest.SkipTest("tmux 不可用")
+        # 確認 PTY 可用
+        try:
+            mfd, sfd = pty.openpty()
+            os.close(mfd)
+            os.close(sfd)
+        except OSError as exc:
+            raise unittest.SkipTest(f"PTY 不可用: {exc}")
+
+    def setUp(self) -> None:
+        self._td = tempfile.mkdtemp(prefix="sw-coexist-")
+        self._root = pathlib.Path(self._td)
+        self._by_id_dir = self._root / "by-id"
+        self._profile_dir = self._root / "profiles"
+        self._by_id_dir.mkdir(parents=True)
+        self._profile_dir.mkdir(parents=True)
+
+        self._fake = FakeTarget()
+        self._fake.start()
+
+        self._link_path = self._by_id_dir / "fake-uart0"
+        os.symlink(self._fake.slave_path, self._link_path)
+
+        profile = f"""profiles:
+  prpl-template:
+    platform: prpl
+    prompt_regex: "(?m)^root@prplOS:.*# "
+    ready_probe: "echo __READY__${{nonce}}"
+    uart:
+      baud: 115200
+      data_bits: 8
+      parity: N
+      stop_bits: 1
+      flow_control: rtscts
+      xonxoff: false
+
+targets:
+  - act_no: 1
+    com: COM0
+    alias: dut
+    profile: prpl-template
+    device_by_id: {self._link_path}
+"""
+        (self._profile_dir / "test.yaml").write_text(profile, encoding="utf-8")
+
+        self._env = os.environ.copy()
+        self._env["SERIALWRAP_STATE_DIR"] = str(self._root / "state")
+        self._env["SERIALWRAP_RUN_DIR"] = str(self._root / "run")
+        self._env["SERIALWRAP_BY_ID_DIR"] = str(self._by_id_dir)
+        self._env["SERIALWRAP_BY_PATH_DIR"] = str(self._root / "by-path")
+        self._env["SERIALWRAP_WAL_DIR"] = str(self._root / "wal")
+
+        self._socket = str(self._root / "run" / "serialwrapd.sock")
+        self._lock = str(self._root / "run" / "serialwrapd.lock")
+
+        self._daemon = subprocess.Popen(
+            [
+                os.environ.get("PYTHON", "python3"),
+                SERIALWRAPD,
+                "--profile-dir", str(self._profile_dir),
+                "--socket", self._socket,
+                "--lock", self._lock,
+            ],
+            env=self._env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        self._wait_ready()
+
+        self._tmux_session = f"sw_test_{os.getpid()}"
+
+    def tearDown(self) -> None:
+        # 清理 tmux session
+        subprocess.run(
+            ["tmux", "kill-session", "-t", self._tmux_session],
+            capture_output=True, timeout=5,
+        )
+        # 清理 daemon
+        try:
+            self._sw("daemon", "stop")
+        except Exception:
+            pass
+        if self._daemon.poll() is None:
+            self._daemon.terminate()
+            try:
+                self._daemon.wait(timeout=3.0)
+            except subprocess.TimeoutExpired:
+                self._daemon.kill()
+        self._fake.stop()
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _sw(self, *args: str, timeout: float = 10.0) -> dict[str, Any]:
+        cmd = [SERIALWRAP, "--socket", self._socket, *args]
+        proc = subprocess.run(
+            cmd, env=self._env,
+            capture_output=True, text=True, timeout=timeout,
+        )
+        out = proc.stdout.strip()
+        if not out:
+            return {"ok": False, "_stderr": proc.stderr.strip(), "_rc": proc.returncode}
+        try:
+            return json.loads(out)
+        except json.JSONDecodeError:
+            return {"ok": False, "_stdout": out, "_rc": proc.returncode}
+
+    def _wait_ready(self, timeout_s: float = 20.0) -> None:
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            resp = self._sw("session", "list")
+            if resp.get("ok"):
+                sessions = resp.get("sessions") or []
+                if sessions and sessions[0].get("state") == "READY":
+                    return
+            time.sleep(0.3)
+        self.fail(f"session 未在 {timeout_s}s 內達到 READY")
+
+    def _attach_console(self, label: str = "tmux-human") -> dict[str, Any]:
+        return self._sw("session", "console-attach", "--selector", "COM0", "--label", label)
+
+    def _tmux_new(self, command: str = "bash") -> None:
+        subprocess.run(
+            ["tmux", "new-session", "-d", "-s", self._tmux_session, command],
+            check=True, timeout=5,
+        )
+
+    def _tmux_send(self, keys: str, delay: float = 0.5) -> None:
+        subprocess.run(
+            ["tmux", "send-keys", "-t", self._tmux_session, keys, "Enter"],
+            check=True, timeout=5,
+        )
+        time.sleep(delay)
+
+    def _tmux_capture(self) -> str:
+        proc = subprocess.run(
+            ["tmux", "capture-pane", "-t", self._tmux_session, "-p"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return proc.stdout
+
+    def _start_minicom_in_tmux(self, vtty: str) -> None:
+        """在 tmux session 內用 cat 讀 vtty（模擬 minicom 的 RX 觀測）。"""
+        self._tmux_new("bash")
+        time.sleep(0.3)
+        # 用 cat 讀 PTY slave 以觀測 RX（比 minicom 更輕量且不需安裝）
+        self._tmux_send(f"cat {vtty}", delay=1.0)
+
+    # ---------------------------------------------------------------
+    # T1: wal.reset 後 console PTY 仍然有效
+    # ---------------------------------------------------------------
+    def test_t1_wal_reset_preserves_console(self) -> None:
+        attach = self._attach_console("t1-human")
+        self.assertTrue(attach.get("ok"), msg=f"console-attach 失敗: {attach}")
+        vtty = attach["vtty"]
+        client_id = attach["client_id"]
+
+        self._start_minicom_in_tmux(vtty)
+
+        # 執行 wal.reset
+        reset_resp = self._sw("wal", "reset")
+        self.assertTrue(reset_resp.get("ok"), msg=f"wal reset 失敗: {reset_resp}")
+
+        # wal.reset 後送 agent 命令，驗證 console 仍可收到
+        submit = self._sw("cmd", "submit", "--selector", "COM0", "--cmd", "echo T1_ALIVE", "--cmd-timeout", "5")
+        self.assertTrue(submit.get("ok"), msg=f"cmd submit 失敗: {submit}")
+        time.sleep(2.0)
+
+        # 驗證 console 仍在 list 中
+        consoles = self._sw("session", "console-list", "--selector", "COM0")
+        self.assertTrue(consoles.get("ok"))
+        ids = [c["client_id"] for c in consoles.get("consoles", [])]
+        self.assertIn(client_id, ids, msg="wal.reset 後 console 消失了")
+
+        # 驗證 tmux 看到輸出
+        pane = self._tmux_capture()
+        self.assertIn("T1_ALIVE", pane, msg=f"console 未收到 agent 命令輸出:\n{pane}")
+
+    # ---------------------------------------------------------------
+    # T2: wal.reset 後 seq 從 0 重新計數
+    # ---------------------------------------------------------------
+    def test_t2_wal_reset_seq_resets_to_zero(self) -> None:
+        # 先產生一些 WAL 記錄
+        self._sw("cmd", "submit", "--selector", "COM0", "--cmd", "echo before_reset", "--cmd-timeout", "5")
+        time.sleep(1.0)
+
+        seq_before = self._sw("wal", "current-seq")
+        self.assertTrue(seq_before.get("ok"))
+        self.assertGreater(seq_before["seq"], 0, "reset 前 seq 應 > 0")
+
+        # 執行 reset
+        reset_resp = self._sw("wal", "reset")
+        self.assertTrue(reset_resp.get("ok"))
+
+        seq_after = self._sw("wal", "current-seq")
+        self.assertTrue(seq_after.get("ok"))
+        self.assertEqual(seq_after["seq"], 0, "reset 後 seq 應 == 0")
+
+        # 再送一條命令，seq 應從 1 開始
+        self._sw("cmd", "submit", "--selector", "COM0", "--cmd", "echo after_reset", "--cmd-timeout", "5")
+        time.sleep(1.0)
+        seq_new = self._sw("wal", "current-seq")
+        self.assertTrue(seq_new.get("ok"))
+        self.assertGreater(seq_new["seq"], 0, "新命令後 seq 應 > 0")
+
+    # ---------------------------------------------------------------
+    # T3: wal.current_seq RPC 與 WAL 檔案一致
+    # ---------------------------------------------------------------
+    def test_t3_wal_current_seq_matches_live(self) -> None:
+        self._sw("cmd", "submit", "--selector", "COM0", "--cmd", "echo seq_check", "--cmd-timeout", "5")
+        time.sleep(1.0)
+
+        rpc_seq = self._sw("wal", "current-seq")
+        self.assertTrue(rpc_seq.get("ok"))
+
+        # 直接讀 WAL 檔案最後一行取 seq
+        wal_path = self._root / "wal" / "raw.wal.ndjson"
+        if wal_path.exists():
+            lines = wal_path.read_text(encoding="utf-8").strip().splitlines()
+            if lines:
+                last = json.loads(lines[-1])
+                self.assertEqual(rpc_seq["seq"], last["seq"])
+
+    # ---------------------------------------------------------------
+    # T4: bind 冪等 — 已 READY 的 session 不重新 attach
+    # ---------------------------------------------------------------
+    def test_t4_bind_idempotent_ready_session(self) -> None:
+        state_before = self._sw("session", "list")
+        self.assertTrue(state_before.get("ok"))
+        session = state_before["sessions"][0]
+        self.assertEqual(session["state"], "READY")
+
+        # 再次 bind 同一 device
+        bind_resp = self._sw(
+            "session", "bind",
+            "--selector", "COM0",
+            "--device-by-id", str(self._link_path),
+        )
+        self.assertTrue(bind_resp.get("ok"), msg=f"bind 失敗: {bind_resp}")
+        self.assertTrue(bind_resp.get("already_bound"), msg="應回傳 already_bound=True")
+
+        # session 仍然 READY
+        state_after = self._sw("session", "list")
+        self.assertEqual(state_after["sessions"][0]["state"], "READY")
+
+    # ---------------------------------------------------------------
+    # T5: bind 冪等後 human console 不斷線
+    # ---------------------------------------------------------------
+    def test_t5_bind_idempotent_preserves_console(self) -> None:
+        attach = self._attach_console("t5-human")
+        self.assertTrue(attach.get("ok"))
+        client_id = attach["client_id"]
+        vtty = attach["vtty"]
+
+        self._start_minicom_in_tmux(vtty)
+
+        # 冪等 bind
+        self._sw(
+            "session", "bind",
+            "--selector", "COM0",
+            "--device-by-id", str(self._link_path),
+        )
+
+        # 送 agent 命令
+        self._sw("cmd", "submit", "--selector", "COM0", "--cmd", "echo T5_BIND_OK", "--cmd-timeout", "5")
+        time.sleep(2.0)
+
+        consoles = self._sw("session", "console-list", "--selector", "COM0")
+        ids = [c["client_id"] for c in consoles.get("consoles", [])]
+        self.assertIn(client_id, ids, msg="冪等 bind 後 console 消失了")
+
+        pane = self._tmux_capture()
+        self.assertIn("T5_BIND_OK", pane, msg=f"bind 後 console 未收到輸出:\n{pane}")
+
+    # ---------------------------------------------------------------
+    # T6: human 能即時看到 agent 提交的命令及回應
+    # ---------------------------------------------------------------
+    def test_t6_human_sees_agent_commands(self) -> None:
+        attach = self._attach_console("t6-monitor")
+        self.assertTrue(attach.get("ok"))
+        vtty = attach["vtty"]
+
+        self._start_minicom_in_tmux(vtty)
+
+        commands = ["echo T6_CMD_1", "echo T6_CMD_2", "echo T6_CMD_3"]
+        for cmd in commands:
+            self._sw("cmd", "submit", "--selector", "COM0", "--cmd", cmd, "--cmd-timeout", "5")
+            time.sleep(0.5)
+
+        time.sleep(2.0)
+        pane = self._tmux_capture()
+
+        for cmd in commands:
+            marker = cmd.split()[-1]  # T6_CMD_1, T6_CMD_2, T6_CMD_3
+            self.assertIn(marker, pane, msg=f"human 未看到 {marker}:\n{pane}")
+
+    # ---------------------------------------------------------------
+    # T7: human 打字期間 agent 命令不被阻擋
+    # ---------------------------------------------------------------
+    def test_t7_agent_runs_while_human_types(self) -> None:
+        attach = self._attach_console("t7-typer")
+        self.assertTrue(attach.get("ok"))
+        vtty = attach["vtty"]
+
+        self._start_minicom_in_tmux(vtty)
+
+        # 模擬 human 持續打字（透過 tmux send-keys 打一些字但不按 Enter）
+        subprocess.run(
+            ["tmux", "send-keys", "-t", self._tmux_session, "C-c"],
+            check=True, timeout=5,
+        )
+        time.sleep(0.3)
+        # 在 human "打字" 期間提交 agent 命令
+        t0 = time.monotonic()
+        submit = self._sw("cmd", "submit", "--selector", "COM0", "--cmd", "echo T7_CONCURRENT", "--cmd-timeout", "5")
+        elapsed = time.monotonic() - t0
+
+        self.assertTrue(submit.get("ok"), msg=f"agent 命令被阻擋: {submit}")
+        self.assertLess(elapsed, 5.0, msg=f"agent 命令提交耗時 {elapsed:.1f}s，可能被阻擋")
+
+        # 等命令完成
+        if submit.get("cmd_id"):
+            time.sleep(2.0)
+            result = self._sw("cmd", "status", "--cmd-id", submit["cmd_id"])
+            self.assertIn(result.get("command", {}).get("status", ""), ("done", "accepted", "running"),
+                          msg=f"命令狀態異常: {result}")
+
+    # ---------------------------------------------------------------
+    # T8: 完整 full run 模擬
+    # ---------------------------------------------------------------
+    def test_t8_full_run_simulation(self) -> None:
+        attach = self._attach_console("t8-fullrun")
+        self.assertTrue(attach.get("ok"))
+        vtty = attach["vtty"]
+        client_id = attach["client_id"]
+
+        self._start_minicom_in_tmux(vtty)
+
+        # Step 1: wal.reset（模擬 testpilot run 開始）
+        reset = self._sw("wal", "reset")
+        self.assertTrue(reset.get("ok"))
+
+        # Step 2: 確認 session 已 READY（模擬 setup_sessions 跳過 bind）
+        state = self._sw("session", "list")
+        self.assertEqual(state["sessions"][0]["state"], "READY")
+
+        # Step 3: 模擬 3 個 test case 的 seq 追蹤
+        case_seqs: list[tuple[int, int]] = []
+        for i in range(1, 4):
+            seq_before = self._sw("wal", "current-seq")["seq"]
+            self._sw("cmd", "submit", "--selector", "COM0",
+                     "--cmd", f"echo CASE_{i}_RESULT", "--cmd-timeout", "5")
+            time.sleep(1.0)
+            seq_after = self._sw("wal", "current-seq")["seq"]
+            case_seqs.append((seq_before, seq_after))
+
+        # Step 4: 驗證 seq 遞增
+        for i, (s, e) in enumerate(case_seqs):
+            self.assertGreater(e, s, msg=f"case {i+1} seq 未遞增: {s} -> {e}")
+
+        # Step 5: wal export 驗證
+        export = self._sw("wal", "export", "--from-seq", "0")
+        self.assertTrue(export.get("ok"))
+        self.assertGreater(len(export.get("records", [])), 0, "WAL export 無記錄")
+
+        # Step 6: console 全程不斷線
+        consoles = self._sw("session", "console-list", "--selector", "COM0")
+        ids = [c["client_id"] for c in consoles.get("consoles", [])]
+        self.assertIn(client_id, ids, msg="full run 後 console 斷線了")
+
+        # Step 7: human 看到所有 case 輸出
+        pane = self._tmux_capture()
+        for i in range(1, 4):
+            self.assertIn(f"CASE_{i}_RESULT", pane,
+                          msg=f"human 未看到 CASE_{i}_RESULT:\n{pane}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 解決問題

修復 human console (minicom) + agent 共存時的兩個穩定性問題：

1. **minicom 不斷斷線**：testpilot 每次 run 重啟 daemon → 所有 PTY 銷毀 → minicom 斷線
2. **minicom 阻擋 agent**：`session.bind` 重複呼叫 → detach bridge → console 銷毀 → login FSM 重跑

## 修復方案

### 新增 API
- **`wal.reset`**：輪替 WAL 檔案（重命名為 `*.{timestamp}`），重設 seq = 0。daemon 不重啟，console PTY 不受影響
- **`wal.current_seq`**：透過 RPC 取得目前 WAL seq，無需讀檔，避免 race condition

### session.bind 冪等化
- 已綁定同 device + bridge 存在 + READY/ATTACHED 狀態 → 不 detach，回傳 `already_bound: true`
- 外部 orchestrator 可安全重複呼叫，不會破壞 console 連線

### 同步更新
- CLI：`wal reset`、`wal current-seq` 子命令
- MCP：`serialwrap_wal_reset`、`serialwrap_wal_current_seq` 工具映射
- README：WAL 管理、session.bind 冪等行為文件

## 測試

新增 8 項 tmux 整合測試（`tests/test_human_agent_coexist.py`）：
- T1-T2：wal.reset 後 console 不斷線、seq 正確重置
- T3：wal.current_seq 與 WAL 檔案一致
- T4-T5：bind 冪等不破壞 console
- T6：human 能即時看到 agent 命令
- T7：human 打字期間 agent 不被阻擋
- T8：完整 full run 模擬

全部 186 項測試通過（178 既有 + 8 新增）。