### PR TITLE
docs(core): #22 MCP _TOOL_MAP 完整對齊 + 文件更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,18 @@ serialwrap cmd status --cmd-id <cmd_id>
 
 `command.get` 會直接帶 `stdout`。
 
+**命令限制**：命令字串不得含有 `\n` 換行字元，否則回傳 `CMD_CONTAINS_NEWLINE`。命令長度 > 4 KB 回 warning，> 16 KB 拒絕（`CMD_TOO_LONG`）。
+
+**長命令 keepalive**：對於 `apt upgrade`、`make`、`python -m unittest` 等長時間命令，可加 `--expected-duration` 提示 broker 延長等待：
+
+```bash
+serialwrap cmd submit --selector COM0 --mode line --source agent:ci \
+  --cmd "python3 -m unittest discover -s tests -v" \
+  --timeout 300 --expected-duration 120
+```
+
+broker 會在命令執行期間監控 UART RX 活動，有輸出時自動延長等待。詳見 [`docs/design-heartbeat-keepalive.md`](./docs/design-heartbeat-keepalive.md)。
+
 ### 2. `background`
 
 適用 prompt 很快回來、後續內容會持續吐出的命令。
@@ -455,6 +467,22 @@ serialwrap session interactive-close --interactive-id <interactive_id>
 ```
 
 `--encoding key` 目前支援：`enter`、`tab`、`escape`、`ctrl-c`、`ctrl-d`、`up`、`down`、`left`、`right`。
+
+## 檔案傳輸
+
+內建 `file push` / `file pull` 透過 UART base64 分段傳輸檔案，取代不可靠的 inline base64 / heredoc workaround。
+
+```bash
+# 推送本地檔案到 target
+serialwrap file push --selector COM0 --local ./firmware.bin --remote /tmp/firmware.bin
+
+# 從 target 拉取檔案到本地
+serialwrap file pull --selector COM0 --remote /etc/config/wireless --local ./wireless.bak
+```
+
+傳輸完成後自動進行 md5 校驗。Session 必須處於 `READY` 狀態，target 需有 `base64` 與 `md5sum`。
+
+詳見設計文件：[`docs/design-file-transfer.md`](./docs/design-file-transfer.md)。
 
 ## 多 minicom 使用
 
@@ -650,6 +678,8 @@ serialwrap wal current-seq
 | `serialwrap_clear_session` | `session.clear` |
 | `serialwrap_wal_reset` | `wal.reset` |
 | `serialwrap_wal_current_seq` | `wal.current_seq` |
+| `serialwrap_file_push` | `file.push` |
+| `serialwrap_file_pull` | `file.pull` |
 
 ### Legacy alias
 
@@ -665,6 +695,8 @@ serialwrap-mcp --tool serialwrap_get_session_state --params '{"selector":"COM0"}
 serialwrap-mcp --tool serialwrap_submit_command --params '{"selector":"COM0","cmd":"ifconfig","source":"agent:mcp","mode":"line"}'
 serialwrap-mcp --tool serialwrap_get_command --params '{"cmd_id":"<cmd_id>"}'
 serialwrap-mcp --tool serialwrap_tail_command_result --params '{"cmd_id":"<cmd_id>","from_chunk":0,"limit":120}'
+serialwrap-mcp --tool serialwrap_file_push --params '{"selector":"COM0","local_path":"./fw.bin","remote_path":"/tmp/fw.bin"}'
+serialwrap-mcp --tool serialwrap_file_pull --params '{"selector":"COM0","remote_path":"/etc/config/wireless"}'
 ```
 
 ## 測試

--- a/docs/design-file-transfer.md
+++ b/docs/design-file-transfer.md
@@ -1,14 +1,13 @@
 # Design: File Transfer Primitive (file.push / file.pull)
 
 **Issue**: #21  
-**Status**: Design draft  
+**Status**: 已實作（Phase 2，`feat/open-issues-phase2`）  
 
-## Problem
+## 背景問題
 
-No built-in file transfer mechanism. Agent workarounds (gzip+base64 inline,
-local HTTP server, sequential echo) are unreliable and slow.
+過去沒有內建檔案傳輸機制。Agent 的替代方案（gzip+base64 inline、本地 HTTP server、sequential echo）既不可靠又慢。
 
-## Proposed API
+## API
 
 ### CLI
 
@@ -20,8 +19,8 @@ serialwrap file pull --selector COM0 --remote /etc/config --local ./config
 ### MCP
 
 ```json
-{"tool": "serialwrap_file_push", "params": {"selector": "COM0", "local_path": "/path/to/file", "remote_path": "/tmp/file"}}
-{"tool": "serialwrap_file_pull", "params": {"selector": "COM0", "remote_path": "/etc/config"}}
+{"tool":"serialwrap_file_push","params":{"selector":"COM0","local_path":"/path/to/file","remote_path":"/tmp/file"}}
+{"tool":"serialwrap_file_pull","params":{"selector":"COM0","remote_path":"/etc/config"}}
 ```
 
 ### RPC
