### PR TITLE
feat(session): add activity observability for quiet-but-healthy detection

### DIFF
--- a/sw_core/cli.py
+++ b/sw_core/cli.py
@@ -285,6 +285,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_sst = sess_sub.add_parser("self-test")
     p_sst.add_argument("--selector", required=True, help="session_id | COMx | alias")
     p_sst.add_argument("--probe-timeout", dest="probe_timeout_s", type=float, default=2.0)
+    p_sact = sess_sub.add_parser("activity", help="show RX/TX/state activity for a session")
+    p_sact.add_argument("--selector", required=True, help="session_id | COMx | alias")
     p_sr = sess_sub.add_parser("recover")
     p_sr.add_argument("--selector", required=True, help="session_id | COMx | alias")
     p_sr.add_argument("--timeout", dest="recover_timeout_s", type=float, default=2.0)
@@ -461,6 +463,8 @@ def main(argv: list[str] | None = None) -> int:
             return _run_rpc(args, "session.attach", {"selector": args.selector})
         if args.session_cmd == "self-test":
             return _run_rpc(args, "session.self_test", {"selector": args.selector, "timeout_s": args.probe_timeout_s})
+        if args.session_cmd == "activity":
+            return _run_rpc(args, "session.activity", {"selector": args.selector})
         if args.session_cmd == "recover":
             return _run_rpc(args, "session.recover", {"selector": args.selector, "timeout_s": args.recover_timeout_s, "force": getattr(args, "force", False)})
         if args.session_cmd == "console-attach":

--- a/sw_core/service.py
+++ b/sw_core/service.py
@@ -274,6 +274,18 @@ class SerialwrapService:
             selector = str(params.get("selector") or "")
             return self._sessions.get_session_state(selector)
 
+        if method == "session.activity":
+            selector = str(
+                params.get("selector")
+                or params.get("session_id")
+                or params.get("com")
+                or params.get("alias")
+                or ""
+            )
+            if not selector:
+                return {"ok": False, "error_code": "INVALID_ARGS"}
+            return self._sessions.get_session_state(selector)
+
         if method == "session.self_test":
             selector = str(params.get("selector") or params.get("session_id") or params.get("com") or params.get("alias") or "")
             timeout_s = float(params.get("timeout_s") or 2.0)

--- a/sw_core/session_manager.py
+++ b/sw_core/session_manager.py
@@ -93,7 +93,6 @@ class SessionCapture:
 class SessionRuntime:
     session_id: str
     profile: SessionProfile
-    state: str = "DETACHED"
     last_error: str | None = None
     detached_at: str | None = None
     last_ready_at: str | None = None
@@ -113,6 +112,43 @@ class SessionRuntime:
     retained_human_timeout_s: float | None = None
     fg_cmd_started_mono: float | None = None
     fg_cmd_expected_duration_s: float | None = None
+    # Activity tracking (issue #34)
+    last_state_change_at: str | None = None
+    last_rx_at: str | None = None
+    last_tx_at: str | None = None
+    last_probe_at: str | None = None
+    last_rx_mono: float = 0.0
+    last_tx_mono: float = 0.0
+    _state: str = dataclasses.field(default="DETACHED", init=False, repr=False)
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    @state.setter
+    def state(self, value: str) -> None:
+        prev = getattr(self, "_state", None)
+        if prev is not None and prev != value:
+            self.last_state_change_at = now_iso()
+        self._state = value
+
+    def compute_idle_ms(self) -> int | None:
+        last = max(self.last_rx_mono, self.last_tx_mono)
+        if last == 0.0:
+            return None
+        return int((time.monotonic() - last) * 1000)
+
+    def classify_activity(self) -> str:
+        if self._state not in ("READY", "ATTACHED"):
+            return "offline"
+        idle = self.compute_idle_ms()
+        if idle is None:
+            return "newly-attached"
+        if idle < 5_000:
+            return "active"
+        if idle < 60_000:
+            return "idle-healthy"
+        return "quiet-suspicious"
 
     def to_public_dict(self) -> dict[str, Any]:
         console_count = 0
@@ -123,6 +159,7 @@ class SessionRuntime:
         vtty_path = self.vtty_path
         if vtty_path is None and self.retained_consoles is not None:
             vtty_path = self.retained_consoles.primary_vtty()
