### PR TITLE
fix(file_transfer): strip ANSI escape sequences from base64 before decode

### DIFF
--- a/sw_core/event_engine/line_buffer.py
+++ b/sw_core/event_engine/line_buffer.py
@@ -1,12 +1,6 @@
 from __future__ import annotations
 
-import re
-
-_ANSI_RE = re.compile(r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*\x07|[@-Z\\-_])")
-
-
-def strip_ansi(text: str) -> str:
-    return _ANSI_RE.sub("", text)
+from sw_core.util import strip_ansi  # noqa: F401 – re-exported for callers
 
 
 class LineBuffer:

--- a/sw_core/file_transfer.py
+++ b/sw_core/file_transfer.py
@@ -9,6 +9,8 @@ import shlex
 import uuid
 from typing import TYPE_CHECKING, Any
 
+from .util import strip_ansi
+
 if TYPE_CHECKING:
     from .uart_io import UARTBridge
 
@@ -197,5 +199,5 @@ def _extract_between_sentinels(text: str) -> str | None:
     if begin_idx < 0 or end_idx < 0 or end_idx <= begin_idx:
         return None
     content = text[begin_idx + len(_SENTINEL_BEGIN) : end_idx]
-    # 去除空白與換行，只保留有效 base64 字元
-    return re.sub(r"\s+", "", content)
+    # 去除 ANSI 逸出序列（顏色、游標控制、括弧貼上模式等），再去除空白
+    return re.sub(r"\s+", "", strip_ansi(content))

--- a/sw_core/util.py
+++ b/sw_core/util.py
@@ -35,6 +35,13 @@ def to_printable(data: bytes) -> str:
 
 _ANSI_RE = re.compile(r"\x1B\[[0-9;?]*[A-Za-z]")
 _OSC_RE = re.compile(r"\x1B\][^\x07]*(\x07|\x1B\\)")
+_ESC_RE = re.compile(
+    r"\x1b(?:"
+    r"\[[0-?]*[ -/]*[@-~]"
+    r"|\][^\x07]*\x07"
+    r"|[@-Z\\-_]"
+    r")"
+)
 _TRAILING_CONTINUATION_RE = re.compile(r"(?:\|\|?|\&\&)\s*$")
 
 
@@ -53,6 +60,10 @@ def clean_text(text: str) -> str:
             continue
         out.append(ch)
     return "".join(out)
+
+
+def strip_ansi(text: str) -> str:
+    return _ESC_RE.sub("", text)
 
 
 def shell_command_incomplete_reason(command: str) -> str | None:

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -258,6 +258,44 @@ class TestPullFileSuccess(unittest.TestCase):
         if os.path.exists("config.txt"):
             os.unlink("config.txt")
 
+    def test_pull_with_ansi_contamination(self) -> None:
+        """pull_file should work with ANSI-contaminated base64 output."""
+        data = b"binary\x00\x01\x02file"
+        b64 = base64.b64encode(data).decode("ascii")
+        md5 = hashlib.md5(data).hexdigest()
+        from sw_core.file_transfer import _SENTINEL_BEGIN, _SENTINEL_END
+
+        bridge = _FakeBridge()
+        # Contaminate the base64 with ANSI color codes and bracketed-paste markers
+        b64_with_ansi = (
+            f"{b64[:8]}\x1b[0m{b64[8:16]}\x1b[31m"
+            f"{b64[16:24]}\x1b[?2004h{b64[24:]}\x1b[?2004l\x1b[0m"
+        )
+        bridge.enqueue_rx(
+            f"echo start\r\n{_SENTINEL_BEGIN}\r\n"
+            f"{b64_with_ansi}\r\n"
+            f"{_SENTINEL_END}\r\n{_PROMPT}"
+        )
+        bridge.enqueue_rx(f"{md5}  /tmp/binary.bin\r\n{_PROMPT}")
+
+        outdir = tempfile.mkdtemp()
+        local = os.path.join(outdir, "ansi_pull.bin")
+        try:
+            result = pull_file(
+                bridge, "/tmp/binary.bin", local,
+                timeout_s=5.0,
+                prompt_regex=_PROMPT_REGEX,
+            )
+            self.assertTrue(result["ok"], f"Pull failed: {result}")
+            self.assertEqual(result["bytes"], len(data))
+            self.assertEqual(result["md5"], md5)
+            with open(local, "rb") as f:
+                self.assertEqual(f.read(), data)
+        finally:
+            if os.path.exists(local):
+                os.unlink(local)
+            os.rmdir(outdir)
+
 
 class TestPushChunkBoundary(unittest.TestCase):
     """邊界測試：空檔、恰好一個 chunk、多個 chunk。"""
@@ -373,6 +411,30 @@ class TestExtractBetweenSentinels(unittest.TestCase):
         text = "===SW_XFER_BEGIN======SW_XFER_END==="
         result = _extract_between_sentinels(text)
         self.assertEqual(result, "")
+
+    def test_ansi_color_sequences(self) -> None:
+        """ANSI color codes embedded in base64 should be stripped."""
+        clean_b64 = "aGVsbG8gd29ybGQ="
+        # Inject ANSI color codes (SGR reset, red foreground, etc.)
+        text = (
+            "===SW_XFER_BEGIN===\r\n"
+            f"\x1b[0m{clean_b64[:8]}\x1b[31m{clean_b64[8:]}\x1b[0m"
+            "\r\n===SW_XFER_END==="
+        )
+        result = _extract_between_sentinels(text)
+        self.assertEqual(result, clean_b64)
+
+    def test_bracketed_paste_marker(self) -> None:
+        """Bracketed paste mode sequences should be stripped."""
+        clean_b64 = "aGVsbG8="
+        # \x1b[?2004h and \x1b[?2004l are bracketed-paste enable/disable
+        text = (
+            "===SW_XFER_BEGIN===\r\n"
+            f"\x1b[?2004h{clean_b64}\x1b[?2004l"
+            "\r\n===SW_XFER_END==="
+        )
+        result = _extract_between_sentinels(text)
+        self.assertEqual(result, clean_b64)
 
 
 class TestPullParseFailed(unittest.TestCase):


### PR DESCRIPTION
## Summary

Fixes #32 — file pull fails with BASE64_DECODE_FAILED on binary files when the terminal contains ANSI escape sequences.

When pulling binary files over UART, colored PS1, bracketed-paste mode, or other ANSI sequences get mixed into the base64 data. The decoder then fails. This fix:

- Adds `strip_ansi()` utility to `util.py` with a comprehensive regex covering CSI, OSC, and all Fe two-byte escapes
- Updates `event_engine/line_buffer.py` to use the shared utility
- Applies ANSI stripping in `file_transfer._extract_between_sentinels()` before whitespace removal
- Adds 3 new tests for ANSI contamination scenarios

## Test Plan

- ✅ All 322 existing tests pass
- ✅ New test: `test_ansi_color_sequences` — ANSI colors in base64
- ✅ New test: `test_bracketed_paste_marker` — bracketed paste mode sequences
- ✅ New test: `test_pull_with_ansi_contamination` — end-to-end binary pull with terminal noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)