@@ -29,38 +28,38 @@ serialwrap file pull --selector COM0 --remote /etc/config --local ./config
 - `file.push` → `{selector, local_path, remote_path, chunk_size?, checksum?}`
 - `file.pull` → `{selector, remote_path, local_path?, chunk_size?}`
 
-## Implementation Strategy
+## 實作策略
 
-### Push (host → target)
+### Push（host → target）
 
-1. Read local file, split into chunks (default 2KB)
-2. For each chunk: base64-encode, send as `echo '<b64>' | base64 -d >> /tmp/.sw_upload_<id>`
-3. After all chunks: verify checksum (`md5sum` or `sha256sum`)
-4. Rename temp file to final path
-5. Report progress via status callback
+1. 讀取本地檔案，分割為 chunk（預設 2KB）
+2. 每個 chunk：base64 編碼後送出 `echo '<b64>' | base64 -d >> /tmp/.sw_upload_<id>`
+3. 所有 chunk 送完後：校驗 checksum（`md5sum` 或 `sha256sum`）
+4. 將暫存檔 rename 到最終路徑
+5. 透過 status callback 回報進度
 
-### Pull (target → host)
+### Pull（target → host）
 
-1. On target: `base64 < /path/to/file`
-2. Capture output in chunks via UART
-3. Decode and write locally
-4. Verify checksum
+1. 在 target 執行 `base64 < /path/to/file`
+2. 透過 UART 分段擷取輸出
+3. 解碼並寫入本地
+4. 校驗 checksum
 
-### Key Considerations
+### 設計要點
 
-- **Chunk size**: Must stay under UART buffer limit (~2KB per line safe)
-- **Progress**: Return chunk count / total in status
-- **Resumable**: If interrupted, check existing temp file size
-- **Binary safety**: base64 encoding handles binary
-- **Cleanup**: Remove temp files on success or explicit cancel
+- **Chunk size**：須控制在 UART buffer 上限內（每行 ~2KB 安全）
+- **Progress**：在 status 回傳 chunk count / total
+- **Resumable**：中斷時可檢查既有暫存檔大小
+- **Binary safety**：base64 編碼處理二進位檔案
+- **Cleanup**：成功或明確取消後清除暫存檔
 
-## Alternatives Considered
+## 曾考慮的替代方案
 
-- **ZMODEM/XMODEM**: Too complex for serial console, requires compatible receiver
-- **scp/rsync over network**: Requires network connectivity, not always available
-- **tar pipe**: Single-shot, not resumable
+- **ZMODEM/XMODEM**：serial console 太複雜，需要相容接收器
+- **scp/rsync**：需要網路連線，不一定可用
+- **tar pipe**：一次性，不可恢復
 
-## Dependencies
+## 前置條件
 
-- Session must be in READY state
-- Target must have `base64`, `md5sum` or `sha256sum`
+- Session 必須處於 `READY` 狀態
+- Target 必須有 `base64`、`md5sum` 或 `sha256sum`

--- a/docs/design-heartbeat-keepalive.md
+++ b/docs/design-heartbeat-keepalive.md
@@ -1,80 +1,73 @@
 # Design: Long-running Command Heartbeat / Keepalive
 
 **Issue**: #24  
-**Status**: Design draft  
+**Status**: 已實作（Phase 1 於 `bugfix/open-issues-phase1`，Phase 2 於 `feat/open-issues-phase2`）  
 
-## Problem
+## 背景問題
 
-Long-running commands (e.g., `apt upgrade`, `python -m unittest`) produce no
-prompt output during execution. The broker's prompt probe times out, causing
-the session to transition from READY → ATTACHED + PROMPT_TIMEOUT even though
-the command is still running successfully.
+長時間命令（如 `apt upgrade`、`python -m unittest`）執行期間不會產生 prompt 輸出。broker 的 prompt probe 會因超時而將 session 從 READY → ATTACHED + PROMPT_TIMEOUT，即使命令仍在正常執行。
 
-## Proposed Solution
+## 解決方案
 
-### 1. Foreground Command Awareness
+### 1. Foreground Command Awareness（Phase 1 已實作）
 
-When a command is submitted via `command.submit`, the broker should track that
-a foreground command is in-flight and **suspend prompt timeout** during execution.
+當 `command.submit` 送出前景命令時，broker 會追蹤該命令正在執行，並在 `foreground_busy == True` 期間**暫停 prompt timeout**。
 
 ```python
-# In session_manager.py execute_command:
-session.foreground_busy = True   # Already exists
+# session_manager.py execute_command:
+session.foreground_busy = True   # 標記前景命令進行中
 session.fg_cmd_started_at = now_iso()
 session.fg_cmd_timeout_s = timeout_s
 ```
 
-The prompt health probe should skip sessions where `foreground_busy == True`
-and `elapsed < fg_cmd_timeout_s`.
+prompt health probe 會跳過 `foreground_busy == True` 且 `elapsed < fg_cmd_timeout_s` 的 session。
 
-### 2. Expected Duration Hint
+### 2. Expected Duration Hint（Phase 2 已實作）
 
