### PR TITLE
fix(core): 修正 #26 recover 語義、#27 換行拒絕、#28 background 生命週期

### DIFF
--- a/sw_core/arbiter.py
+++ b/sw_core/arbiter.py
@@ -88,6 +88,13 @@ class CommandArbiter:
                 "soft_limit": CMD_WARN_BYTES,
                 "hint": "Command exceeds 4 KB soft limit. Long commands may cause UART buffer overflow or prompt timeout.",
             }
+        if "\n" in command:
+            return {
+                "ok": False,
+                "error_code": "CMD_CONTAINS_NEWLINE",
+                "hint": "Command must not contain embedded newline characters. "
+                        "Split into multiple independent submissions.",
+            }
 
         with self._lock:
             pq = self._queues.get(session_id)

--- a/sw_core/service.py
+++ b/sw_core/service.py
@@ -145,6 +145,40 @@ class SerialwrapService:
             priority=100,
         )
 
+    def _bg_fallback_from_arbiter(
+        self, cmd_id: str, from_chunk: int = 0,
+    ) -> dict[str, Any]:
+        """BackgroundCapture 尚未建立時，以 arbiter 狀態合成 result_tail 回應。
+
+        當 background 命令已被 arbiter 接受但 worker 尚未執行完畢（或
+        執行失敗導致 BackgroundCapture 從未建立），回傳帶有 arbiter
+        狀態的空 chunks 回應，避免 caller 收到 CMD_NOT_FOUND。
+        """
+        arb_result = self._arbiter.get(cmd_id)
+        if not arb_result.get("ok"):
+            return {"ok": False, "error_code": "CMD_NOT_FOUND", "cmd_id": cmd_id}
+        cmd_rec = arb_result["command"]
+        if cmd_rec.get("execution_mode") != "background":
+            return {"ok": False, "error_code": "CMD_NOT_FOUND", "cmd_id": cmd_id}
+        status = cmd_rec["status"]
+        # done 狀態應有 BackgroundCapture；若缺失代表內部異常，不遮蓋
+        if status == "done":
+            return {"ok": False, "error_code": "CMD_NOT_FOUND", "cmd_id": cmd_id}
+        # canceled 若已開始執行，capture 可能稍後建立，不能提前宣告終止
+        if status == "canceled" and cmd_rec.get("started_at") is not None:
+            return {"ok": False, "error_code": "CMD_NOT_FOUND", "cmd_id": cmd_id}
+        return {
+            "ok": True,
+            "cmd_id": cmd_id,
+            "status": status,
+            "error_code": cmd_rec.get("error_code"),
+            "from_seq": 0,  # pre-capture sentinel，非真實 WAL 邊界
+            "last_seq": 0,
+            "from_chunk": from_chunk,
+            "next_chunk": from_chunk,
+            "chunks": [],
+        }
+
     def _on_device_change(self, _added, _removed) -> None:
         self._sessions.update_devices(self._watcher.devices)
 
@@ -360,7 +394,10 @@ class SerialwrapService:
             limit = int(params.get("limit") or 200)
             if not cmd_id:
                 return {"ok": False, "error_code": "INVALID_ARGS"}
-            return self._sessions.get_background_result(cmd_id, from_chunk=from_chunk, limit=limit)
+            result = self._sessions.get_background_result(cmd_id, from_chunk=from_chunk, limit=limit)
+            if not result.get("ok") and result.get("error_code") == "CMD_NOT_FOUND":
+                result = self._bg_fallback_from_arbiter(cmd_id, from_chunk)
+            return result
 
         if method == "command.cancel":
             cmd_id = str(params.get("cmd_id") or "")
@@ -371,7 +408,10 @@ class SerialwrapService:
             if cmd_id:
                 from_chunk = int(params.get("from_chunk") or 0)
                 limit = int(params.get("limit") or 200)
-                return self._sessions.get_background_result(cmd_id, from_chunk=from_chunk, limit=limit)
+                result = self._sessions.get_background_result(cmd_id, from_chunk=from_chunk, limit=limit)
+                if not result.get("ok") and result.get("error_code") == "CMD_NOT_FOUND":
+                    result = self._bg_fallback_from_arbiter(cmd_id, from_chunk)
+                return result
             # Deprecated legacy path: fall back to raw WAL tail by selector.
 
         if method in {"result.tail", "log.tail_raw"}:

