### PR TITLE
fix: command length guard, recover --force, session mgmt docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -181,6 +181,8 @@ MCP 只是 RPC 的薄轉接層。新增或改名工具時，要把 `sw_mcp/serve
 - `serialwrap cmd result-tail`
 - `serialwrap_tail_command_result`
 
+其中 `serialwrap_tail_results` 目前固定對應 `result.tail` raw records，不會依 `cmd_id` 自動切到 `command.result_tail`。
+
 ### Python 風格慣例
 
 - Python 3.10+

--- a/README.md
+++ b/README.md
@@ -655,7 +655,7 @@ serialwrap wal current-seq
 
 | Tool | 說明 |
 |------|------|
-| `serialwrap_tail_results` | 舊工具名。若帶 `cmd_id` 走 `command.result_tail`；若帶 `selector/from_seq` 走 legacy `result.tail` raw records。 |
+| `serialwrap_tail_results` | 舊工具名，固定對應 `result.tail` raw records。若要讀 `background` capture，請改用 `serialwrap_tail_command_result`。 |
 
 ### 範例
 

--- a/docs/design-file-transfer.md
+++ b/docs/design-file-transfer.md
@@ -1,0 +1,66 @@
+# Design: File Transfer Primitive (file.push / file.pull)
+
+**Issue**: #21  
+**Status**: Design draft  
+
+## Problem
+
+No built-in file transfer mechanism. Agent workarounds (gzip+base64 inline,
+local HTTP server, sequential echo) are unreliable and slow.
+
+## Proposed API
+
+### CLI
+
+```bash
+serialwrap file push --selector COM0 --local /path/to/file --remote /tmp/file
+serialwrap file pull --selector COM0 --remote /etc/config --local ./config
+```
+
+### MCP
+
+```json
+{"tool": "serialwrap_file_push", "params": {"selector": "COM0", "local_path": "/path/to/file", "remote_path": "/tmp/file"}}
+{"tool": "serialwrap_file_pull", "params": {"selector": "COM0", "remote_path": "/etc/config"}}
+```
+
+### RPC
+
+- `file.push` → `{selector, local_path, remote_path, chunk_size?, checksum?}`
+- `file.pull` → `{selector, remote_path, local_path?, chunk_size?}`
+
+## Implementation Strategy
+
+### Push (host → target)
+
+1. Read local file, split into chunks (default 2KB)
+2. For each chunk: base64-encode, send as `echo '<b64>' | base64 -d >> /tmp/.sw_upload_<id>`
+3. After all chunks: verify checksum (`md5sum` or `sha256sum`)
+4. Rename temp file to final path
+5. Report progress via status callback
+
+### Pull (target → host)
+
+1. On target: `base64 < /path/to/file`
+2. Capture output in chunks via UART
+3. Decode and write locally
+4. Verify checksum
+
+### Key Considerations
+
+- **Chunk size**: Must stay under UART buffer limit (~2KB per line safe)
+- **Progress**: Return chunk count / total in status
+- **Resumable**: If interrupted, check existing temp file size
+- **Binary safety**: base64 encoding handles binary
+- **Cleanup**: Remove temp files on success or explicit cancel
+
+## Alternatives Considered
+
+- **ZMODEM/XMODEM**: Too complex for serial console, requires compatible receiver
+- **scp/rsync over network**: Requires network connectivity, not always available
+- **tar pipe**: Single-shot, not resumable
+
+## Dependencies
+
+- Session must be in READY state
+- Target must have `base64`, `md5sum` or `sha256sum`

--- a/docs/design-heartbeat-keepalive.md
+++ b/docs/design-heartbeat-keepalive.md
@@ -1,0 +1,80 @@
+# Design: Long-running Command Heartbeat / Keepalive
+
+**Issue**: #24  
+**Status**: Design draft  
+
+## Problem
+
+Long-running commands (e.g., `apt upgrade`, `python -m unittest`) produce no
+prompt output during execution. The broker's prompt probe times out, causing
+the session to transition from READY → ATTACHED + PROMPT_TIMEOUT even though
+the command is still running successfully.
+
+## Proposed Solution
+
+### 1. Foreground Command Awareness
+
+When a command is submitted via `command.submit`, the broker should track that
+a foreground command is in-flight and **suspend prompt timeout** during execution.
+
+```python
+# In session_manager.py execute_command:
+session.foreground_busy = True   # Already exists
+session.fg_cmd_started_at = now_iso()
+session.fg_cmd_timeout_s = timeout_s
+```
+
+The prompt health probe should skip sessions where `foreground_busy == True`
+and `elapsed < fg_cmd_timeout_s`.
+
+### 2. Expected Duration Hint
+
+Add optional `expected_duration_s` parameter to `command.submit`:
+
+```json
+{"tool": "serialwrap_submit_command", "params": {
+  "selector": "COM0",
+  "cmd": "python3 -m unittest discover",
+  "timeout_s": 120,
+  "expected_duration_s": 60
+}}
+```
+
+When `expected_duration_s` is provided:
+- Prompt timeout is suspended for that duration
+- After expiry, normal prompt probing resumes
+
+### 3. Output-based Keepalive Detection
+
+Monitor UART rx during command execution. If any bytes are received (even
+non-prompt output like test progress dots), reset the silence timer.
+
+```python
+# In _wait_for_prompt:
+while elapsed < timeout_s:
+    if bridge.rx_snapshot_len() > last_rx_len:
+        last_rx_len = bridge.rx_snapshot_len()
+        silence_start = time.monotonic()  # Reset silence timer
+    if time.monotonic() - silence_start > silence_timeout:
+        break  # True silence
+```
+
+### 4. Distinguishing Silence Types
+
+| Condition | Meaning | Action |
+|-----------|---------|--------|
+| foreground_busy + rx flowing | Command running, producing output | Wait |
+| foreground_busy + rx silent + elapsed < expected | Command running silently | Wait |
+| foreground_busy + rx silent + elapsed > expected | Possibly stuck | Warn |
+| NOT foreground_busy + rx silent | Session may be lost | Probe |
+
+## Implementation Phases
+
+1. **Phase 1**: Skip prompt timeout when `foreground_busy == True` (minimal)
+2. **Phase 2**: Add `expected_duration_s` parameter
+3. **Phase 3**: Output-based silence detection
+
+## Risks
+
+- Phase 1 alone could mask real session loss if command crashes
+- Need a hard upper bound (e.g., 10x expected_duration or 30 min) as safety net

--- a/docs/serialwrap-spec.md
+++ b/docs/serialwrap-spec.md
@@ -488,13 +488,15 @@ Agent 可透過 `session.log_start` / `session.log_stop` 對特定 session 啟�
 - `serialwrap_log_start` -> `session.log_start`
 - `serialwrap_log_stop` -> `session.log_stop`
 - `serialwrap_log_status` -> `session.log_status`
+- `serialwrap_wal_reset` -> `wal.reset`
+- `serialwrap_wal_current_seq` -> `wal.current_seq`
 - `serialwrap_clear_session` -> `session.clear`
 
 相容 alias：
 
 - `serialwrap_tail_results` -> `result.tail`
-  - 帶 `cmd_id` 時，回到 `command.result_tail` 語義
-  - 帶 `selector/from_seq` 時，維持 legacy raw result tail
+  - 固定維持 legacy raw result tail
+  - 若要讀 `background` capture，請改用 `serialwrap_tail_command_result`
 
 ## 12. `minicom_router.sh` 行為
 

--- a/sills.md
+++ b/sills.md
@@ -1,3 +1,3 @@
 # Redirect
 
-請使用 `/home/paul_chen/arc_prj/ser-dep/skills.md`。本檔保留為相容入口。
+請使用同層的 `skills.md`。本檔保留為相容入口。

--- a/skills.md
+++ b/skills.md
@@ -26,7 +26,8 @@
 5. 提交命令：`serialwrap_submit_command`，必填 `source` 與 `selector`。
 6. 前景命令：`serialwrap_get_command` 直接取 `stdout`。
 7. 背景命令：`serialwrap_tail_command_result` 增量取回後續內容。
-8. 需要完整證據時，改拉 CLI `log tail-raw` / `wal export`。
+8. 若需要 focused 純文字 RX capture，可用 `serialwrap_log_start` / `serialwrap_log_status` / `serialwrap_log_stop`。
+9. 需要完整證據時，改拉 CLI `log tail-raw` / `wal export`；若只要查目前 WAL seq，可用 `serialwrap_wal_current_seq`。
 
 ## MCP Tool 對應
 - `serialwrap_get_health` -> `health.status`
@@ -48,6 +49,11 @@
 - `serialwrap_send_interactive_keys` -> `session.interactive_send`
 - `serialwrap_get_interactive_status` -> `session.interactive_status`
 - `serialwrap_close_interactive` -> `session.interactive_close`
+- `serialwrap_log_start` -> `session.log_start`
+- `serialwrap_log_stop` -> `session.log_stop`
+- `serialwrap_log_status` -> `session.log_status`
+- `serialwrap_wal_reset` -> `wal.reset`
+- `serialwrap_wal_current_seq` -> `wal.current_seq`
 - `serialwrap_tail_results` -> `result.tail`（deprecated alias）
 
 ## MCP 參數規範
@@ -61,6 +67,13 @@
   - 建議：`from_chunk`, `limit`
 - `serialwrap_get_session_state`
   - 必填：`selector`（`session_id | COMx | alias`）
+- `serialwrap_log_start`
+  - 必填：`selector`
+  - 選填：`log_dir`
+- `serialwrap_log_status`
+  - 必填：`selector`
+- `serialwrap_wal_current_seq`
+  - 不需參數
 
 ## 安全規則
 - 禁止 Agent 直接寫 `/dev/ttyUSB*` 或 `/dev/ttyACM*`。
@@ -77,4 +90,6 @@
 /home/paul_chen/.paul_tools/serialwrap-mcp --tool serialwrap_submit_command --params "{\"selector\":\"COM0\",\"cmd\":\"ifconfig\",\"source\":\"agent:diag\",\"mode\":\"line\"}"
 /home/paul_chen/.paul_tools/serialwrap-mcp --tool serialwrap_get_command --params "{\"cmd_id\":\"<cmd_id>\"}"
 /home/paul_chen/.paul_tools/serialwrap-mcp --tool serialwrap_tail_command_result --params "{\"cmd_id\":\"<cmd_id>\",\"from_chunk\":0,\"limit\":120}"
+/home/paul_chen/.paul_tools/serialwrap-mcp --tool serialwrap_log_status --params "{\"selector\":\"COM0\"}"
+/home/paul_chen/.paul_tools/serialwrap-mcp --tool serialwrap_wal_current_seq --params "{}"
 ```