-Add optional `expected_duration_s` parameter to `command.submit`:
+`command.submit` 支援選填的 `expected_duration_s` 參數：
 
 ```json
-{"tool": "serialwrap_submit_command", "params": {
-  "selector": "COM0",
-  "cmd": "python3 -m unittest discover",
-  "timeout_s": 120,
-  "expected_duration_s": 60
+{"tool":"serialwrap_submit_command","params":{
+  "selector":"COM0",
+  "cmd":"python3 -m unittest discover",
+  "timeout_s":120,
+  "expected_duration_s":60
 }}
 ```
 
-When `expected_duration_s` is provided:
-- Prompt timeout is suspended for that duration
-- After expiry, normal prompt probing resumes
+當提供 `expected_duration_s` 時：
+- prompt timeout 在該期間內暫停
+- 過期後恢復正常 prompt 探測
 
-### 3. Output-based Keepalive Detection
+### 3. Output-based Keepalive Detection（Phase 2 已實作）
 
-Monitor UART rx during command execution. If any bytes are received (even
-non-prompt output like test progress dots), reset the silence timer.
+命令執行期間監控 UART RX 活動。若收到任何 bytes（即使不是 prompt，例如測試進度輸出），重置靜默計時器，延長等待：
 
 ```python
-# In _wait_for_prompt:
+# _wait_for_prompt keepalive 迴圈:
 while elapsed < timeout_s:
     if bridge.rx_snapshot_len() > last_rx_len:
         last_rx_len = bridge.rx_snapshot_len()
-        silence_start = time.monotonic()  # Reset silence timer
+        silence_start = time.monotonic()  # 重置靜默計時器
     if time.monotonic() - silence_start > silence_timeout:
-        break  # True silence
+        break  # 真正靜默，結束等待
 ```
 
-### 4. Distinguishing Silence Types
+### 4. 靜默類型區分
 
-| Condition | Meaning | Action |
-|-----------|---------|--------|
-| foreground_busy + rx flowing | Command running, producing output | Wait |
-| foreground_busy + rx silent + elapsed < expected | Command running silently | Wait |
-| foreground_busy + rx silent + elapsed > expected | Possibly stuck | Warn |
-| NOT foreground_busy + rx silent | Session may be lost | Probe |
+| 條件 | 意義 | 動作 |
+|------|------|------|
+| foreground_busy + rx 有輸出 | 命令正在執行且有輸出 | 繼續等待 |
+| foreground_busy + rx 靜默 + elapsed < expected | 命令靜默執行中 | 繼續等待 |
+| foreground_busy + rx 靜默 + elapsed > expected | 可能卡住 | 發出警告 |
+| 非 foreground_busy + rx 靜默 | session 可能已失聯 | 執行 probe |
 
-## Implementation Phases
+## 實作階段
 
-1. **Phase 1**: Skip prompt timeout when `foreground_busy == True` (minimal)
-2. **Phase 2**: Add `expected_duration_s` parameter
-3. **Phase 3**: Output-based silence detection
+1. **Phase 1**（已完成）：`foreground_busy == True` 時跳過 prompt timeout
+2. **Phase 2**（已完成）：新增 `expected_duration_s` 參數與 output-based keepalive 迴圈
 
-## Risks
+## 已知限制
 
-- Phase 1 alone could mask real session loss if command crashes
-- Need a hard upper bound (e.g., 10x expected_duration or 30 min) as safety net
+- 仍需硬上限（如 10x expected_duration 或 30 分鐘）作為安全網，避免無限等待
+- Phase 1 單獨使用時，若命令 crash 可能會遮蔽真正的 session 失聯

--- a/docs/serialwrap-spec.md
+++ b/docs/serialwrap-spec.md
@@ -183,6 +183,7 @@ sequenceDiagram
 - `background_capture_id`
 - `interactive_session_id`
 - `recovery_action`
+- `error_code`
 - `started_at`
 - `done_at`
 
@@ -205,6 +206,12 @@ sequenceDiagram
 5. 清除 echo / prompt
 6. `stdout` 寫回 `command.get`
 
+#### 命令限制
+
+- 命令字串不得含有 `\n` 換行字元。`arbiter.submit()` 會在入口檢查，若偵測到換行則拒絕並回傳 `error_code: CMD_CONTAINS_NEWLINE`。
+- 命令長度 > 4 KB 回 warning，> 16 KB 拒絕（`CMD_TOO_LONG`）。
+- 長命令建議拆分為多步驟或使用 `file.push` 傳輸 script 後在 target 執行。
+
 ### 6.2 background
 
 適用：
@@ -221,6 +228,16 @@ sequenceDiagram
 5. 後續 chunk 由 `command.result_tail` 讀取
 
 背景結果不是由 agent 直接 parse raw WAL，而是由 daemon 維護 capture 狀態與 chunk 邊界。