+        outstanding = len(self.background_cmd_ids) + (1 if self.foreground_busy else 0)
         return {
             "session_id": self.session_id,
             "profile": self.profile.profile_name,
@@ -143,6 +180,13 @@ class SessionRuntime:
             "foreground_busy": self.foreground_busy,
             "fg_cmd_expected_duration_s": self.fg_cmd_expected_duration_s,
             "console_count": console_count,
+            "last_state_change_at": self.last_state_change_at,
+            "last_rx_at": self.last_rx_at,
+            "last_tx_at": self.last_tx_at,
+            "last_probe_at": self.last_probe_at,
+            "idle_for_ms": self.compute_idle_ms(),
+            "outstanding_commands": outstanding,
+            "activity_classification": self.classify_activity(),
             "capture": {
                 "capture_id": self.active_capture.capture_id,
                 "log_path": self.active_capture.log_path,
@@ -566,6 +610,16 @@ class SessionManager:
             for session in targets:
                 self._detach_session_locked(session, reason=reason)
 
+    def _mark_session_rx(self, session: SessionRuntime) -> None:
+        """Update session's last_rx_at / last_rx_mono. Cheap; safe outside lock."""
+        session.last_rx_at = now_iso()
+        session.last_rx_mono = time.monotonic()
+
+    def _mark_session_tx(self, session: SessionRuntime) -> None:
+        """Update session's last_tx_at / last_tx_mono. Cheap; safe outside lock."""
+        session.last_tx_at = now_iso()
+        session.last_tx_mono = time.monotonic()
+
     def _on_bridge_console_line(self, session_id: str, client_id: str, line: str) -> None:
         if self._on_console_line is not None:
             self._on_console_line(session_id, client_id, line)
@@ -590,7 +644,10 @@ class SessionManager:
             return
         with self._lock:
             session = self._sessions.get(session_id)
-            if session is None or session.foreground_busy:
+            if session is None:
+                return
+            self._mark_session_rx(session)
+            if session.foreground_busy:
                 return
             # agent log capture
             cap = session.active_capture
@@ -1157,6 +1214,7 @@ class SessionManager:
     ) -> dict[str, Any]:
         prompt_regex = session.profile.prompt_regex
         pre_offset = bridge.rx_snapshot_len()
+        self._mark_session_tx(session)
         bridge.send_command(command, source=source, cmd_id=cmd_id)
         if bridge.wait_for_regex_from(prompt_regex, pre_offset, min(timeout_s, 2.0)):
             raw_text = bridge.rx_text_from(pre_offset)
@@ -1273,6 +1331,7 @@ class SessionManager:
                         capture.status = "done"
                 lease = self._open_interactive_locked(session, owner=source, timeout_s=max(timeout_s, session.profile.hard_timeout_s))
             if command:
+                self._mark_session_tx(session)
                 bridge.send_command(command, source=source, cmd_id=cmd_id)
             return {
                 "ok": True,
@@ -1309,6 +1368,7 @@ class SessionManager:
                     session.fg_cmd_expected_duration_s = None
         pre_offset = bridge.rx_snapshot_len()
         try:
+            self._mark_session_tx(session)
             bridge.send_command(command, source=source, cmd_id=cmd_id)
 
             # — heartbeat / keepalive 迴圈 —
@@ -1404,6 +1464,7 @@ class SessionManager:
 
         for action_name, payload in (("CTRL_C", b"\x03"), ("CTRL_D", b"\x04")):
             offset = bridge.rx_snapshot_len()
+            self._mark_session_tx(session)
             bridge.send_bytes(payload, source="system:recover", cmd_id=None)
             if bridge.wait_for_regex_from(prompt_regex, offset, min(timeout_s, 2.0)):
                 stdout = self._extract_command_stdout(bridge.rx_text_from(pre_offset), command, prompt_regex)
@@ -1508,6 +1569,7 @@ class SessionManager:
             lease = self._open_interactive_locked(session, owner=owner, timeout_s=timeout_s)
             bridge = session.bridge
         if command:
+            self._mark_session_tx(session)
             bridge.send_command(command, source=owner, cmd_id=None)
         return {
             "ok": True,
@@ -1551,6 +1613,7 @@ class SessionManager:
             if session is None or session.bridge is None:
                 return {"ok": False, "error_code": "SESSION_NOT_READY", "interactive_id": interactive_id}
             payload = self._encode_interactive_payload(data, encoding)
+            self._mark_session_tx(session)
             session.bridge.send_bytes(payload, source=lease.owner, cmd_id=None)
             lease.touch()
             return {"ok": True, "interactive_id": interactive_id, "bytes": len(payload)}
@@ -1678,6 +1741,8 @@ class SessionManager:
             nonce = uuid.uuid4().hex[:8]
             probe = session.profile.ready_probe.replace("${nonce}", nonce)
             offset = bridge.rx_snapshot_len()
+            session.last_probe_at = now_iso()
+            self._mark_session_tx(session)
             bridge.send_command(probe, source="system:self_test", cmd_id=None)
             if not bridge.wait_for_regex_from(nonce, offset, timeout_s):
                 return {

--- a/sw_mcp/server.py
+++ b/sw_mcp/server.py
@@ -15,6 +15,7 @@ _TOOL_MAP = {
     "serialwrap_get_health": "health.status",
     "serialwrap_get_command": "command.get",
     "serialwrap_get_session_state": "session.get_state",
+    "serialwrap_get_session_activity": "session.activity",
     "serialwrap_bind_session": "session.bind",
     "serialwrap_attach_session": "session.attach",
     "serialwrap_self_test": "session.self_test",
@@ -89,6 +90,12 @@ _TOOL_DEFS: list[dict[str, Any]] = [
     _td(
         "serialwrap_get_session_state",
         "取得指定 session 狀態",
+        {"selector": _STR},
+        ["selector"],
+    ),
+    _td(
+        "serialwrap_get_session_activity",
+        "取得 session 活動觀測（last_rx_at / last_tx_at / idle_for_ms / activity_classification 等，用於分辨 quiet-but-healthy 與 dead）",
         {"selector": _STR},
         ["selector"],
     ),

--- a/tests/test_session_activity.py
+++ b/tests/test_session_activity.py
@@ -1,0 +1,220 @@
+"""Issue #34 — session activity / heartbeat observability tests.
+
+Covers SessionRuntime activity fields, classification, and the
+integration with SessionManager._on_bridge_rx and _mark_session_tx.
+"""
+from __future__ import annotations
+
+import time
+import unittest
+from typing import Any
+from unittest import mock
+
+from sw_core.config import SessionProfile
+from sw_core.session_manager import SessionManager, SessionRuntime
+
+
+def _make_profile(**overrides: Any) -> SessionProfile:
+    defaults: dict[str, Any] = {
+        "profile_name": "test",
+        "platform": "shell",
+        "com": "COM0",
+        "act_no": 0,
+        "alias": "t0",
+        "device_by_id": "/dev/serial/by-id/test",
+        "prompt_regex": r"[$#] $",
+        "login_regex": r"(?mi)login:\s*$",
+        "password_regex": r"(?mi)password:\s*$",
+        "user_env": "U",
+        "pass_env": "P",
+        "ready_probe": "echo __READY__${nonce}",
+        "timeout_s": 5.0,
+    }
+    defaults.update(overrides)
+    return SessionProfile(**defaults)
+
+
+def _make_session(state: str = "DETACHED") -> SessionRuntime:
+    s = SessionRuntime(session_id="sid-1", profile=_make_profile())
+    if state != "DETACHED":
+        s.state = state
+    return s
+
+
+class TestSessionRuntimeActivityFields(unittest.TestCase):
+    """SessionRuntime 新增的 activity 欄位與 helper 方法測試。"""
+
+    def test_initial_state_is_detached_with_no_activity(self) -> None:
+        s = _make_session()
+        self.assertEqual(s.state, "DETACHED")
+        self.assertIsNone(s.last_rx_at)
+        self.assertIsNone(s.last_tx_at)
+        self.assertIsNone(s.last_state_change_at)
+        self.assertIsNone(s.last_probe_at)
+        self.assertEqual(s.last_rx_mono, 0.0)
+        self.assertEqual(s.last_tx_mono, 0.0)
+
+    def test_state_change_auto_updates_last_state_change_at(self) -> None:
+        s = _make_session()
+        self.assertIsNone(s.last_state_change_at)
+        s.state = "ATTACHING"
+        first = s.last_state_change_at
+        self.assertIsNotNone(first)
+        s.state = "READY"
+        second = s.last_state_change_at
+        self.assertIsNotNone(second)
+        # different transitions produce a fresh timestamp string
+        self.assertNotEqual(first, second)
+
+    def test_state_set_to_same_value_does_not_update_timestamp(self) -> None:
+        s = _make_session()
+        s.state = "READY"
+        ts = s.last_state_change_at
+        # set to the same state again — timestamp should NOT advance
+        s.state = "READY"
+        self.assertEqual(s.last_state_change_at, ts)
+
+    def test_compute_idle_ms_returns_none_when_no_activity(self) -> None:
+        s = _make_session("READY")
+        self.assertIsNone(s.compute_idle_ms())
+
+    def test_compute_idle_ms_uses_max_of_rx_tx(self) -> None:
+        s = _make_session("READY")
+        now = time.monotonic()
+        s.last_rx_mono = now - 0.5  # 500ms ago
+        s.last_tx_mono = now - 0.1  # 100ms ago (more recent)
+        idle = s.compute_idle_ms()
+        self.assertIsNotNone(idle)
+        # use the most recent of rx/tx (~100ms)
+        self.assertLess(idle, 200)
+
+    def test_classify_offline_when_not_ready(self) -> None:
+        for state in ("DETACHED", "ATTACHING", "RECOVERING", "ERROR"):
+            s = _make_session(state)
+            self.assertEqual(s.classify_activity(), "offline", f"state={state}")
+
+    def test_classify_newly_attached_when_no_rx_tx_yet(self) -> None:
+        s = _make_session("READY")
+        self.assertEqual(s.classify_activity(), "newly-attached")
+
+    def test_classify_active_when_recent_activity(self) -> None:
+        s = _make_session("READY")
+        s.last_rx_mono = time.monotonic()  # now
+        self.assertEqual(s.classify_activity(), "active")
+
+    def test_classify_idle_healthy_after_5s_silence(self) -> None:
+        s = _make_session("READY")
+        s.last_rx_mono = time.monotonic() - 10.0  # 10s ago
+        self.assertEqual(s.classify_activity(), "idle-healthy")
+
+    def test_classify_quiet_suspicious_after_60s_silence(self) -> None:
+        s = _make_session("READY")
+        s.last_rx_mono = time.monotonic() - 70.0  # 70s ago
+        self.assertEqual(s.classify_activity(), "quiet-suspicious")
+
+    def test_classify_active_for_attached_state(self) -> None:
+        s = _make_session("ATTACHED")
+        s.last_tx_mono = time.monotonic()
+        self.assertEqual(s.classify_activity(), "active")
+
+
+class TestSessionPublicDict(unittest.TestCase):
+    """to_public_dict 新欄位 expose 測試。"""
+
+    def test_public_dict_contains_activity_fields(self) -> None:
+        s = _make_session("READY")
+        d = s.to_public_dict()
+        for key in (
+            "last_state_change_at",
+            "last_rx_at",
+            "last_tx_at",
+            "last_probe_at",
+            "idle_for_ms",
+            "outstanding_commands",
+            "activity_classification",
+        ):
+            self.assertIn(key, d, f"missing field {key}")
+
+    def test_public_dict_state_unchanged_after_property_refactor(self) -> None:
+        s = _make_session()
+        s.state = "READY"
+        d = s.to_public_dict()
+        self.assertEqual(d["state"], "READY")
+
+    def test_outstanding_commands_counts_background_and_foreground(self) -> None:
+        s = _make_session("READY")
+        # only foreground
+        s.foreground_busy = True
+        self.assertEqual(s.to_public_dict()["outstanding_commands"], 1)
+        # add 2 background
+        s.background_cmd_ids.extend(["cmd-1", "cmd-2"])
+        self.assertEqual(s.to_public_dict()["outstanding_commands"], 3)
+        # only background
+        s.foreground_busy = False
+        self.assertEqual(s.to_public_dict()["outstanding_commands"], 2)
+        # none
+        s.background_cmd_ids.clear()
+        self.assertEqual(s.to_public_dict()["outstanding_commands"], 0)
+
+    def test_idle_for_ms_in_public_dict(self) -> None:
+        s = _make_session("READY")
+        # no activity → None
+        self.assertIsNone(s.to_public_dict()["idle_for_ms"])
+        # with activity → small int
+        s.last_rx_mono = time.monotonic()
+        self.assertIsNotNone(s.to_public_dict()["idle_for_ms"])
+        self.assertLess(s.to_public_dict()["idle_for_ms"], 100)
+
+
+class TestSessionManagerActivityHooks(unittest.TestCase):
+    """SessionManager 內 RX / TX 標記助手在實際路徑被呼叫的整合測試。"""
+
+    def _make_manager(self) -> SessionManager:
+        wal = mock.MagicMock()
+        wal.current_seq = 0
+        mgr = SessionManager(
+            profiles=[_make_profile()],
+            wal=wal,
+            on_ready=lambda _sid: None,
+            on_detached=lambda _sid: None,
+        )
+        return mgr
+
+    def test_mark_session_rx_updates_timestamps(self) -> None:
+        mgr = self._make_manager()
+        s = _make_session("READY")
+        mgr._mark_session_rx(s)
+        self.assertIsNotNone(s.last_rx_at)
+        self.assertGreater(s.last_rx_mono, 0.0)
+
+    def test_mark_session_tx_updates_timestamps(self) -> None:
+        mgr = self._make_manager()
+        s = _make_session("READY")
+        mgr._mark_session_tx(s)
+        self.assertIsNotNone(s.last_tx_at)
+        self.assertGreater(s.last_tx_mono, 0.0)
+
+    def test_on_bridge_rx_updates_session_rx_activity(self) -> None:
+        mgr = self._make_manager()
+        # inject a session into the manager
+        s = SessionRuntime(session_id="sid-rx", profile=_make_profile())
+        s.state = "READY"
+        mgr._sessions["sid-rx"] = s
+        mgr._on_bridge_rx("sid-rx", b"hello\n")
+        self.assertIsNotNone(s.last_rx_at)
+        self.assertGreater(s.last_rx_mono, 0.0)
+
+    def test_on_bridge_rx_marks_rx_even_when_foreground_busy(self) -> None:
+        """RX activity tracking should NOT be gated by foreground_busy —
+        the data is still being received from the UART."""
+        mgr = self._make_manager()
+        s = SessionRuntime(session_id="sid-busy", profile=_make_profile())
+        s.state = "READY"
+        s.foreground_busy = True
+        mgr._sessions["sid-busy"] = s
+        mgr._on_bridge_rx("sid-busy", b"chunk during fg\n")
+        self.assertIsNotNone(s.last_rx_at)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #34 — agents can now distinguish "quiet but healthy" from "dead" without invoking self_test (which would interfere with workload).

When DUT/STA soak workflows sit silently for 60+ seconds during sleep / wait-next-probe, observers previously had no way to tell whether the target was working as intended or hung. This PR exposes RX/TX/state-change/probe timestamps + an idle classification.

## Changes

**SessionRuntime fields:**
- `last_rx_at`, `last_tx_at`, `last_state_change_at`, `last_probe_at` (ISO timestamps)
- `last_rx_mono`, `last_tx_mono` (internal monotonic for idle math)
- `state` becomes a property; setter auto-updates `last_state_change_at` (avoids refactoring 20+ assignment sites)

**Derived in `to_public_dict`:**
- `idle_for_ms` — `now - max(last_rx_mono, last_tx_mono)`
- `outstanding_commands` — `len(background_cmd_ids) + (1 if foreground_busy else 0)`
- `activity_classification` — `active` (<5s) / `idle-healthy` (<60s) / `quiet-suspicious` (>=60s) / `newly-attached` / `offline`

**Hooks added:**
- `SessionManager._mark_session_rx` called from `_on_bridge_rx` (also when foreground_busy — RX is RX)
- `SessionManager._mark_session_tx` called before all 7 `bridge.send_command`/`send_bytes` sites
- `self_test` also sets `last_probe_at`

**New surfaces:**
- RPC `session.activity` (alias of `get_session_state` with activity-focused semantics)
- CLI: `serialwrap session activity --selector <s>`
- MCP: `serialwrap_get_session_activity`

## Test Plan

- ✅ 19 new unit tests in `tests/test_session_activity.py`
  - Field initialization & state setter timestamping
  - Classification across all 5 activity states
  - `compute_idle_ms` correctness
  - `outstanding_commands` foreground/background counting
  - `to_public_dict` shape verification
  - `_on_bridge_rx` updates `last_rx_at` even when foreground_busy
- ✅ Full regression suite: 341 / 341 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)