--- a/skills.md
+++ b/skills.md
@@ -60,6 +60,11 @@
 - `serialwrap_submit_command`
   - 必填：`selector`, `cmd`
   - 建議：`source="agent:<name>"`, `mode="line|background|interactive"`, `timeout_s`, `priority`
+  - 命令長度限制：> 4 KB 會回 warning，> 16 KB 會被 reject (`CMD_TOO_LONG`)
+  - 長命令建議改用 file-based injection（見 `docs/design-file-transfer.md`）
+- `serialwrap_recover_session`
+  - 必填：`selector`
+  - 選填：`timeout_s`, `force`（布林，force=true 時自動 clear+reattach+wait-ready）
 - `serialwrap_get_command`
   - 必填：`cmd_id`
 - `serialwrap_tail_command_result`
@@ -81,6 +86,13 @@
 - 長流命令（`logread -f`, `tcpdump`, kernel debug）一律使用 `mode=background` 或限制 timeout，避免阻塞共享通道。
 - 每筆自動化命令必填 `source`，不可省略，確保追蹤性。
 - 卡住時先 `serialwrap_self_test`，再決定是否 `serialwrap_recover_session`。
+
+## 短命令原則（Best Practice）
+- **避免 heredoc**：heredoc 經 UART 傳輸時容易遺失字元或打亂 prompt，改用 `echo ... > file` 分步寫入。
+- **單行 < 2 KB**：每條命令盡量控制在 2 KB 以內，超過 4 KB 會收到 warning。
+- **避免 base64 inline**：不要將整個檔案 base64 編碼塞進 `cmd submit`，改用分段寫入或 file transfer（待實作）。
+- **長命令拆分**：管線命令過長時，先寫成 script 檔再 `source` 或 `sh /tmp/script.sh`。
+- **回復策略**：若命令導致 PROMPT_TIMEOUT，使用 `serialwrap_recover_session` (可加 `force=true`)。
 
 ## 最小可用 MCP 範例
 ```bash

--- a/sw_core/arbiter.py
+++ b/sw_core/arbiter.py
@@ -9,6 +9,9 @@ from typing import Any, Callable
 
 from .util import now_iso
 
+CMD_WARN_BYTES = 4096
+CMD_REJECT_BYTES = 16384
+
 
 @dataclasses.dataclass(order=True)
 class _QueuedCommand:
@@ -68,6 +71,24 @@ class CommandArbiter:
         timeout_s: float,
         priority: int = 10,
     ) -> dict[str, Any]:
+        cmd_len = len(command.encode("utf-8", errors="replace"))
+        if cmd_len > CMD_REJECT_BYTES:
+            return {
+                "ok": False,
+                "error_code": "CMD_TOO_LONG",
+                "cmd_length": cmd_len,
+                "limit": CMD_REJECT_BYTES,
+                "hint": "Command exceeds 16 KB hard limit. Use file-based injection or split into smaller commands.",
+            }
+        cmd_warning = None
+        if cmd_len > CMD_WARN_BYTES:
+            cmd_warning = {
+                "code": "CMD_LENGTH_WARNING",
+                "cmd_length": cmd_len,
+                "soft_limit": CMD_WARN_BYTES,
+                "hint": "Command exceeds 4 KB soft limit. Long commands may cause UART buffer overflow or prompt timeout.",
+            }
+
         with self._lock:
             pq = self._queues.get(session_id)
             if pq is None:
@@ -101,7 +122,10 @@ class CommandArbiter:
         with self._lock:
             self._commands[cmd_id] = rec
         pq.put(_QueuedCommand(sort_key=(priority, counter), cmd_id=cmd_id, session_id=session_id, command=command, source=source, mode=mode, timeout_s=timeout_s))
-        return {"ok": True, "cmd_id": cmd_id, "status": "accepted", "session_id": session_id}
+        result: dict[str, Any] = {"ok": True, "cmd_id": cmd_id, "status": "accepted", "session_id": session_id}
+        if cmd_warning is not None:
+            result["warning"] = cmd_warning
+        return result
 
     def get(self, cmd_id: str) -> dict[str, Any]:
         with self._lock:

--- a/sw_core/cli.py
+++ b/sw_core/cli.py
@@ -215,6 +215,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_sr = sess_sub.add_parser("recover")
     p_sr.add_argument("--selector", required=True, help="session_id | COMx | alias")
     p_sr.add_argument("--timeout", dest="recover_timeout_s", type=float, default=2.0)
+    p_sr.add_argument("--force", action="store_true", help="force clear+reattach if normal recovery fails")
     p_sca = sess_sub.add_parser("console-attach")
     p_sca.add_argument("--selector", required=True, help="session_id | COMx | alias")
     p_sca.add_argument("--label")
@@ -335,7 +336,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.session_cmd == "self-test":
             return _run_rpc(args, "session.self_test", {"selector": args.selector, "timeout_s": args.probe_timeout_s})
         if args.session_cmd == "recover":
-            return _run_rpc(args, "session.recover", {"selector": args.selector, "timeout_s": args.recover_timeout_s})
+            return _run_rpc(args, "session.recover", {"selector": args.selector, "timeout_s": args.recover_timeout_s, "force": getattr(args, "force", False)})
         if args.session_cmd == "console-attach":
             params: dict[str, Any] = {"selector": args.selector}
             if args.label:

--- a/sw_core/service.py
+++ b/sw_core/service.py
@@ -228,9 +228,10 @@ class SerialwrapService:
         if method == "session.recover":
             selector = str(params.get("selector") or params.get("session_id") or params.get("com") or params.get("alias") or "")
             timeout_s = float(params.get("timeout_s") or 2.0)
+            force = bool(params.get("force"))
             if not selector:
                 return {"ok": False, "error_code": "INVALID_ARGS"}
-            return self._sessions.recover_session(selector, timeout_s=timeout_s)
+            return self._sessions.recover_session(selector, timeout_s=timeout_s, force=force)
 
         if method == "session.clear":
             selector = str(

--- a/sw_core/session_manager.py
+++ b/sw_core/session_manager.py
@@ -1355,6 +1355,19 @@ class SessionManager:
                 error_code="PROMPT_TIMEOUT",
             )
         self._transition_to_attached(session, reason="PROMPT_TIMEOUT")
+
+        # Auto-fallback: try force clear + reattach when both CTRL_C/D fail
+        if source == "system:recover":
+            force_result = self._force_recover(session)
+            if force_result.get("recovered"):
+                return {
+                    "ok": True,
+                    "error_code": "PROMPT_TIMEOUT_FORCE_RECOVERED",
+                    "partial": True,
+                    "recovery_action": "FORCE_CLEAR_REATTACH",
+                    "session": force_result.get("session", {}),
+                }
+
         return {
             "ok": False,
             "error_code": "PROMPT_TIMEOUT",
@@ -1613,7 +1626,7 @@ class SessionManager:
                 "recommended_action": "none",
             }
 
-    def recover_session(self, selector: str, *, timeout_s: float = 2.0) -> dict[str, Any]:
+    def recover_session(self, selector: str, *, timeout_s: float = 2.0, force: bool = False) -> dict[str, Any]:
         reprobe = False
         with self._lock:
             session = self.get_session(selector)
@@ -1628,15 +1641,21 @@ class SessionManager:
                     return {"ok": True, "recovering": False, "action": "REATTACH", "session": session.to_public_dict()}
                 return {"ok": False, "error_code": "SESSION_NOT_READY", "session": session.to_public_dict()}
             if session.state == "ATTACHED":
+                if force:
+                    return self._force_recover(session)
                 bridge = session.bridge
                 reprobe = True
             elif session.state != "READY":
+                if force:
+                    return self._force_recover(session)
                 return {"ok": False, "error_code": "SESSION_NOT_READY", "session": session.to_public_dict()}
             else:
                 bridge = session.bridge
         if reprobe:
             result = self._probe_existing_bridge(session, bridge)
             if not result.get("ok"):
+                if force:
+                    return self._force_recover(session)
                 return result
             recovered = result["session"]["state"] == "READY"
             payload: dict[str, Any] = {
@@ -1648,6 +1667,8 @@ class SessionManager:
             }
             if not recovered:
                 payload["error_code"] = result["session"].get("last_error") or "SESSION_NOT_READY"
+                if force:
+                    return self._force_recover(session)
             return payload
         return self._recover_after_failure(
             session,
@@ -1659,6 +1680,31 @@ class SessionManager:
             prompt_regex=session.profile.prompt_regex,
             pre_offset=bridge.rx_snapshot_len(),
         )
+
+    def _force_recover(self, session: SessionRuntime) -> dict[str, Any]:
+        """Force recovery via clear + reattach + wait-ready."""
+        selector = session.session_id
+        self.clear_session(selector)
+        import time
+        for _ in range(10):
+            time.sleep(1.0)
+            state = self.get_session_state(selector)
+            if state.get("ok") and state.get("session", {}).get("state") == "READY":
+                return {
+                    "ok": True,
+                    "recovering": False,
+                    "action": "FORCE_CLEAR_REATTACH",
+                    "recovered": True,
+                    "session": state["session"],
+                }
+        state = self.get_session_state(selector)
+        return {
+            "ok": False,
+            "error_code": "FORCE_RECOVER_TIMEOUT",
+            "action": "FORCE_CLEAR_REATTACH",
+            "recovered": False,
+            "session": state.get("session", {}),
+        }
 
     def get_background_result(self, cmd_id: str, *, from_chunk: int = 0, limit: int = 200) -> dict[str, Any]:
         with self._lock:


### PR DESCRIPTION
## Changes

### Fixes
- **#19/#23**: Command length guard in `arbiter.submit()` — warn >4KB, reject >16KB (`CMD_TOO_LONG`). Short-command best practices added to skills.md.
- **#20**: `--force` flag for `session recover`. Auto-fallback to clear+reattach+wait-ready when CTRL_C/D fail. Also auto-fallback in `_recover_after_failure` for system:recover calls.
- **#22**: Verified MCP already has `serialwrap_attach_session`, `serialwrap_recover_session`, `serialwrap_bind_session`. Added `force` param to recover.

### Design Docs (partial for #21, #24)
- `docs/design-file-transfer.md`: Design for `file.push`/`file.pull` primitive
- `docs/design-heartbeat-keepalive.md`: Design for heartbeat/keepalive mechanism

### Doc Alignment
- Fix `serialwrap_tail_results` description (fixed to `result.tail`)
- Add `log_*`/`wal_*` tools to skills.md
- Fix stale redirect in sills.md

### Tests
- 185/186 pass. The 1 failure (`test_five_agents_three_rounds_no_conflict`: 70 != 15) is pre-existing.

Closes #19 Closes #20 Closes #23
Refs #21 #22 #24