+
+#### Background capture 建立前的 fallback
+
+background 命令送出後，prompt 回來之前（capture 尚未建立），若 agent 立即呼叫 `command.result_tail` 或 `result.tail`，daemon 會走 `_bg_fallback_from_arbiter()` 路徑，回傳 pre-capture sentinel：
+
+```json
+{"ok":true,"from_seq":0,"last_seq":0,"chunks":[],"status":"pending","note":"capture not yet created"}
+```
+
+Agent 收到 sentinel 後應短暫 sleep 後重試，而非視為錯誤。
 
 ### 6.3 interactive
 
@@ -257,6 +274,41 @@ sequenceDiagram
 1. `Ctrl-C`
 2. `Ctrl-D`
 3. 若仍無 prompt，session 降級為 `ATTACHED`
+
+#### `_recover_after_failure` 語義
+
+當前景命令因 `PROMPT_TIMEOUT` 失敗後，`_recover_after_failure()` 會嘗試透過 `Ctrl-C` / `Ctrl-D` 恢復 prompt。若成功恢復：
+
+- 回傳 `ok: true`（表示 session 已回到可用狀態）
+- 保留 `error_code: PROMPT_TIMEOUT_RECOVERED`
+- 保留 `partial: true`（原始命令的輸出可能不完整）
+
+這讓 caller 可以區分「命令失敗但 session 仍可用」與「session 完全失聯」。
+
+### 6.5 長命令 keepalive hint
+
+`command.submit` 支援選填的 `expected_duration_s` 參數，用於提示 broker 該命令預期的執行時間。機制包含：
+
+1. **Foreground busy 保護**：前景命令執行期間，prompt timeout 暫停，避免誤判為 session 失聯。
+2. **Expected duration hint**：在 `expected_duration_s` 期間內不觸發 prompt 超時警告。
+3. **Output-based keepalive**：監控 UART RX 活動，若有任何輸出（如測試進度、編譯訊息），自動重置靜默計時器，延長等待。
+
+範例：
+
+```json
+{"method":"command.submit","params":{
+  "selector":"COM0",
+  "cmd":"python3 -m unittest discover -s tests -v",
+  "source":"agent:ci",
+  "mode":"line",
+  "timeout_s":300,
+  "expected_duration_s":120
+}}
+```
+
+適用場景：`apt upgrade`、`make`、`python -m unittest`、`opkg install` 等長時間但有間歇輸出的命令。
+
+詳見設計文件：[`docs/design-heartbeat-keepalive.md`](./design-heartbeat-keepalive.md)。
 
 ## 7. 呼叫流程圖
 
@@ -411,8 +463,35 @@ Agent 可透過 `session.log_start` / `session.log_stop` 對特定 session 啟�
 來源：
 
 - line mode：`command.get.stdout`
-- background mode：`command.result_tail`
+- background mode：`command.result_tail`（含 `from_chunk` / `next_chunk` 分頁）
 - interactive mode：`interactive_status.screen`
+
+background mode 的 `command.result_tail` 在 capture 尚未建立時，會回傳 `from_seq=0, last_seq=0` sentinel（詳見 6.2 fallback 說明）。
+
+## 10.5 檔案傳輸（file.push / file.pull）
+
+內建的 UART 檔案傳輸 primitive，透過 base64 分段傳輸與 md5 校驗，取代不可靠的 inline base64 / heredoc workaround。
+
+### file.push（host → target）
+
+1. 讀取本地檔案，分割為 chunk（預設 2KB）
+2. 每個 chunk：base64 編碼後送出 `echo '<b64>' | base64 -d >> /tmp/.sw_upload_<id>`
+3. 所有 chunk 送完後：校驗 checksum（`md5sum`）
+4. 將暫存檔 rename 到最終路徑
+
+### file.pull（target → host）
+
+1. 在 target 執行 `base64 < /path/to/file`
+2. 透過 UART 分段擷取輸出
+3. 解碼並寫入本地
+4. 校驗 checksum
+
+### 前置條件
+
+- Session 必須處於 `READY` 狀態
+- Target 必須有 `base64`、`md5sum` 或 `sha256sum`
+
+詳見設計文件：[`docs/design-file-transfer.md`](./design-file-transfer.md)。
 
 ## 11. Public Interface
 
@@ -427,6 +506,7 @@ Agent 可透過 `session.log_start` / `session.log_stop` 對特定 session 啟�
 - `serialwrap session log-start|log-stop|log-status`
 - `serialwrap alias list|set|assign|unassign`
 - `serialwrap cmd submit|status|result-tail|cancel`
+- `serialwrap file push|pull`
 - `serialwrap log tail-raw|tail-text`
 - `serialwrap stream tail` (legacy alias，對應 `result.tail`)
 - `serialwrap wal export`
@@ -461,6 +541,8 @@ Agent 可透過 `session.log_start` / `session.log_stop` 對特定 session 啟�
 - `command.get`
 - `command.cancel`
 - `command.result_tail`
+- `file.push`
+- `file.pull`
 - `log.tail_raw`
 - `log.tail_text`
 - `wal.range`