--- a/sw_core/session_manager.py
+++ b/sw_core/session_manager.py
@@ -1339,7 +1339,7 @@ class SessionManager:
                         error_code="PROMPT_TIMEOUT_RECOVERED",
                     )
                 return {
-                    "ok": False,
+                    "ok": True,
                     "error_code": "PROMPT_TIMEOUT_RECOVERED",
                     "stdout": stdout,
                     "partial": True,

--- a/tests/test_bad_command_recovery.py
+++ b/tests/test_bad_command_recovery.py
@@ -62,7 +62,7 @@ class TestBadCommandRecovery(unittest.TestCase):
 
         resp = mgr.execute_command("p:COM0", "cat", "agent:test", "cid-bad1", timeout_s=0.1)
 
-        self.assertFalse(resp["ok"])
+        self.assertTrue(resp["ok"])
         self.assertEqual(resp["error_code"], "PROMPT_TIMEOUT_RECOVERED")
         self.assertEqual(resp["recovery_action"], "CTRL_C")
         # Ctrl-C 應被送出
@@ -85,7 +85,7 @@ class TestBadCommandRecovery(unittest.TestCase):
         bridge.rx_text_from.return_value = "$ "
 
         resp1 = mgr.execute_command("p:COM0", "broken-cmd", "agent:test", "cid-bad2", timeout_s=0.1)
-        self.assertFalse(resp1["ok"])
+        self.assertTrue(resp1["ok"])
         self.assertEqual(resp1["recovery_action"], "CTRL_C")
         self.assertEqual(session.state, "READY")
 
@@ -125,7 +125,7 @@ class TestBadCommandRecovery(unittest.TestCase):
             resp = mgr.execute_command(
                 "p:COM0", f"bad-{i}", "agent:test", f"cid-bad-{i}", timeout_s=0.1,
             )
-            self.assertFalse(resp["ok"])
+            self.assertTrue(resp["ok"])
             self.assertEqual(resp["recovery_action"], "CTRL_C")
             # 每次 recover 後都回 READY
             self.assertEqual(session.state, "READY")

--- a/tests/test_issue26_interactive_guard.py
+++ b/tests/test_issue26_interactive_guard.py
@@ -1,0 +1,51 @@
+"""Issue #26 測試：recover ok 語義修正（成功恢復 prompt 後回 ok:True）。"""
+from __future__ import annotations
+
+import threading
+import unittest
+from unittest.mock import MagicMock
+
+from sw_core.session_manager import SessionManager
+
+
+class TestRecoverOkTrue(unittest.TestCase):
+    """驗證 _recover_after_failure 成功恢復 prompt 後回 ok: True。"""
+
+    def test_recover_ok_true_on_success(self) -> None:
+        """CTRL_C 成功恢復 prompt 後，回應應包含 ok: True。"""
+        mgr = MagicMock(spec=SessionManager)
+        mgr._lock = threading.RLock()
+        mgr._extract_command_stdout = MagicMock(return_value="partial output")
+        mgr._set_terminal_capture_locked = MagicMock()
+
+        bridge = MagicMock()
+        bridge.rx_snapshot_len.return_value = 0
+        bridge.wait_for_regex_from.return_value = True
+        bridge.rx_text_from.return_value = "partial output"
+
+        session = MagicMock()
+        session.profile = MagicMock()
+        session.profile.prompt_regex = r"\$ $"
+        session.interactive_session_id = None
+        session.bridge = bridge
+
+        result = SessionManager._recover_after_failure(
+            mgr,
+            session,
+            bridge,
+            cmd_id="cmd-999",
+            timeout_s=5.0,
+            source="agent:test",
+            command="bad_cmd",
+            prompt_regex=r"\$ $",
+            pre_offset=0,
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["error_code"], "PROMPT_TIMEOUT_RECOVERED")
+        self.assertTrue(result["partial"])
+        self.assertIn(result["recovery_action"], ("CTRL_C", "CTRL_D"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue27_newline_reject.py
+++ b/tests/test_issue27_newline_reject.py
@@ -1,0 +1,61 @@
+"""Issue #27 — 命令換行符拒絕的單元測試。
+
+驗證 CommandArbiter.submit() 在命令包含嵌入換行符時正確拒絕，
+並確認 CMD_TOO_LONG 優先於 CMD_CONTAINS_NEWLINE。
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from sw_core.arbiter import CMD_REJECT_BYTES, CommandArbiter
+
+
+class TestNewlineReject(unittest.TestCase):
+    """測試 CommandArbiter 對嵌入換行符命令的拒絕行為。"""
+
+    def setUp(self) -> None:
+        self.send_cb = MagicMock(return_value={"ok": True})
+        self.arbiter = CommandArbiter(send_cb=self.send_cb)
+        self.session_id = "test-session"
+        self.arbiter.register_session(self.session_id)
+
+    def tearDown(self) -> None:
+        self.arbiter.unregister_session(self.session_id)
+
+    def _submit(self, command: str) -> dict:
+        return self.arbiter.submit(
+            session_id=self.session_id,
+            command=command,
+            source="agent",
+            mode="foreground",
+            timeout_s=5.0,
+        )
+
+    def test_command_with_newline_rejected(self) -> None:
+        """含嵌入 \\n 的命令應被拒絕，回傳 CMD_CONTAINS_NEWLINE。"""
+        result = self._submit("echo hello\necho world")
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error_code"], "CMD_CONTAINS_NEWLINE")
+
+    def test_command_without_newline_accepted(self) -> None:
+        """不含換行符的正常命令不應被此規則攔截。"""
+        result = self._submit("echo hello")
+        self.assertTrue(result["ok"])
+
+    def test_command_with_only_trailing_newline_rejected(self) -> None:
+        """尾部 \\n 也應被拒絕。"""
+        result = self._submit("echo hello\n")
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error_code"], "CMD_CONTAINS_NEWLINE")
+
+    def test_command_too_long_takes_priority(self) -> None:
+        """超長命令（>16KB）的 CMD_TOO_LONG 應優先於 CMD_CONTAINS_NEWLINE。"""
+        long_cmd = "A" * (CMD_REJECT_BYTES + 1) + "\n"
+        result = self._submit(long_cmd)
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error_code"], "CMD_TOO_LONG")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue28_bg_lifecycle.py
+++ b/tests/test_issue28_bg_lifecycle.py
@@ -1,0 +1,278 @@
+"""Issue #28：background command 在 BackgroundCapture 建立前的 result_tail 回應。
+
+submit() 回傳 cmd_id 後、worker 尚未執行完畢前，
+``command.result_tail`` 應回傳 arbiter 狀態（accepted / running），
+而非 CMD_NOT_FOUND。
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _make_service() -> "SerialwrapService":
+    """建立最小化 SerialwrapService，用 mock 替代所有 I/O 元件。"""
+    from sw_core.config import SessionProfile
+
+    profiles: list[SessionProfile] = []
+    with (
+        patch("sw_core.service.WalWriter"),
+        patch("sw_core.service.SessionManager"),
+        patch("sw_core.service.DeviceWatcher"),
+    ):
+        from sw_core.service import SerialwrapService
+
+        svc = SerialwrapService(profiles)
+    return svc
+
+
+class TestBgResultTailFallback(unittest.TestCase):
+    """測試 command.result_tail 在 BackgroundCapture 不存在時的 arbiter fallback。"""
+
+    def setUp(self) -> None:
+        self.svc = _make_service()
+
+    # ------------------------------------------------------------------
+    # 輔助
+    # ------------------------------------------------------------------
+
+    def _arbiter_rec(self, cmd_id: str, status: str, **overrides) -> dict:
+        """產生 arbiter.get() 的模擬回傳。"""
+        rec = {
+            "cmd_id": cmd_id,
+            "session_id": "COM0",
+            "command": "sleep 999",
+            "source": "agent:a1",
+            "mode": "bg",
+            "execution_mode": "background",
+            "timeout_s": 30.0,
+            "priority": 0,
+            "status": status,
+            "created_at": "2025-01-01T00:00:00Z",
+            "accepted_at": "2025-01-01T00:00:00Z",
+            "started_at": None,
+            "done_at": None,
+            "error_code": None,
+            "stdout": "",
+            "partial": False,
+            "background_capture_id": None,
+            "interactive_session_id": None,
+            "recovery_action": None,
+        }
+        rec.update(overrides)
+        return {"ok": True, "command": rec}
+
+    def _call_result_tail(self, cmd_id: str, from_chunk: int = 0) -> dict:
+        return self.svc.rpc("command.result_tail", {"cmd_id": cmd_id, "from_chunk": from_chunk})
+
+    # ------------------------------------------------------------------
+    # 測試
+    # ------------------------------------------------------------------
+
+    def test_result_tail_before_execution_returns_accepted(self) -> None:
+        """BackgroundCapture 不存在、arbiter status=accepted → ok + 空 chunks。"""
+        cmd_id = "abc123"
+        self.svc._sessions.get_background_result = MagicMock(
+            return_value={"ok": False, "error_code": "CMD_NOT_FOUND", "cmd_id": cmd_id},
+        )
+        self.svc._arbiter.get = MagicMock(
+            return_value=self._arbiter_rec(cmd_id, "accepted"),
+        )
+
+        result = self._call_result_tail(cmd_id)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["status"], "accepted")
+        self.assertIsNone(result["error_code"])
+        self.assertEqual(result["chunks"], [])
+        self.assertEqual(result["from_chunk"], 0)
+        self.assertEqual(result["next_chunk"], 0)
+
+    def test_result_tail_during_execution_returns_running(self) -> None:
+        """BackgroundCapture 不存在、arbiter status=running → ok + 空 chunks。"""
+        cmd_id = "def456"
+        self.svc._sessions.get_background_result = MagicMock(
+            return_value={"ok": False, "error_code": "CMD_NOT_FOUND", "cmd_id": cmd_id},
+        )
+        self.svc._arbiter.get = MagicMock(
+            return_value=self._arbiter_rec(cmd_id, "running"),
+        )
+
+        result = self._call_result_tail(cmd_id)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["status"], "running")
+        self.assertEqual(result["chunks"], [])
+
+    def test_result_tail_after_completion_returns_chunks(self) -> None:
+        """BackgroundCapture 存在時，直接回傳 capture 結果，不走 fallback。"""
+        cmd_id = "ghi789"
+        expected = {
+            "ok": True,
+            "cmd_id": cmd_id,
+            "status": "done",
+            "error_code": None,
+            "from_seq": 100,
+            "last_seq": 105,
+            "from_chunk": 0,
+            "next_chunk": 2,
+            "chunks": ["line1\n", "line2\n"],
+        }
+        self.svc._sessions.get_background_result = MagicMock(return_value=expected)
+        # arbiter.get 不應被呼叫
+        self.svc._arbiter.get = MagicMock()
+
+        result = self._call_result_tail(cmd_id)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["status"], "done")
+        self.assertEqual(result["chunks"], ["line1\n", "line2\n"])
+        self.svc._arbiter.get.assert_not_called()
+
+    def test_result_tail_unknown_cmd_still_not_found(self) -> None:
+        """cmd_id 在 capture 和 arbiter 都不存在 → CMD_NOT_FOUND。"""
+        cmd_id = "nonexistent"
+        self.svc._sessions.get_background_result = MagicMock(
+            return_value={"ok": False, "error_code": "CMD_NOT_FOUND", "cmd_id": cmd_id},
+        )
+        self.svc._arbiter.get = MagicMock(
+            return_value={"ok": False, "error_code": "CMD_NOT_FOUND", "cmd_id": cmd_id},
+        )
+
+        result = self._call_result_tail(cmd_id)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error_code"], "CMD_NOT_FOUND")
+
+    def test_result_tail_error_without_capture(self) -> None:
+        """arbiter status=error 且 BackgroundCapture 從未建立 → 回傳 error 狀態。"""
+        cmd_id = "err001"
+        self.svc._sessions.get_background_result = MagicMock(
+            return_value={"ok": False, "error_code": "CMD_NOT_FOUND", "cmd_id": cmd_id},
+        )
+        self.svc._arbiter.get = MagicMock(
+            return_value=self._arbiter_rec(cmd_id, "error", error_code="SEND_FAILED"),
+        )
+
+        result = self._call_result_tail(cmd_id)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error_code"], "SEND_FAILED")
+        self.assertEqual(result["chunks"], [])
+
+    def test_result_tail_canceled_before_start(self) -> None:
+        """arbiter status=canceled、started_at=None → 回傳 canceled（命令未開始執行）。"""
+        cmd_id = "can001"
+        self.svc._sessions.get_background_result = MagicMock(
+            return_value={"ok": False, "error_code": "CMD_NOT_FOUND", "cmd_id": cmd_id},
+        )
+        self.svc._arbiter.get = MagicMock(
+            return_value=self._arbiter_rec(cmd_id, "canceled"),
+        )
+
+        result = self._call_result_tail(cmd_id)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["status"], "canceled")
+        self.assertEqual(result["chunks"], [])
+
+    def test_result_tail_canceled_after_start_not_synthesized(self) -> None:
+        """arbiter status=canceled 但已開始執行 → CMD_NOT_FOUND（capture 可能稍後建立）。"""
+        cmd_id = "can002"
+        self.svc._sessions.get_background_result = MagicMock(
+            return_value={"ok": False, "error_code": "CMD_NOT_FOUND", "cmd_id": cmd_id},
+        )
+        self.svc._arbiter.get = MagicMock(
+            return_value=self._arbiter_rec(
+                cmd_id, "canceled",
+                started_at="2025-01-01T00:00:01Z",
+            ),
+        )
+
+        result = self._call_result_tail(cmd_id)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error_code"], "CMD_NOT_FOUND")
+
+    def test_result_tail_done_without_capture_still_not_found(self) -> None:
+        """arbiter status=done 但 BackgroundCapture 缺失 → CMD_NOT_FOUND（不遮蓋異常）。"""
+        cmd_id = "done001"
+        self.svc._sessions.get_background_result = MagicMock(
+            return_value={"ok": False, "error_code": "CMD_NOT_FOUND", "cmd_id": cmd_id},
+        )
+        self.svc._arbiter.get = MagicMock(
+            return_value=self._arbiter_rec(cmd_id, "done"),
+        )
+
+        result = self._call_result_tail(cmd_id)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error_code"], "CMD_NOT_FOUND")
+
+    def test_from_chunk_echoed_in_fallback(self) -> None:
+        """fallback 回應的 from_chunk / next_chunk 應反映 caller 的 from_chunk。"""
+        cmd_id = "pg001"
+        self.svc._sessions.get_background_result = MagicMock(
+            return_value={"ok": False, "error_code": "CMD_NOT_FOUND", "cmd_id": cmd_id},
+        )
+        self.svc._arbiter.get = MagicMock(
+            return_value=self._arbiter_rec(cmd_id, "accepted"),
+        )
+
+        result = self._call_result_tail(cmd_id, from_chunk=5)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["from_chunk"], 5)
+        self.assertEqual(result["next_chunk"], 5)
+        self.assertEqual(result["chunks"], [])
+
+    def test_fg_command_not_eligible_for_fallback(self) -> None:
+        """非 background 的命令不走 fallback，仍回 CMD_NOT_FOUND。"""
+        cmd_id = "fg001"
+        self.svc._sessions.get_background_result = MagicMock(
+            return_value={"ok": False, "error_code": "CMD_NOT_FOUND", "cmd_id": cmd_id},
+        )
+        fg_rec = self._arbiter_rec(cmd_id, "running")
+        fg_rec["command"]["execution_mode"] = "line"
+        self.svc._arbiter.get = MagicMock(return_value=fg_rec)
+
+        result = self._call_result_tail(cmd_id)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["error_code"], "CMD_NOT_FOUND")
+
+
+class TestLegacyResultTailFallback(unittest.TestCase):
+    """確保 legacy result.tail（帶 cmd_id）也有相同 fallback。"""
+
+    def setUp(self) -> None:
+        self.svc = _make_service()
+
+    def test_legacy_result_tail_accepted(self) -> None:
+        cmd_id = "leg001"
+        self.svc._sessions.get_background_result = MagicMock(
+            return_value={"ok": False, "error_code": "CMD_NOT_FOUND", "cmd_id": cmd_id},
+        )
+        arb_rec = {
+            "cmd_id": cmd_id, "session_id": "COM0", "command": "sleep 1",
+            "source": "agent:a", "mode": "bg", "execution_mode": "background",
+            "timeout_s": 30.0, "priority": 0, "status": "accepted",
+            "created_at": "", "accepted_at": "", "started_at": None,
+            "done_at": None, "error_code": None, "stdout": "",
+            "partial": False, "background_capture_id": None,
+            "interactive_session_id": None, "recovery_action": None,
+        }
+        self.svc._arbiter.get = MagicMock(
+            return_value={"ok": True, "command": arb_rec},
+        )
+
+        result = self.svc.rpc("result.tail", {"cmd_id": cmd_id})
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["status"], "accepted")
+        self.assertEqual(result["chunks"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_bind.py
+++ b/tests/test_session_bind.py
@@ -112,7 +112,7 @@ class TestSessionBind(unittest.TestCase):
 
         resp = mgr.execute_command("p:COM0", "printf 'broken", "agent:test", "cid-1", timeout_s=0.1)
 
-        self.assertFalse(resp["ok"])
+        self.assertTrue(resp["ok"])
         self.assertEqual(resp["error_code"], "PROMPT_TIMEOUT_RECOVERED")
         self.assertEqual(resp["recovery_action"], "CTRL_C")
         self.assertEqual(bridge.send_command.call_count, 1)


### PR DESCRIPTION
#26: _recover_after_failure 成功恢復 prompt 後回 ok:true（保留 error_code=PROMPT_TIMEOUT_RECOVERED）
#27: arbiter.submit() 拒絕含 \n 的命令，回 CMD_CONTAINS_NEWLINE
#28: _bg_fallback_from_arbiter() 在 BackgroundCapture 建立前回傳 arbiter 狀態

測試：新增 test_issue26/27/28 共 16 個測試，更新既有 recover 測試

Closes #26, Closes #27, Closes #28