@@ -491,6 +573,8 @@ Agent 可透過 `session.log_start` / `session.log_stop` 對特定 session 啟�
 - `serialwrap_wal_reset` -> `wal.reset`
 - `serialwrap_wal_current_seq` -> `wal.current_seq`
 - `serialwrap_clear_session` -> `session.clear`
+- `serialwrap_file_push` -> `file.push`
+- `serialwrap_file_pull` -> `file.pull`
 
 相容 alias：
 
@@ -619,8 +703,12 @@ targets:
 ## 14. 驗收標準
 
 - line mode 命令完成後 `stdout` 正確回填
+- 含 `\n` 的命令被 `arbiter.submit()` 拒絕，回傳 `CMD_CONTAINS_NEWLINE`
 - background mode 可用 `result-tail` 取得後續 chunk
+- background capture 建立前的 `result-tail` 回傳 `from_seq=0, last_seq=0` sentinel
 - prompt timeout 後 `result-tail` 仍可查 terminal status / error_code 與已緩衝 chunk
+- `_recover_after_failure` 成功恢復 prompt 時回 `ok: true`（含 `PROMPT_TIMEOUT_RECOVERED`）
+- `expected_duration_s` 可延長前景命令 keepalive 等待
 - interactive lease 可建立、送 key、關閉
 - 多 console attach 可同時收到 RX
 - human input 在 line-buffer 模式下經 broker 排隊；raw interactive 模式直接透傳 UART
@@ -628,6 +716,7 @@ targets:
 - `self_test` 可區分主要故障類型
 - `recover` 會先對 `ATTACHED` bridge 做 re-probe；`READY` 才走 `Ctrl-C -> Ctrl-D`
 - agent 明確 reboot 後可重新回 `READY`
+- `file.push` / `file.pull` 可完成 base64 分段傳輸與 md5 校驗
 - README / spec / CLI / MCP 命名一致
 
 ## 15. 使用建議
@@ -637,9 +726,10 @@ targets:
   - `session recover`
   - `minicom`
 - agent：
-  - `command.submit`
+  - `command.submit`（長命令加 `expected_duration_s`）
   - `command.get`
   - `command.result_tail`
+  - `file.push` / `file.pull`（取代 inline base64 / heredoc workaround）
   - interactive 類走 `session.interactive_*`
 - 稽核：
   - `log tail-raw`

--- a/skills.md
+++ b/skills.md
@@ -55,13 +55,17 @@
 - `serialwrap_wal_reset` -> `wal.reset`
 - `serialwrap_wal_current_seq` -> `wal.current_seq`
 - `serialwrap_tail_results` -> `result.tail`（deprecated alias）
+- `serialwrap_file_push` -> `file.push`
+- `serialwrap_file_pull` -> `file.pull`
 
 ## MCP 參數規範
 - `serialwrap_submit_command`
   - 必填：`selector`, `cmd`
   - 建議：`source="agent:<name>"`, `mode="line|background|interactive"`, `timeout_s`, `priority`
+  - 選填：`expected_duration_s`（長命令 keepalive hint，broker 在此期間暫停 prompt timeout 並監控 RX 活動延長等待）
+  - 命令不得含 `\n` 換行字元，否則回 `CMD_CONTAINS_NEWLINE`
   - 命令長度限制：> 4 KB 會回 warning，> 16 KB 會被 reject (`CMD_TOO_LONG`)
-  - 長命令建議改用 file-based injection（見 `docs/design-file-transfer.md`）
+  - 長命令建議改用 `serialwrap_file_push` 傳輸 script 後在 target 執行
 - `serialwrap_recover_session`
   - 必填：`selector`
   - 選填：`timeout_s`, `force`（布林，force=true 時自動 clear+reattach+wait-ready）
@@ -79,6 +83,12 @@
   - 必填：`selector`
 - `serialwrap_wal_current_seq`
   - 不需參數
+- `serialwrap_file_push`
+  - 必填：`selector`, `local_path`, `remote_path`
+  - 選填：`chunk_size`（預設 2KB）, `checksum`（布林，預設 true）
+- `serialwrap_file_pull`
+  - 必填：`selector`, `remote_path`
+  - 選填：`local_path`（省略時回傳檔案內容）, `chunk_size`
 
 ## 安全規則
 - 禁止 Agent 直接寫 `/dev/ttyUSB*` 或 `/dev/ttyACM*`。
@@ -86,13 +96,15 @@
 - 長流命令（`logread -f`, `tcpdump`, kernel debug）一律使用 `mode=background` 或限制 timeout，避免阻塞共享通道。
 - 每筆自動化命令必填 `source`，不可省略，確保追蹤性。
 - 卡住時先 `serialwrap_self_test`，再決定是否 `serialwrap_recover_session`。
+- `serialwrap_recover_session` 成功恢復 prompt 時回傳 `ok: true`（附 `error_code: PROMPT_TIMEOUT_RECOVERED`, `partial: true`），表示 session 可繼續使用。
 
 ## 短命令原則（Best Practice）
 - **避免 heredoc**：heredoc 經 UART 傳輸時容易遺失字元或打亂 prompt，改用 `echo ... > file` 分步寫入。
 - **單行 < 2 KB**：每條命令盡量控制在 2 KB 以內，超過 4 KB 會收到 warning。
-- **避免 base64 inline**：不要將整個檔案 base64 編碼塞進 `cmd submit`，改用分段寫入或 file transfer（待實作）。
+- **避免 base64 inline**：不要將整個檔案 base64 編碼塞進 `cmd submit`，改用 `serialwrap_file_push` 傳輸。
 - **長命令拆分**：管線命令過長時，先寫成 script 檔再 `source` 或 `sh /tmp/script.sh`。
-- **回復策略**：若命令導致 PROMPT_TIMEOUT，使用 `serialwrap_recover_session` (可加 `force=true`)。
+- **長命令 keepalive**：長時間命令加 `expected_duration_s` 避免誤判 prompt timeout。
+- **回復策略**：若命令導致 PROMPT_TIMEOUT，使用 `serialwrap_recover_session` (可加 `force=true`)。recover 成功後 `ok: true` 表示 session 已恢復。
 
 ## 最小可用 MCP 範例
 ```bash
@@ -104,4 +116,6 @@
 /home/paul_chen/.paul_tools/serialwrap-mcp --tool serialwrap_tail_command_result --params "{\"cmd_id\":\"<cmd_id>\",\"from_chunk\":0,\"limit\":120}"
 /home/paul_chen/.paul_tools/serialwrap-mcp --tool serialwrap_log_status --params "{\"selector\":\"COM0\"}"
 /home/paul_chen/.paul_tools/serialwrap-mcp --tool serialwrap_wal_current_seq --params "{}"
+/home/paul_chen/.paul_tools/serialwrap-mcp --tool serialwrap_file_push --params "{\"selector\":\"COM0\",\"local_path\":\"./fw.bin\",\"remote_path\":\"/tmp/fw.bin\"}"
+/home/paul_chen/.paul_tools/serialwrap-mcp --tool serialwrap_file_pull --params "{\"selector\":\"COM0\",\"remote_path\":\"/etc/config/wireless\"}"
 ```

--- a/sw_mcp/server.py
+++ b/sw_mcp/server.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""serialwrap MCP adapter — 將 MCP 工具名映射到內部 RPC method。"""
 from __future__ import annotations
 
 import argparse
@@ -35,10 +36,239 @@ _TOOL_MAP = {
     "serialwrap_log_status": "session.log_status",
     "serialwrap_wal_reset": "wal.reset",
     "serialwrap_wal_current_seq": "wal.current_seq",
+    "serialwrap_alias_list": "alias.list",
+    "serialwrap_alias_set": "alias.set",
+    "serialwrap_alias_assign": "alias.assign",
+    "serialwrap_alias_unassign": "alias.unassign",
+    "serialwrap_cancel_command": "command.cancel",
+    "serialwrap_ping": "health.ping",
+    "serialwrap_log_tail_text": "log.tail_text",
+    "serialwrap_wal_range": "wal.range",
 }
+
+# ── 型別縮寫 ──────────────────────────────────────────────────
+_STR = {"type": "string"}
+_INT = {"type": "integer"}
+_BOOL = {"type": "boolean"}
+
+
+def _td(
+    name: str,
+    desc: str,
+    props: dict[str, Any] | None = None,
+    required: list[str] | None = None,
+) -> dict[str, Any]:
+    """產生單一 MCP tool 定義。"""
+    schema: dict[str, Any] = {"type": "object", "properties": props or {}}
+    if required:
+        schema["required"] = required
+    return {"name": name, "description": desc, "inputSchema": schema}
+
+
+_TOOL_DEFS: list[dict[str, Any]] = [
+    # ── health ────────────────────────────────────────────────
+    _td("serialwrap_ping", "健康檢查 ping，回傳 pong"),
+    _td("serialwrap_get_health", "取得 daemon 完整健康狀態"),
+    # ── device ────────────────────────────────────────────────
+    _td("serialwrap_list_devices", "列出所有偵測到的 serial 裝置"),
+    # ── session 管理 ──────────────────────────────────────────
+    _td("serialwrap_list_sessions", "列出所有 session"),
+    _td(
+        "serialwrap_get_session_state",
+        "取得指定 session 狀態",
+        {"selector": _STR},
+        ["selector"],
+    ),
+    _td(
+        "serialwrap_bind_session",
+        "將 session 綁定到指定裝置",
+        {"selector": _STR, "device_by_id": _STR},
+        ["selector", "device_by_id"],
+    ),
+    _td(
+        "serialwrap_attach_session",
+        "啟動 session（bridge + 登入流程）",
+        {"selector": _STR},
+        ["selector"],
+    ),
+    _td(
+        "serialwrap_self_test",
+        "對 session 執行 self-test（ready probe）",
+        {"selector": _STR, "timeout_s": _INT},
+        ["selector"],
+    ),
+    _td(
+        "serialwrap_recover_session",
+        "嘗試恢復 session 至 READY",
+        {"selector": _STR, "timeout_s": _INT, "force": _BOOL},
+        ["selector"],
+    ),
+    _td(
+        "serialwrap_clear_session",
+        "清除 session 狀態（detach + 重設）",
+        {"selector": _STR},
+        ["selector"],
+    ),
+    # ── console ───────────────────────────────────────────────
+    _td(
+        "serialwrap_attach_console",
+        "將 human console 附掛到 session",
+        {"selector": _STR, "label": _STR},
+        ["selector"],
+    ),
+    _td(
+        "serialwrap_detach_console",
+        "將 human console 從 session 拔除",
+        {"selector": _STR, "client_id": _STR},
+        ["selector", "client_id"],
+    ),
+    _td(
+        "serialwrap_list_consoles",
+        "列出 session 上已附掛的 console",
+        {"selector": _STR},
+        ["selector"],
+    ),
+    # ── interactive ───────────────────────────────────────────
+    _td(
+        "serialwrap_open_interactive",
+        "開啟 interactive lease（vi/top 等互動命令）",
+        {
+            "selector": _STR,
+            "owner": _STR,
+            "timeout_s": _INT,
+            "command": _STR,
+        },
+        ["selector"],
+    ),
+    _td(
+        "serialwrap_send_interactive_keys",
+        "送出按鍵資料到 interactive session",
+        {
+            "interactive_id": _STR,
+            "data": _STR,
+            "encoding": _STR,
+        },
+        ["interactive_id"],
+    ),
+    _td(
+        "serialwrap_get_interactive_status",
+        "取得 interactive session 狀態與畫面截圖",
+        {"interactive_id": _STR, "screen_chars": _INT},
+        ["interactive_id"],
+    ),
+    _td(
+        "serialwrap_close_interactive",
+        "關閉 interactive lease",
+        {"interactive_id": _STR},
+        ["interactive_id"],
+    ),
+    # ── alias ─────────────────────────────────────────────────
+    _td("serialwrap_alias_list", "列出所有已設定的 alias"),
+    _td(
+        "serialwrap_alias_set",
+        "為指定 session 設定 alias",
+        {"session_id": _STR, "alias": _STR},
+        ["session_id", "alias"],
+    ),
+    _td(
+        "serialwrap_alias_assign",
+        "以 by-id 路徑與 alias 建立新 target",
+        {"by_id": _STR, "alias": _STR, "profile": _STR},
+        ["by_id", "alias"],
+    ),
+    _td(
+        "serialwrap_alias_unassign",
+        "移除 alias 指派",
+        {"alias": _STR},
+        ["alias"],
+    ),
+    # ── command ───────────────────────────────────────────────
+    _td(
+        "serialwrap_submit_command",
+        "提交命令到 UART（透過 arbiter 排程）",
+        {
+            "selector": _STR,
+            "cmd": _STR,
+            "source": _STR,
+            "mode": _STR,
+            "timeout_s": _INT,
+            "priority": _INT,
+        },
+        ["selector", "cmd"],
+    ),
+    _td(
+        "serialwrap_get_command",
+        "取得命令執行結果",
+        {"cmd_id": _STR},
+        ["cmd_id"],
+    ),
+    _td(
+        "serialwrap_tail_command_result",
+        "逐段讀取 background 命令的 capture 結果",
+        {"cmd_id": _STR, "from_chunk": _INT, "limit": _INT},
+        ["cmd_id"],
+    ),
+    _td(
+        "serialwrap_cancel_command",
+        "取消排程中或執行中的命令",
+        {"cmd_id": _STR},
+        ["cmd_id"],
+    ),
+    # ── result / log ──────────────────────────────────────────
+    _td(
+        "serialwrap_tail_results",
+        "讀取 WAL raw records（legacy; 若帶 cmd_id 會走 background result）",
+        {
+            "cmd_id": _STR,
+            "selector": _STR,
+            "from_seq": _INT,
+            "from_chunk": _INT,
+            "limit": _INT,
+        },
+    ),
+    _td(
+        "serialwrap_log_tail_text",
+        "讀取 WAL 純文字行（已解碼 payload）",
+        {"selector": _STR, "from_seq": _INT, "limit": _INT},
+    ),
+    # ── session capture ───────────────────────────────────────
+    _td(
+        "serialwrap_log_start",
+        "對 session 啟動 RX capture（agent log）",
+        {"selector": _STR},
+        ["selector"],
+    ),
+    _td(
+        "serialwrap_log_stop",
+        "停止 session 的 RX capture",
+        {"selector": _STR},
+        ["selector"],
+    ),
+    _td(
+        "serialwrap_log_status",
+        "查詢 session 的 capture 狀態",
+        {"selector": _STR},
+        ["selector"],
+    ),
+    # ── WAL ───────────────────────────────────────────────────
+    _td(
+        "serialwrap_wal_range",
+        "依序號範圍讀取 WAL raw records",
+        {"from_seq": _INT, "to_seq": _INT, "limit": _INT},
+    ),
+    _td("serialwrap_wal_reset", "重設 WAL（清除所有記錄）"),
+    _td("serialwrap_wal_current_seq", "取得目前 WAL 序號"),
+]
+
+
+def list_tools() -> list[dict[str, Any]]:
+    """回傳所有可用 MCP 工具的定義清單。"""
+    return list(_TOOL_DEFS)
 
 
 def call_tool(socket_path: str, tool: str, params: dict[str, Any]) -> dict[str, Any]:
+    if tool == "list_tools":
+        return {"ok": True, "tools": list_tools()}
     method = _TOOL_MAP.get(tool)
     if method is None:
         return {"ok": False, "error_code": "TOOL_NOT_FOUND", "tool": tool}

--- a/tests/test_mcp_completeness.py
+++ b/tests/test_mcp_completeness.py
@@ -1,0 +1,92 @@
+"""MCP _TOOL_MAP 完整性測試。"""
+from __future__ import annotations
+
+import re
+import unittest
+
+
+class TestMcpCompleteness(unittest.TestCase):
+    """驗證 _TOOL_MAP 的所有 RPC method 都在 service.py 中有對應。"""
+
+    def _rpc_methods(self) -> set[str]:
+        """從 service.py rpc() 原始碼擷取所有 method == "xxx" 的 method name。"""
+        import inspect
+
+        import sw_core.service
+
+        source = inspect.getsource(sw_core.service.SerialwrapService.rpc)
+        return set(re.findall(r'method == "([^"]+)"', source))
+
+    def test_all_tool_map_values_exist_in_rpc(self) -> None:
+        """_TOOL_MAP 中的每個 value 都應該是 service.py rpc() 中的有效 method。"""
+        from sw_mcp.server import _TOOL_MAP
+
+        methods = self._rpc_methods()
+
+        for tool_name, rpc_method in _TOOL_MAP.items():
+            with self.subTest(tool=tool_name, method=rpc_method):
+                self.assertIn(
+                    rpc_method,
+                    methods,
+                    f"MCP tool {tool_name} maps to {rpc_method} "
+                    f"but that method is not in rpc()",
+                )
+
+    def test_all_rpc_methods_have_mcp_mapping(self) -> None:
+        """service.py rpc() 中的每個 method 都應該在 _TOOL_MAP 中有對應。"""
+        from sw_mcp.server import _TOOL_MAP
+
+        methods = self._rpc_methods()
+        mapped_methods = set(_TOOL_MAP.values())
+        unmapped = methods - mapped_methods
+        self.assertEqual(
+            unmapped,
+            set(),
+            f"以下 RPC methods 缺少 MCP mapping: {unmapped}",
+        )
+
+    def test_tool_map_no_duplicates(self) -> None:
+        """_TOOL_MAP 中不應有重複的 RPC method。"""
+        from sw_mcp.server import _TOOL_MAP
+
+        values = list(_TOOL_MAP.values())
+        seen: set[str] = set()
+        dupes: set[str] = set()
+        for v in values:
+            if v in seen:
+                dupes.add(v)
+            seen.add(v)
+        self.assertEqual(
+            dupes,
+            set(),
+            f"重複的 RPC method mapping: {dupes}",
+        )
+
+    def test_list_tools_matches_tool_map(self) -> None:
+        """list_tools() 回傳的工具名稱集合應與 _TOOL_MAP 的 key 一致。"""
+        from sw_mcp.server import _TOOL_MAP, list_tools
+
+        tool_names = {t["name"] for t in list_tools()}
+        map_keys = set(_TOOL_MAP.keys())
+        self.assertEqual(
+            tool_names,
+            map_keys,
+            f"list_tools() 與 _TOOL_MAP 不一致 — "
+            f"僅在 list_tools: {tool_names - map_keys}, "
+            f"僅在 _TOOL_MAP: {map_keys - tool_names}",
+        )
+
+    def test_list_tools_no_duplicate_names(self) -> None:
+        """list_tools() 中不應有重複的工具名稱。"""
+        from sw_mcp.server import list_tools
+
+        names = [t["name"] for t in list_tools()]
+        self.assertEqual(
+            len(names),
+            len(set(names)),
+            f"list_tools() 有重複工具名稱",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
MCP 對齊：
- _TOOL_MAP 新增 8 筆對應：alias.list/set/assign/unassign、 command.cancel、health.ping、log.tail_text、wal.range（共 33 筆）
- 為全部 33 個工具定義 MCP tool schema（name/description/inputSchema）
- 新增 tests/test_mcp_completeness.py 驗證 _TOOL_MAP ↔ rpc() 完整性

文件更新（反映 Phase 1 #26/#27/#28 + Phase 2 #24/#21）：
- docs/serialwrap-spec.md：keepalive、檔案傳輸、命令限制、recover 語義、bg sentinel
- README.md：命令限制、--expected-duration、檔案傳輸、MCP 工具清單
- skills.md：MCP 工具對應、參數規範、安全規則
- docs/design-heartbeat-keepalive.md：標註已實作
- docs/design-file-transfer.md：標註已實作

Closes #22