### PR TITLE
feat(reboot-test): recover serialwrap event statistics toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,6 +963,67 @@ Handler **建議**：
 
 詳細設計請見 [`docs/plan-event-trigger.md`](./docs/plan-event-trigger.md)。
 
+## Serialwrap Reboot Log Test Toolkit
+
+`serialwrap_reboot_test/` 提供長時間 reboot log soak 測試工具，建立在 Event Trigger Engine 之上。它用一個 controller process 管一個 COM selector，COM0/COM1 共用同一套流程；COM1 可另外安裝 boot-time fault injector 做異常 reboot 測試。
+
+### 工具
+
+| Tool | 用途 |
+|------|------|
+| `bin/serialwrap-reboot-controller` | 驗證 serialwrap、找 active minicom log、註冊 event rules、驅動 reboot loop、退出時清理 event state |
+| `bin/serialwrap-event-handler` | 由 event rules spawn，維護 `~/b-log/event-triggered_COMx_<timestamp>.md` |
+| `bin/serialwrap-fault-install` | 將 fault injector 安裝到 COM1 target 的 `/usr/sbin`、`/etc/init.d`、`/etc/rc.d` |
+
+### Event rules
+
+Controller 啟動時會註冊並啟用目前 selector 的 shared rules：
+
+| Event | Match |
+|-------|-------|
+| `brcm-therm` | `brcm-therm` |
+| `Link is Down` | `Link is Down` |
+| `pstate` | lowercase case-sensitive `pstate` |
+| `Kernel panic` | `Kernel panic` |
+| `SMC bootloader` | `SMC bootloader` |
+
+每條 rule 都呼叫 `serialwrap-event-handler`。handler 會從 stdin 讀取 serialwrap event payload，解析目前 selector 的 active minicom log，並更新報告：
+
+```text
+~/b-log/event-triggered_COMx_<timestamp>.md
+```
+
+報告包含 summary table 與 event table。Summary 以 `SMC bootloader` 次數為分母，計算其他事件的發生機率；若分母為 0，機率顯示 `N/A`。Event table 記錄 minicom log name、physical log line number、event trigger time 與 event name。handler 也會維護 per-event scan cursor，避免重複事件一直對到同一行 log。
+
+### 使用流程
+
+先確認部署版 serialwrap 支援 event subcommand 且 daemon 正常：
+
+```bash
+/home/paul_chen/.paul_tools/serialwrap event --help
+/home/paul_chen/.paul_tools/serialwrap daemon status
+/home/paul_chen/.paul_tools/serialwrap event status --selector COM0
+/home/paul_chen/.paul_tools/serialwrap event status --selector COM1
+```
+
+先開 minicom logging，再啟動 controller：
+
+```bash
+minicom COM0 -O timestamp=extended
+minicom COM1 -O timestamp=extended
+
+bin/serialwrap-reboot-controller --selector COM0
+bin/serialwrap-reboot-controller --selector COM1
+```
+
+可用 `--count N` 或 `--hours N` 限制執行長度。COM1 fault injector 可用下列命令安裝：
+
+```bash
+bin/serialwrap-fault-install --selector COM1
+```
+
+詳細設計請見 [`docs/superpowers/specs/2026-05-06-serialwrap-reboot-log-test-design.md`](./docs/superpowers/specs/2026-05-06-serialwrap-reboot-log-test-design.md) 與 [`openspec/specs/serialwrap-reboot-log-test/spec.md`](./openspec/specs/serialwrap-reboot-log-test/spec.md)。
+
 ## 延伸閱讀
 
 - 詳細決策與 API 契約：[`docs/serialwrap-spec.md`](./docs/serialwrap-spec.md)

--- a/bin/serialwrap-event-handler
+++ b/bin/serialwrap-event-handler
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Entrypoint for serialwrap-event-handler."""
+
+import sys
+import os
+
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, project_root)
+
+from serialwrap_reboot_test.event_handler import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/serialwrap-fault-install
+++ b/bin/serialwrap-fault-install
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Entrypoint for serialwrap-fault-install."""
+
+import sys
+import os
+
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, project_root)
+
+from serialwrap_reboot_test.fault_installer import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/serialwrap-reboot-controller
+++ b/bin/serialwrap-reboot-controller
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Entrypoint for serialwrap-reboot-controller."""
+
+import sys
+import os
+
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, project_root)
+
+from serialwrap_reboot_test.controller import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/superpowers/specs/2026-05-06-serialwrap-reboot-log-test-design.md
+++ b/docs/superpowers/specs/2026-05-06-serialwrap-reboot-log-test-design.md
@@ -1,0 +1,407 @@
+# Serialwrap Reboot Log Test Design
+
+Date: 2026-05-06
+
+## Goal
+
+Build a deploy-first serialwrap reboot log test toolkit that can run long
+soak tests for one COM selector at a time.
+
+The same reboot controller flow is used for COM0 and COM1. The difference
+between the normal test and the abnormal test is only that the COM1 target
+board has a boot-time fault injector installed.
+
+The toolkit must:
+
+- Generate normal reboot logs for COM0.
+- Generate reboot logs with random injected faults for COM1.
+- Drive reboots through serialwrap as an agent source so serialwrap enters its
+  expected reboot recovery path.
+- Maintain per-COM, per-minicom-log event reports.
+- Keep controller runtime state limited to the current process run.
+- Clean up serialwrap event lifecycle when the controller exits.
+
+## Deployment Assumption
+
+All runtime commands use:
+
+```bash
+/home/paul_chen/.paul_tools/serialwrap
+```
+
+Before the toolkit can be used, `/home/paul_chen/.paul_tools/serialwrap` must
+be updated from `/home/paul_chen/prj_pri/serialwrap` or another equivalent
+source so that this command supports the `event` subcommand.
+
+The deployment must verify:
+
+```bash
+/home/paul_chen/.paul_tools/serialwrap event --help
+/home/paul_chen/.paul_tools/serialwrap daemon status
+/home/paul_chen/.paul_tools/serialwrap event status --selector COM0
+/home/paul_chen/.paul_tools/serialwrap event status --selector COM1
+```
+
+## Components
+
+### `serialwrap-reboot-controller`
+
+Controls exactly one selector per process, for example `COM0` or `COM1`.
+
+Responsibilities:
+
+- Verify serialwrap daemon health.
+- Verify the installed serialwrap supports `event`.
+- Verify a minicom wrapper log exists and is active for the selected COM.
+- Send a dummy echo marker to identify the active minicom log for this run.
+- Store current-run state under `/tmp`.
+- Register the shared reboot-test event rules and enable the selected COM.
+- Drive the reboot loop.
+- On exit, disable/reset this COM's event state, delete event rules if no other
+  COM still uses them, and remove `/tmp` state.
+
+The controller does not install the COM1 fault injector and does not know
+whether the selected COM is the normal or abnormal target.
+
+### `serialwrap-fault-install`
+
+One-time provisioning tool for the COM1 target board.
+
+Responsibilities:
+
+- Push the target fault injector to `/usr/sbin/serialwrap-fault-injector`.
+- Push the init script to `/etc/init.d/serialwrap-fault-injector`.
+- Prefer serialwrap file transfer.
+- Fall back to short command based writes if file transfer fails.
+- Avoid heredoc and large UART writes in the fallback path.
+- Set executable permissions.
+- Create `/etc/rc.d/S50serialwrap-fault-injector`.
+- Verify file existence, executable permissions, and symlink target.
+
+If `/etc/init.d` or `/etc/rc.d` does not exist, the installer fails.
+
+### `serialwrap-event-handler`
+
+Handler process invoked by the serialwrap event engine.
+
+Responsibilities:
+
+- Read the serialwrap event JSON payload from stdin.
+- Resolve the active minicom log for the payload selector.
+- Update `~/b-log/event-triggered_COMx_<timestamp>.md`.
+- Maintain per-event scan cursors so repeated events map to the next matching
+  log line instead of an old line.
+- Exit quickly and idempotently.
+
+### Target Fault Injector
+
+Installed on the COM1 target board only.
+
+Files:
+
+- `/usr/sbin/serialwrap-fault-injector`
+- `/etc/init.d/serialwrap-fault-injector`
+- `/etc/rc.d/S50serialwrap-fault-injector`
+
+Behavior:
+
+- Runs once per boot at S50 level.
+- Has a 10 percent chance to trigger one fault.
+- If triggered, chooses one of four events with equal probability.
+- Produces no service startup/status/debug output.
+- Redirects routine stdout/stderr to `/dev/null`.
+
+Fault events:
+
+1. Thermal notification:
+
+   ```bash
+   echo 'bcm_thermal_drv brcm-therm: Trip 0: threshold=105000 mC hysteresis=2000 mC' > /dev/console
+   ```
+
+2. 5G ethernet AN rerun:
+
+   ```bash
+   ethctl eth0 phy-reset
+   ```
+
+3. Process coredump:
+
+   Select a random process from `ps aux` whose PID is greater than 4000, then:
+
+   ```bash
+   kill -SIGABRT <PID>
+   ```
+
+   If no process qualifies, exit 0 silently.
+
+4. System crash coredump:
+
+   ```bash
+   echo c > /proc/sysrq-trigger
+   ```
+
+The thermal event writes to `/dev/console` so the serial log looks like a board
+generated notification, not a tool-generated message.
+
+## Controller Flow
+
+### Startup
+
+1. Parse arguments.
+2. Require `--selector COMx`.
+3. Accept optional stop limits:
+   - `--hours N`, where N is hours. Example: 4 days is `--hours 96`.
+   - `--count N`, where N is completed reboot attempts.
+4. Validate `.paul_tools/serialwrap event --help`.
+5. Validate serialwrap daemon health.
+6. Send a dummy marker command through serialwrap, for example:
+
+   ```bash
+   echo __SW_REBOOT_TEST_COM1_<runid>__
+   ```
+
+   Source must be `agent:reboot-controller`.
+
+7. Find the active minicom log:
+   - Pattern: `~/b-log/mini_COMx_*.log`
+   - Must be updated within the active log window, default 10 minutes.
+   - Must contain the dummy marker.
+8. Derive report path from the minicom log timestamp:
+
+   ```text
+   ~/b-log/mini_COM1_260506-152744.log
+   ~/b-log/event-triggered_COM1_260506-152744.md
+   ```
+
+9. Create current-run state under `/tmp`, for example:
+
+   ```text
+   /tmp/serialwrap-reboot-test.COM1.<pid>/
+   ```
+
+10. Register the shared reboot-test event rules and enable this selector.
+11. Enter the reboot loop.
+
+### Reboot Loop
+
+The controller uses the same loop for COM0 and COM1.
+
+READY check:
+
+1. `session list` must show `state=READY` for the selector.
+2. `session self-test --selector COMx --probe-timeout 10` must report
+   `classification=OK` and `probe_ok=true`.
+
+If READY:
+
+1. Submit a normal reboot through serialwrap:
+
+   ```bash
+   serialwrap cmd submit --selector COMx --source agent:reboot-controller --mode line --cmd reboot
+   ```
+
+2. Record the reboot timestamp.
+3. Increment the controller's reboot attempt count.
+
+If not READY:
+
+1. If less than 5 minutes have elapsed since the last reboot or fallback action,
+   wait and poll again.
+2. If 5 minutes have elapsed, run `session recover`.
+3. If recover returns to READY, the next loop sends a normal `reboot`.
+4. If recover does not return to READY, inspect the tail of the active minicom
+   log only:
+   - If the tail contains `=>`, send raw broker console input:
+
+     ```text
+     reset
+     ```
+
+   - If the tail contains `root@prplOS:/#`, send raw broker console input:
+
+     ```text
+     reboot -f
+     ```
+
+   - If neither prompt is present, wait until the next 5 minute rescue cycle.
+5. If `reset` or `reboot -f` is sent, record that fallback timestamp as the new
+   5 minute reference point.
+
+Fallback commands must go through serialwrap broker console/raw input and must
+not write directly to `/dev/ttyUSB*` or `/dev/ttyACM*`.
+
+### Stop Conditions
+
+Default behavior is an infinite run until stopped by the user.
+
+Optional stop conditions:
+
+- `--hours N`
+- `--count N`
+
+The controller must handle SIGINT and SIGTERM. Foreground infinite runs stop
+with `Ctrl-C`. Background runs should stop with SIGTERM, for example:
+
+```bash
+pkill -TERM -f 'serialwrap-reboot-controller --selector COM1'
+```
+
+On normal exit, SIGINT, or SIGTERM, the controller must:
+
+1. Disable this selector's event matcher.
+2. Reset this selector's event counters/state.
+3. Check whether another COM matcher is still enabled for the reboot-test
+   rules.
+4. Delete the shared reboot-test rules only if this selector was the last
+   active user.
+5. Remove the `/tmp/serialwrap-reboot-test.COMx.<pid>/` state directory.
+
+## Event Rules
+
+Rules are registered by the controller at test start and cleaned up by the
+controller at test exit.
+
+The rule IDs are shared across COM0 and COM1. Each rule has selectors
+`["COM0", "COM1"]`. A controller only enables or disables its own COM matcher.
+This avoids rule overwrite when two controllers run at the same time.
+
+The same event set is used for COM0 and COM1:
+
+| Rule name | Match |
+| --- | --- |
+| `brcm-therm` | `brcm-therm` |
+| `link-down` | `Link is Down` |
+| `pstate` | `pstate` |
+| `kernel-panic` | `Kernel panic` |
+| `smc-bootloader` | `SMC bootloader` |
+
+`pstate` is case-sensitive and matches lowercase `pstate` only.
+
+`SMC bootloader` is an event statistic only. The controller's fallback prompt
+check for U-Boot still uses `=>`, but `=>` is not counted as `SMC bootloader`.
+
+Each rule invokes `serialwrap-event-handler`.
+
+## Event Report
+
+Reports are stored next to minicom logs:
+
+```text
+~/b-log/event-triggered_COMx_<timestamp>.md
+```
+
+There is one report per COM and per minicom log. COM0 and COM1 do not share a
+report.
+
+The handler resolves the active minicom log in this order:
+
+1. Current-run `/tmp` state for the selector.
+2. Fallback to latest `~/b-log/mini_COMx_*.log` updated within 10 minutes.
+
+Line numbers are actual physical file line numbers in the minicom log.
+
+For repeated matches, the handler maintains per-event scan cursors. For each
+event, it scans from the previous matched line plus one and records the first
+new matching line.
+
+Report format:
+
+```markdown
+# Event Triggered Report
+
+Log: mini_COM1_260506-152744.log
+Generated: 2026-05-06T16:10:23+08:00
+
+## Summary
+
+Denominator: SMC bootloader = 12
+
+| Event | Count | Probability vs SMC bootloader |
+| --- | ---: | ---: |
+| brcm-therm | 3 | 25.00% |
+| Link is Down | 1 | 8.33% |
+| pstate | 4 | 33.33% |
+| Kernel panic | 1 | 8.33% |
+| SMC bootloader | 12 | 100.00% |
+
+## Events
+
+| Log name | Log line number | Event trigger time | Event |
+| --- | ---: | --- | --- |
+| mini_COM1_260506-152744.log | 1832 | 2026-05-06T16:10:23+08:00 | brcm-therm |
+```
+
+If the `SMC bootloader` count is zero, probability values for other events are
+shown as `N/A`.
+
+## README Requirements
+
+The toolkit README must document:
+
+- Required serialwrap deployment check.
+- How to start `minicom COM0 -O timestamp=extended`.
+- How to start `minicom COM1 -O timestamp=extended`.
+- How to install the COM1 fault injector.
+- How to run COM0 and COM1 controllers separately.
+- Infinite run behavior.
+- `--hours N` and `--count N`.
+- How to stop a foreground controller with `Ctrl-C`.
+- How to stop a background controller with SIGTERM.
+- What cleanup happens on controller exit.
+- Where reports are written.
+
+## Verification Plan
+
+### Local Checks
+
+- Shell syntax checks for scripts.
+- Argument parsing checks.
+- Event rule JSON generation check.
+- Report rewrite check using sample minicom log snippets.
+- Scan cursor check for repeated event lines.
+
+### Serialwrap Integration Checks
+
+- Verify `.paul_tools/serialwrap event --help`.
+- Verify `event status`.
+- Verify rule add/list/show/enable/disable/reset/rm.
+- Verify daemon status.
+
+### Target Installer Checks
+
+- Verify `/etc/init.d` and `/etc/rc.d` exist.
+- Verify `file.push` path.
+- Verify fallback short write path.
+- Verify target file permissions.
+- Verify `/etc/rc.d/S50serialwrap-fault-injector` symlink.
+
+### Controller Smoke
+
+Run a short test with count limit:
+
+```bash
+serialwrap-reboot-controller --selector COM0 --count 1
+serialwrap-reboot-controller --selector COM1 --count 1
+```
+
+Confirm:
+
+- Active minicom log marker detection.
+- Report path derivation.
+- Event rules are registered and enabled at start.
+- Event rules are disabled/reset and possibly removed at stop.
+- `/tmp` state is removed at stop.
+- Reboot command source is `agent:reboot-controller`.
+
+The smoke test must not directly force `echo c > /proc/sysrq-trigger`.
+System crash injection is left to the COM1 random boot-time path during long
+soak testing.
+
+## Open Constraints
+
+- This design assumes the serialwrap source version with `event` support can be
+  deployed to `/home/paul_chen/.paul_tools/serialwrap`.
+- This design assumes minicom wrapper logs follow `~/b-log/mini_COMx_*.log`.
+- This design assumes the target is OpenWrt-like and supports `/etc/init.d` and
+  `/etc/rc.d`.

--- a/openspec/changes/archive/2026-05-06-add-serialwrap-reboot-log-test-toolkit/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-06-add-serialwrap-reboot-log-test-toolkit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/archive/2026-05-06-add-serialwrap-reboot-log-test-toolkit/design.md
+++ b/openspec/changes/archive/2026-05-06-add-serialwrap-reboot-log-test-toolkit/design.md
@@ -1,0 +1,57 @@
+## Context
+
+The toolkit is a small deploy-first set of shell/Python utilities for long-running serialwrap reboot soak tests. Runtime serialwrap access is fixed to `/home/paul_chen/.paul_tools/serialwrap`, and that installed command must already support the `event` subcommand. Minicom wrapper logs are expected at `~/b-log/mini_COMx_*.log` and are the evidence source for per-event reporting.
+
+The same controller flow must work for COM0 and COM1. COM1 abnormal behavior is provided by a target-side boot-time fault injector installed separately; the controller does not branch on normal versus abnormal targets.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide one-process-per-selector reboot control with explicit serialwrap daemon/event readiness checks.
+- Drive normal reboot and fallback recovery commands through serialwrap so serialwrap observes the expected recovery lifecycle.
+- Register shared reboot-test event rules for COM0/COM1 while enabling only the current selector for each controller process.
+- Maintain current-run state only under `/tmp` and remove it on controller exit.
+- Generate one event report per selector and minicom log with accurate physical log line numbers and per-event scan cursors.
+- Provide a COM1 provisioning tool for installing target-side random boot-time fault injection.
+- Cover local behavior with automated tests before production implementation.
+
+**Non-Goals:**
+- Do not update or build serialwrap itself; deployment only verifies the installed command supports required subcommands.
+- Do not directly write to `/dev/ttyUSB*` or `/dev/ttyACM*`.
+- Do not install the COM1 fault injector from the controller.
+- Do not persist controller runtime state across process runs except the markdown report next to minicom logs.
+- Do not force system crash injection during local smoke tests.
+
+## Decisions
+
+1. **Use shell entrypoints backed by a testable Python library.**
+   - Rationale: The toolkit is operator-facing, but controller/reporting behavior needs deterministic unit tests.
+   - Alternative considered: Pure shell scripts. Rejected because report rewriting, scan cursors, JSON payload parsing, and argument validation are harder to test safely.
+
+2. **Represent serialwrap command execution behind a small runner boundary.**
+   - Rationale: Tests can verify exact command construction without needing a live daemon, while production still shells out to `/home/paul_chen/.paul_tools/serialwrap`.
+   - Alternative considered: Inline subprocess calls in every flow. Rejected to keep command generation and error handling reviewable.
+
+3. **Use `/tmp/serialwrap-reboot-test.<selector>.<pid>/` for current-run state.**
+   - Rationale: State is naturally scoped to one controller process and can be cleaned on SIGINT/SIGTERM/normal exit.
+   - Alternative considered: State in `~/b-log`. Rejected because runtime coordination state should not outlive the process by default.
+
+4. **Use shared rule IDs with selector-specific enable/disable state.**
+   - Rationale: COM0 and COM1 controllers can run concurrently without overwriting each other's rules, and cleanup can delete shared rules only when no selector still uses them.
+   - Alternative considered: Per-selector rule IDs. Rejected because it duplicates rule definitions and makes event statistics harder to compare.
+
+5. **Resolve reports from the active minicom log timestamp.**
+   - Rationale: A report belongs to the exact log file containing the controller marker; fallback latest-log resolution is only for handler invocations that cannot read current-run state.
+   - Alternative considered: One rolling report per COM. Rejected because it mixes evidence across minicom sessions.
+
+6. **Installer prefers serialwrap file transfer and falls back to short command writes.**
+   - Rationale: File transfer is safer for full scripts, while the fallback avoids heredoc and large UART writes that are fragile over serial.
+   - Alternative considered: Heredoc over UART. Rejected by design constraint.
+
+## Risks / Trade-offs
+
+- Serialwrap event CLI syntax may differ from assumptions → Centralize command construction and test generated argument vectors/JSON before live integration.
+- Active minicom marker might be delayed in the log → Use an active log window and explicit marker search before entering the reboot loop.
+- Concurrent controllers can race during shared rule cleanup → Check current event status for both selectors before removing shared rules and tolerate already-removed state as an explicit serialwrap result only if serialwrap reports it.
+- Fallback recovery can send commands to the wrong prompt if stale logs are inspected → Inspect only the active minicom log tail associated with this run.
+- Target-side `ps`, `ethctl`, or init layout can vary → Installer verifies required directories/files/symlink and the fault injector exits silently when a selected process target is unavailable.

--- a/openspec/changes/archive/2026-05-06-add-serialwrap-reboot-log-test-toolkit/proposal.md
+++ b/openspec/changes/archive/2026-05-06-add-serialwrap-reboot-log-test-toolkit/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Long-running reboot soak tests currently need a repeatable way to drive serialwrap through its own reboot recovery path while preserving per-COM evidence from minicom logs. This change adds a deploy-first toolkit for COM0 normal reboot logs and COM1 reboot logs with boot-time random fault injection.
+
+## What Changes
+
+- Add a `serialwrap-reboot-controller` CLI that controls one selector per process, verifies serialwrap/minicom readiness, registers shared event rules, drives reboot loops, and cleans event/runtime state on exit.
+- Add a `serialwrap-event-handler` that consumes serialwrap event payloads and maintains per-COM, per-minicom-log markdown reports with per-event scan cursors.
+- Add a `serialwrap-fault-install` provisioning CLI plus target-side fault injector/init assets for COM1 boot-time random fault injection.
+- Add documentation for deployment checks, minicom startup, COM0/COM1 controller operation, stop limits, cleanup, and report locations.
+- Add local tests for argument parsing, event rule generation, report rewriting, scan cursor behavior, and installer fallback generation.
+
+## Capabilities
+
+### New Capabilities
+- `serialwrap-reboot-log-test`: Deploy-first serialwrap reboot soak test toolkit covering controller flow, event handling/reporting, and COM1 target fault injector installation.
+
+### Modified Capabilities
+
+## Impact
+
+- Adds executable toolkit scripts and target-side shell assets for serialwrap-driven reboot testing.
+- Requires `/home/paul_chen/.paul_tools/serialwrap` to support the `event` subcommand before runtime use.
+- Produces runtime state under `/tmp/serialwrap-reboot-test.COMx.<pid>/` and reports under `~/b-log/event-triggered_COMx_<timestamp>.md`.

--- a/openspec/changes/archive/2026-05-06-add-serialwrap-reboot-log-test-toolkit/specs/serialwrap-reboot-log-test/spec.md
+++ b/openspec/changes/archive/2026-05-06-add-serialwrap-reboot-log-test-toolkit/specs/serialwrap-reboot-log-test/spec.md
@@ -1,0 +1,147 @@
+## ADDED Requirements
+
+### Requirement: Serialwrap deployment readiness
+The toolkit SHALL verify that `/home/paul_chen/.paul_tools/serialwrap` supports the `event` subcommand and that the serialwrap daemon is healthy before a controller starts a reboot loop.
+
+#### Scenario: Controller validates serialwrap event support
+- **WHEN** `serialwrap-reboot-controller --selector COM0` starts
+- **THEN** it SHALL run `/home/paul_chen/.paul_tools/serialwrap event --help` before registering event rules
+
+#### Scenario: Controller validates daemon health
+- **WHEN** `serialwrap-reboot-controller --selector COM1` starts
+- **THEN** it SHALL run `/home/paul_chen/.paul_tools/serialwrap daemon status` before sending marker or reboot commands
+
+### Requirement: One selector per controller process
+The controller SHALL require exactly one `--selector COMx` value per process and SHALL apply the same reboot control flow to COM0 and COM1.
+
+#### Scenario: Selector is required
+- **WHEN** the controller is invoked without `--selector`
+- **THEN** it SHALL exit with an argument parsing error
+
+#### Scenario: COM1 does not alter controller flow
+- **WHEN** the controller is invoked with `--selector COM1`
+- **THEN** it SHALL use the same readiness, reboot, fallback, event registration, and cleanup flow as COM0
+
+### Requirement: Active minicom log detection
+The controller SHALL identify the active minicom log for the selected COM by sending a dummy marker through serialwrap with source `agent:reboot-controller` and finding a recently updated `~/b-log/mini_COMx_*.log` that contains that marker.
+
+#### Scenario: Marker identifies active log
+- **WHEN** the controller starts for COM1
+- **THEN** it SHALL submit an echo marker through serialwrap with source `agent:reboot-controller` and derive `~/b-log/event-triggered_COM1_<timestamp>.md` from the matching minicom log name
+
+#### Scenario: No active marker log exists
+- **WHEN** no `~/b-log/mini_COMx_*.log` updated within the active log window contains the marker
+- **THEN** the controller SHALL fail before entering the reboot loop
+
+### Requirement: Current-run state lifecycle
+The controller SHALL store current-run state under `/tmp/serialwrap-reboot-test.<selector>.<pid>/` and SHALL remove that state on normal exit, SIGINT, or SIGTERM.
+
+#### Scenario: State is created for a run
+- **WHEN** the controller has resolved the active minicom log
+- **THEN** it SHALL create a `/tmp` run directory containing enough state for the event handler to resolve the selector's active log and report path
+
+#### Scenario: State is removed on termination
+- **WHEN** the controller receives SIGINT or SIGTERM
+- **THEN** it SHALL clean up the selector event state and remove its `/tmp` run directory before exiting
+
+### Requirement: Shared event rule registration
+The controller SHALL register shared reboot-test rules for selectors `COM0` and `COM1`, enable only its selected COM matcher at start, disable and reset only its selected COM matcher at exit, and delete shared rules only when no COM matcher still uses them.
+
+#### Scenario: Rules contain required events
+- **WHEN** the controller registers reboot-test event rules
+- **THEN** it SHALL include matches for `brcm-therm`, `Link is Down`, lowercase case-sensitive `pstate`, `Kernel panic`, and `SMC bootloader`
+
+#### Scenario: Concurrent controller cleanup preserves shared rules
+- **WHEN** a COM0 controller exits while a COM1 matcher is still enabled
+- **THEN** the COM0 controller SHALL disable/reset COM0 state and SHALL NOT delete the shared reboot-test rules
+
+### Requirement: Reboot loop readiness and normal reboot
+The controller SHALL poll serialwrap session readiness and submit a normal `reboot` command through serialwrap with source `agent:reboot-controller` when the selected session is ready and self-test reports `classification=OK` and `probe_ok=true`.
+
+#### Scenario: Ready session reboots normally
+- **WHEN** `session list` shows `state=READY` for COM0 and `session self-test --selector COM0 --probe-timeout 10` reports OK
+- **THEN** the controller SHALL submit `reboot` through serialwrap command submission with source `agent:reboot-controller` and increment the reboot attempt count
+
+### Requirement: Reboot loop fallback recovery
+The controller SHALL attempt recovery no more often than every five minutes after the last reboot or fallback action, and fallback commands SHALL go through serialwrap broker console/raw input instead of direct TTY writes.
+
+#### Scenario: U-Boot prompt fallback
+- **WHEN** recovery does not return to READY and the active minicom log tail contains `=>`
+- **THEN** the controller SHALL send raw broker console input `reset` through serialwrap and record that fallback timestamp
+
+#### Scenario: Linux prompt fallback
+- **WHEN** recovery does not return to READY and the active minicom log tail contains `root@prplOS:/#`
+- **THEN** the controller SHALL send raw broker console input `reboot -f` through serialwrap and record that fallback timestamp
+
+#### Scenario: No fallback prompt
+- **WHEN** recovery does not return to READY and the active minicom log tail contains neither fallback prompt
+- **THEN** the controller SHALL wait until the next five-minute rescue cycle without sending direct TTY input
+
+### Requirement: Stop conditions
+The controller SHALL run indefinitely by default and SHALL support optional `--hours N` and `--count N` stop limits.
+
+#### Scenario: Count limit stops loop
+- **WHEN** the controller is invoked with `--count 1`
+- **THEN** it SHALL exit after one completed reboot attempt and perform normal cleanup
+
+#### Scenario: Infinite default
+- **WHEN** the controller is invoked without `--hours` or `--count`
+- **THEN** it SHALL continue running until stopped by SIGINT or SIGTERM
+
+### Requirement: Event handler report generation
+The event handler SHALL read a serialwrap event JSON payload from stdin, resolve the active minicom log for the payload selector, update `~/b-log/event-triggered_COMx_<timestamp>.md`, and exit quickly and idempotently.
+
+#### Scenario: Handler uses current-run state first
+- **WHEN** current-run state exists for the payload selector
+- **THEN** the handler SHALL use the active log and report path recorded in that state
+
+#### Scenario: Handler falls back to recent minicom log
+- **WHEN** current-run state is absent for the payload selector
+- **THEN** the handler SHALL use the latest `~/b-log/mini_COMx_*.log` updated within ten minutes
+
+### Requirement: Event report contents
+The event report SHALL include a summary table with counts and probability versus `SMC bootloader`, plus an events table containing log name, physical log line number, event trigger time, and event name.
+
+#### Scenario: Probability denominator exists
+- **WHEN** the `SMC bootloader` count is greater than zero
+- **THEN** non-denominator event probabilities SHALL be formatted as percentages against the `SMC bootloader` count
+
+#### Scenario: Probability denominator missing
+- **WHEN** the `SMC bootloader` count is zero
+- **THEN** probabilities for other events SHALL be shown as `N/A`
+
+### Requirement: Event scan cursors
+The event handler SHALL maintain per-event scan cursors so repeated events map to the next matching physical log line instead of an earlier match.
+
+#### Scenario: Repeated event advances cursor
+- **WHEN** two `brcm-therm` payloads are handled for a log containing two matching lines
+- **THEN** the report SHALL record the first payload at the first line and the second payload at the second line
+
+### Requirement: COM1 fault injector installation
+The `serialwrap-fault-install` tool SHALL install the target fault injector to `/usr/sbin/serialwrap-fault-injector`, install the init script to `/etc/init.d/serialwrap-fault-injector`, create `/etc/rc.d/S50serialwrap-fault-injector`, set executable permissions, and verify the installed files and symlink.
+
+#### Scenario: Required target directories missing
+- **WHEN** `/etc/init.d` or `/etc/rc.d` does not exist on the target
+- **THEN** the installer SHALL fail before attempting installation
+
+#### Scenario: File transfer fallback
+- **WHEN** serialwrap file transfer fails
+- **THEN** the installer SHALL fall back to short command based writes without heredoc or large UART writes
+
+### Requirement: Target fault injector behavior
+The target fault injector SHALL run once per boot at S50 level, silently choose a fault with 10 percent probability, and choose equally among thermal notification, 5G ethernet AN rerun, process coredump, and system crash coredump when triggered.
+
+#### Scenario: Thermal notification uses console
+- **WHEN** the thermal fault is selected
+- **THEN** the injector SHALL write the thermal notification text to `/dev/console`
+
+#### Scenario: No eligible process for coredump
+- **WHEN** the process coredump fault is selected and no `ps aux` process has PID greater than 4000
+- **THEN** the injector SHALL exit 0 silently
+
+### Requirement: Toolkit documentation
+The toolkit README SHALL document serialwrap deployment checks, minicom startup for COM0 and COM1, COM1 fault injector installation, separate controller execution, infinite/default stop behavior, `--hours`, `--count`, foreground/background stopping, cleanup behavior, and report locations.
+
+#### Scenario: Operator can follow README
+- **WHEN** an operator reads the README
+- **THEN** it SHALL include the commands and explanations needed to deploy serialwrap, start minicom logs, install COM1 faults, run COM0/COM1 controllers, stop them, and find reports

--- a/openspec/changes/archive/2026-05-06-add-serialwrap-reboot-log-test-toolkit/tasks.md
+++ b/openspec/changes/archive/2026-05-06-add-serialwrap-reboot-log-test-toolkit/tasks.md
@@ -1,0 +1,29 @@
+## 1. Project scaffolding and test harness
+
+- [x] 1.1 Create toolkit package/script structure with executable entrypoints for `serialwrap-reboot-controller`, `serialwrap-event-handler`, and `serialwrap-fault-install`
+- [x] 1.2 Add an automated test harness and baseline tests for CLI argument parsing and command path constants before production logic
+
+## 2. Controller behavior
+
+- [x] 2.1 Add failing tests then implement controller argument parsing for required `--selector`, optional `--hours`, optional `--count`, and infinite default behavior
+- [x] 2.2 Add failing tests then implement serialwrap readiness checks, daemon checks, marker submission, active minicom log detection, report path derivation, and `/tmp` run-state creation
+- [x] 2.3 Add failing tests then implement shared event rule JSON/command generation, selected-COM enablement, selected-COM disable/reset cleanup, and last-active shared rule removal logic
+- [x] 2.4 Add failing tests then implement reboot loop decisions for READY/self-test normal reboot submission, five-minute recovery throttling, and broker raw fallback commands from active log tail prompts
+- [x] 2.5 Add failing tests then implement SIGINT/SIGTERM/normal-exit cleanup sequencing for event lifecycle and `/tmp` state removal
+
+## 3. Event reporting
+
+- [x] 3.1 Add failing tests then implement event payload parsing, active log resolution from current-run state with recent-log fallback, and fast idempotent handler exit
+- [x] 3.2 Add failing tests then implement report rewriting with summary counts, SMC bootloader denominator probabilities, `N/A` zero-denominator handling, event rows, and physical log line numbers
+- [x] 3.3 Add failing tests then implement per-event scan cursors so repeated payloads advance to the next matching log line
+
+## 4. COM1 fault injector installer and target assets
+
+- [x] 4.1 Add failing tests then implement target fault injector script content for 10 percent boot-time random selection across the four specified fault events with silent normal output
+- [x] 4.2 Add failing tests then implement init script content and `serialwrap-fault-install` directory checks, preferred file-transfer path, short-write fallback path, executable permissions, symlink creation, and verification commands
+
+## 5. Documentation and validation
+
+- [x] 5.1 Add README documentation for deployment checks, minicom startup, COM1 injector installation, controller runs, stop limits, foreground/background stop behavior, cleanup, and reports
+- [x] 5.2 Run the local test suite and shell syntax checks for all scripts
+- [x] 5.3 Run OpenSpec status/validation for `add-serialwrap-reboot-log-test-toolkit`

--- a/openspec/specs/serialwrap-reboot-log-test/spec.md
+++ b/openspec/specs/serialwrap-reboot-log-test/spec.md
@@ -1,0 +1,152 @@
+## Purpose
+Provide a serialwrap-based reboot log test toolkit that can run per-COM reboot
+soak controllers, correlate serialwrap event payloads back to minicom logs, and
+install the COM1 boot-time fault injector used by abnormal reboot testing.
+
+## Requirements
+
+### Requirement: Serialwrap deployment readiness
+The toolkit SHALL verify that `/home/paul_chen/.paul_tools/serialwrap` supports the `event` subcommand and that the serialwrap daemon is healthy before a controller starts a reboot loop.
+
+#### Scenario: Controller validates serialwrap event support
+- **WHEN** `serialwrap-reboot-controller --selector COM0` starts
+- **THEN** it SHALL run `/home/paul_chen/.paul_tools/serialwrap event --help` before registering event rules
+
+#### Scenario: Controller validates daemon health
+- **WHEN** `serialwrap-reboot-controller --selector COM1` starts
+- **THEN** it SHALL run `/home/paul_chen/.paul_tools/serialwrap daemon status` before sending marker or reboot commands
+
+### Requirement: One selector per controller process
+The controller SHALL require exactly one `--selector COMx` value per process and SHALL apply the same reboot control flow to COM0 and COM1.
+
+#### Scenario: Selector is required
+- **WHEN** the controller is invoked without `--selector`
+- **THEN** it SHALL exit with an argument parsing error
+
+#### Scenario: COM1 does not alter controller flow
+- **WHEN** the controller is invoked with `--selector COM1`
+- **THEN** it SHALL use the same readiness, reboot, fallback, event registration, and cleanup flow as COM0
+
+### Requirement: Active minicom log detection
+The controller SHALL identify the active minicom log for the selected COM by sending a dummy marker through serialwrap with source `agent:reboot-controller` and finding a recently updated `~/b-log/mini_COMx_*.log` that contains that marker.
+
+#### Scenario: Marker identifies active log
+- **WHEN** the controller starts for COM1
+- **THEN** it SHALL submit an echo marker through serialwrap with source `agent:reboot-controller` and derive `~/b-log/event-triggered_COM1_<timestamp>.md` from the matching minicom log name
+
+#### Scenario: No active marker log exists
+- **WHEN** no `~/b-log/mini_COMx_*.log` updated within the active log window contains the marker
+- **THEN** the controller SHALL fail before entering the reboot loop
+
+### Requirement: Current-run state lifecycle
+The controller SHALL store current-run state under `/tmp/serialwrap-reboot-test.<selector>.<pid>/` and SHALL remove that state on normal exit, SIGINT, or SIGTERM.
+
+#### Scenario: State is created for a run
+- **WHEN** the controller has resolved the active minicom log
+- **THEN** it SHALL create a `/tmp` run directory containing enough state for the event handler to resolve the selector's active log and report path
+
+#### Scenario: State is removed on termination
+- **WHEN** the controller receives SIGINT or SIGTERM
+- **THEN** it SHALL clean up the selector event state and remove its `/tmp` run directory before exiting
+
+### Requirement: Shared event rule registration
+The controller SHALL register shared reboot-test rules for selectors `COM0` and `COM1`, enable only its selected COM matcher at start, disable and reset only its selected COM matcher at exit, and delete shared rules only when no COM matcher still uses them.
+
+#### Scenario: Rules contain required events
+- **WHEN** the controller registers reboot-test event rules
+- **THEN** it SHALL include matches for `brcm-therm`, `Link is Down`, lowercase case-sensitive `pstate`, `Kernel panic`, and `SMC bootloader`
+
+#### Scenario: Concurrent controller cleanup preserves shared rules
+- **WHEN** a COM0 controller exits while a COM1 matcher is still enabled
+- **THEN** the COM0 controller SHALL disable/reset COM0 state and SHALL NOT delete the shared reboot-test rules
+
+### Requirement: Reboot loop readiness and normal reboot
+The controller SHALL poll serialwrap session readiness and submit a normal `reboot` command through serialwrap with source `agent:reboot-controller` when the selected session is ready and self-test reports `classification=OK` and `probe_ok=true`.
+
+#### Scenario: Ready session reboots normally
+- **WHEN** `session list` shows `state=READY` for COM0 and `session self-test --selector COM0 --probe-timeout 10` reports OK
+- **THEN** the controller SHALL submit `reboot` through serialwrap command submission with source `agent:reboot-controller` and increment the reboot attempt count
+
+### Requirement: Reboot loop fallback recovery
+The controller SHALL attempt recovery no more often than every five minutes after the last reboot or fallback action, and fallback commands SHALL go through serialwrap broker console/raw input instead of direct TTY writes.
+
+#### Scenario: U-Boot prompt fallback
+- **WHEN** recovery does not return to READY and the active minicom log tail contains `=>`
+- **THEN** the controller SHALL send raw broker console input `reset` through serialwrap and record that fallback timestamp
+
+#### Scenario: Linux prompt fallback
+- **WHEN** recovery does not return to READY and the active minicom log tail contains `root@prplOS:/#`
+- **THEN** the controller SHALL send raw broker console input `reboot -f` through serialwrap and record that fallback timestamp
+
+#### Scenario: No fallback prompt
+- **WHEN** recovery does not return to READY and the active minicom log tail contains neither fallback prompt
+- **THEN** the controller SHALL wait until the next five-minute rescue cycle without sending direct TTY input
+
+### Requirement: Stop conditions
+The controller SHALL run indefinitely by default and SHALL support optional `--hours N` and `--count N` stop limits.
+
+#### Scenario: Count limit stops loop
+- **WHEN** the controller is invoked with `--count 1`
+- **THEN** it SHALL exit after one completed reboot attempt and perform normal cleanup
+
+#### Scenario: Infinite default
+- **WHEN** the controller is invoked without `--hours` or `--count`
+- **THEN** it SHALL continue running until stopped by SIGINT or SIGTERM
+
+### Requirement: Event handler report generation
+The event handler SHALL read a serialwrap event JSON payload from stdin, resolve the active minicom log for the payload selector, update `~/b-log/event-triggered_COMx_<timestamp>.md`, and exit quickly and idempotently.
+
+#### Scenario: Handler uses current-run state first
+- **WHEN** current-run state exists for the payload selector
+- **THEN** the handler SHALL use the active log and report path recorded in that state
+
+#### Scenario: Handler falls back to recent minicom log
+- **WHEN** current-run state is absent for the payload selector
+- **THEN** the handler SHALL use the latest `~/b-log/mini_COMx_*.log` updated within ten minutes
+
+### Requirement: Event report contents
+The event report SHALL include a summary table with counts and probability versus `SMC bootloader`, plus an events table containing log name, physical log line number, event trigger time, and event name.
+
+#### Scenario: Probability denominator exists
+- **WHEN** the `SMC bootloader` count is greater than zero
+- **THEN** non-denominator event probabilities SHALL be formatted as percentages against the `SMC bootloader` count
+
+#### Scenario: Probability denominator missing
+- **WHEN** the `SMC bootloader` count is zero
+- **THEN** probabilities for other events SHALL be shown as `N/A`
+
+### Requirement: Event scan cursors
+The event handler SHALL maintain per-event scan cursors so repeated events map to the next matching physical log line instead of an earlier match.
+
+#### Scenario: Repeated event advances cursor
+- **WHEN** two `brcm-therm` payloads are handled for a log containing two matching lines
+- **THEN** the report SHALL record the first payload at the first line and the second payload at the second line
+
+### Requirement: COM1 fault injector installation
+The `serialwrap-fault-install` tool SHALL install the target fault injector to `/usr/sbin/serialwrap-fault-injector`, install the init script to `/etc/init.d/serialwrap-fault-injector`, create `/etc/rc.d/S50serialwrap-fault-injector`, set executable permissions, and verify the installed files and symlink.
+
+#### Scenario: Required target directories missing
+- **WHEN** `/etc/init.d` or `/etc/rc.d` does not exist on the target
+- **THEN** the installer SHALL fail before attempting installation
+
+#### Scenario: File transfer fallback
+- **WHEN** serialwrap file transfer fails
+- **THEN** the installer SHALL fall back to short command based writes without heredoc or large UART writes
+
+### Requirement: Target fault injector behavior
+The target fault injector SHALL run once per boot at S50 level, silently choose a fault with 10 percent probability, and choose equally among thermal notification, 5G ethernet AN rerun, process coredump, and system crash coredump when triggered.
+
+#### Scenario: Thermal notification uses console
+- **WHEN** the thermal fault is selected
+- **THEN** the injector SHALL write the thermal notification text to `/dev/console`
+
+#### Scenario: No eligible process for coredump
+- **WHEN** the process coredump fault is selected and no `ps aux` process has PID greater than 4000
+- **THEN** the injector SHALL exit 0 silently
+
+### Requirement: Toolkit documentation
+The toolkit README SHALL document serialwrap deployment checks, minicom startup for COM0 and COM1, COM1 fault injector installation, separate controller execution, infinite/default stop behavior, `--hours`, `--count`, foreground/background stopping, cleanup behavior, and report locations.
+
+#### Scenario: Operator can follow README
+- **WHEN** an operator reads the README
+- **THEN** it SHALL include the commands and explanations needed to deploy serialwrap, start minicom logs, install COM1 faults, run COM0/COM1 controllers, stop them, and find reports

--- a/serialwrap_reboot_test/__init__.py
+++ b/serialwrap_reboot_test/__init__.py
@@ -1,0 +1,3 @@
+"""Serialwrap reboot test toolkit package."""
+
+__version__ = "0.1.0"

--- a/serialwrap_reboot_test/constants.py
+++ b/serialwrap_reboot_test/constants.py
@@ -1,0 +1,8 @@
+"""Constants for serialwrap reboot test toolkit."""
+
+import os
+
+SERIALWRAP_CMD = os.environ.get(
+    'SERIALWRAP_CMD',
+    '/home/paul_chen/.paul_tools/serialwrap'
+)

--- a/serialwrap_reboot_test/controller.py
+++ b/serialwrap_reboot_test/controller.py
@@ -1,0 +1,1217 @@
+"""Controller module for serialwrap-reboot-controller."""
+
+import argparse
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Optional, Dict, Any, List
+
+from .constants import SERIALWRAP_CMD
+
+
+class ControllerError(Exception):
+    """Controller operation error."""
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_code: Optional[str] = None,
+        payload: Optional[Dict[str, Any]] = None
+    ):
+        super().__init__(message)
+        self.error_code = error_code
+        self.payload = payload or {}
+
+
+class CommandRunner:
+    """Run commands and return results."""
+
+    def run(self, cmd: List[str], **kwargs) -> tuple[int, str, str]:
+        """Run a command and return (returncode, stdout, stderr)."""
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            **kwargs
+        )
+        return result.returncode, result.stdout, result.stderr
+
+
+def positive_int(value: str) -> int:
+    """Parse a positive integer argument."""
+    try:
+        parsed = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{value!r} is not an integer")
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"{value!r} must be greater than zero")
+    return parsed
+
+
+class RebootController:
+    """Main controller for reboot testing."""
+
+    def __init__(
+        self,
+        selector: str,
+        runner: Optional[Any] = None,
+        log_dir: Optional[Path] = None,
+        hours_limit: Optional[int] = None,
+        count_limit: Optional[int] = None,
+        active_log: Optional[Path] = None
+    ):
+        """Initialize the controller.
+
+        Args:
+            selector: COM selector (e.g., COM0, COM1).
+            runner: Command runner (defaults to real CommandRunner).
+            log_dir: Directory for minicom logs (defaults to ~/b-log).
+            hours_limit: Optional hours limit for stop condition.
+            count_limit: Optional count limit for stop condition.
+            active_log: Optional active minicom log path for testing.
+
+        Raises:
+            ValueError: If selector is invalid or contains path traversal.
+        """
+        # Validate selector format (must match ^COM[0-9]+$)
+        if not re.match(r'^COM[0-9]+$', selector):
+            raise ValueError(f"Invalid selector: {selector}. Must match pattern COM[0-9]+")
+
+        self.selector = selector
+        self.runner = runner or CommandRunner()
+        # Ensure log_dir is a Path object
+        if log_dir is None:
+            self.log_dir = Path.home() / "b-log"
+        elif isinstance(log_dir, str):
+            self.log_dir = Path(log_dir)
+        else:
+            self.log_dir = log_dir
+        self.hours_limit = hours_limit
+        self.count_limit = count_limit
+        self.active_log_path = active_log
+
+        self.state_dir: Optional[Path] = None
+        self.start_time = time.time()
+        self.reboot_count = 0
+        self._stop_requested = False
+        self.last_action_time: Optional[float] = None
+        self.sleep_fn = time.sleep  # Injectable for testing
+        self.loop_delay = 10  # Configurable loop delay in seconds
+        self.marker_wait_seconds = 45
+        self.marker_poll_interval = 1
+        self.rpc_timeout_seconds = 30
+        self.recover_timeout_seconds = 15
+        self.command_timeout_seconds = 15
+
+    def serialwrap_cmd(self, *args: str) -> List[str]:
+        """Build a serialwrap command with an extended RPC timeout."""
+        return [SERIALWRAP_CMD, "--timeout", str(self.rpc_timeout_seconds), *args]
+
+    def format_command_error(self, stdout: str, stderr: str) -> str:
+        """Format CLI failures, preferring JSON stdout error payloads."""
+        stderr_text = stderr.strip()
+        if stderr_text:
+            return stderr_text
+
+        stdout_text = stdout.strip()
+        if not stdout_text:
+            return ""
+
+        try:
+            data = json.loads(stdout_text)
+        except json.JSONDecodeError:
+            return stdout_text
+
+        if not isinstance(data, dict):
+            return stdout_text
+
+        parts: List[str] = []
+        if data.get("error_code"):
+            parts.append(str(data["error_code"]))
+        if data.get("message"):
+            parts.append(str(data["message"]))
+        if data.get("classification"):
+            parts.append(f"classification={data['classification']}")
+        if data.get("partial") is True:
+            parts.append("partial=true")
+        session = data.get("session")
+        if isinstance(session, dict) and session.get("state"):
+            parts.append(f"state={session['state']}")
+
+        return "; ".join(parts) if parts else stdout_text
+
+    def parse_json_object(self, text: str) -> Optional[Dict[str, Any]]:
+        """Parse a JSON object response when available."""
+        text = text.strip()
+        if not text:
+            return None
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            return None
+        return data if isinstance(data, dict) else None
+
+    def check_serialwrap_event_support(self) -> bool:
+        """Check if serialwrap supports event subcommand."""
+        returncode, stdout, stderr = self.runner.run(
+            self.serialwrap_cmd("event", "--help")
+        )
+        return returncode == 0
+
+    def check_daemon_status(self) -> bool:
+        """Check if serialwrap daemon is running."""
+        returncode, stdout, stderr = self.runner.run(
+            self.serialwrap_cmd("daemon", "status")
+        )
+        return returncode == 0
+
+    def send_marker_command(self) -> str:
+        """Send marker command through serialwrap and return marker string.
+
+        Raises:
+            ControllerError: If marker submission fails.
+        """
+        # Generate unique marker
+        run_id = str(uuid.uuid4())[:8]
+        marker = f"__SW_REBOOT_TEST_{self.selector}_{run_id}__"
+
+        # Submit echo command with marker
+        returncode, stdout, stderr = self.runner.run(self.serialwrap_cmd(
+            "cmd", "submit",
+            "--selector", self.selector,
+            "--source", "agent:reboot-controller",
+            "--mode", "line",
+            "--cmd", f"echo {marker}"
+        ))
+
+        payload = None
+        stdout_text = stdout.strip()
+        if stdout_text:
+            try:
+                data = json.loads(stdout_text)
+                if isinstance(data, dict):
+                    payload = data
+            except json.JSONDecodeError:
+                payload = None
+
+        if returncode != 0:
+            details = self.format_command_error(stdout, stderr)
+            raise ControllerError(
+                f"Failed to submit marker command: {details}",
+                error_code=payload.get("error_code") if payload else None,
+                payload=payload
+            )
+
+        return marker
+
+    def find_active_minicom_log(
+        self,
+        marker: str,
+        max_age_seconds: int = 600
+    ) -> Optional[Path]:
+        """Find active minicom log containing marker.
+
+        Args:
+            marker: Marker string to search for.
+            max_age_seconds: Maximum age for log file in seconds.
+
+        Returns:
+            Path to active log or None if not found.
+        """
+        pattern = f"mini_{self.selector}_*.log"
+        deadline = time.time() + max(0, self.marker_wait_seconds)
+
+        while True:
+            current_time = time.time()
+
+            for log_file in self.log_dir.glob(pattern):
+                # Check file age
+                try:
+                    mtime = log_file.stat().st_mtime
+                    if current_time - mtime > max_age_seconds:
+                        continue
+                except OSError as e:
+                    print(f"WARNING: Cannot stat {log_file}: {e}", file=sys.stderr)
+                    continue
+
+                # Check for marker using streaming read
+                try:
+                    with open(log_file, 'r', encoding='utf-8', errors='ignore') as f:
+                        for line in f:
+                            if marker in line:
+                                return log_file
+                except OSError as e:
+                    print(f"WARNING: Cannot read {log_file}: {e}", file=sys.stderr)
+                    continue
+
+            if current_time >= deadline:
+                return None
+
+            sleep_seconds = min(self.marker_poll_interval, deadline - current_time)
+            if sleep_seconds > 0:
+                self.sleep_fn(sleep_seconds)
+
+    def derive_report_path(self, minicom_log: Path) -> Path:
+        """Derive report path from minicom log name.
+
+        Args:
+            minicom_log: Path to minicom log file.
+
+        Returns:
+            Path to report file.
+        """
+        # Extract timestamp from minicom log name
+        # mini_COM1_260506-152744.log -> event-triggered_COM1_260506-152744.md
+        name = minicom_log.name
+        prefix = f"mini_{self.selector}_"
+        if name.startswith(prefix):
+            timestamp = name[len(prefix):].replace('.log', '')
+            report_name = f"event-triggered_{self.selector}_{timestamp}.md"
+            return minicom_log.parent / report_name
+
+        # Fallback
+        return minicom_log.parent / f"event-triggered_{self.selector}.md"
+
+    def create_run_state_directory(self) -> Path:
+        """Create /tmp run-state directory.
+
+        Returns:
+            Path to created state directory.
+
+        Raises:
+            ValueError: If resolved path is not under /tmp.
+        """
+        pid = os.getpid()
+        state_dir = Path(f"/tmp/serialwrap-reboot-test.{self.selector}.{pid}")
+
+        # Verify resolved path is under /tmp (protect against symlink attacks)
+        resolved = state_dir.resolve()
+        if not str(resolved).startswith("/tmp/"):
+            raise ValueError(f"State directory must be under /tmp, got: {resolved}")
+
+        state_dir.mkdir(parents=True, exist_ok=True)
+        return state_dir
+
+    def store_run_state(
+        self,
+        state_dir: Path,
+        minicom_log: Path,
+        report_path: Path
+    ) -> None:
+        """Store run state files.
+
+        Args:
+            state_dir: State directory path.
+            minicom_log: Active minicom log path.
+            report_path: Report file path.
+        """
+        (state_dir / "active_minicom_log.txt").write_text(str(minicom_log))
+        (state_dir / "report_path.txt").write_text(str(report_path))
+
+    def generate_event_rules(self) -> List[Dict[str, Any]]:
+        """Generate event rule definitions.
+
+        Returns:
+            List of rule dictionaries.
+        """
+        owner = "agent-reboot-controller"
+        rules = [
+            {
+                "schema_version": 1,
+                "owner": owner,
+                "name": "brcm-therm",
+                "rule_id": f"{owner}.brcm-therm",
+                "kind": "tool",
+                "selectors": ["COM0", "COM1"],
+                "pattern": {"kind": "contains", "value": "brcm-therm"},
+                "handler": {"exec": ["serialwrap-event-handler"]},
+                "auto_enable_com_on_load": False
+            },
+            {
+                "schema_version": 1,
+                "owner": owner,
+                "name": "link-down",
+                "rule_id": f"{owner}.link-down",
+                "kind": "tool",
+                "selectors": ["COM0", "COM1"],
+                "pattern": {"kind": "contains", "value": "Link is Down"},
+                "handler": {"exec": ["serialwrap-event-handler"]},
+                "auto_enable_com_on_load": False
+            },
+            {
+                "schema_version": 1,
+                "owner": owner,
+                "name": "pstate",
+                "rule_id": f"{owner}.pstate",
+                "kind": "tool",
+                "selectors": ["COM0", "COM1"],
+                "pattern": {"kind": "contains", "value": "pstate"},
+                "handler": {"exec": ["serialwrap-event-handler"]},
+                "auto_enable_com_on_load": False
+            },
+            {
+                "schema_version": 1,
+                "owner": owner,
+                "name": "kernel-panic",
+                "rule_id": f"{owner}.kernel-panic",
+                "kind": "tool",
+                "selectors": ["COM0", "COM1"],
+                "pattern": {"kind": "contains", "value": "Kernel panic"},
+                "handler": {"exec": ["serialwrap-event-handler"]},
+                "auto_enable_com_on_load": False
+            },
+            {
+                "schema_version": 1,
+                "owner": owner,
+                "name": "smc-bootloader",
+                "rule_id": f"{owner}.smc-bootloader",
+                "kind": "tool",
+                "selectors": ["COM0", "COM1"],
+                "pattern": {"kind": "contains", "value": "SMC bootloader"},
+                "handler": {"exec": ["serialwrap-event-handler"]},
+                "auto_enable_com_on_load": False
+            }
+        ]
+        return rules
+
+    def register_event_rules(self) -> None:
+        """Register event rules with serialwrap.
+
+        Raises:
+            ControllerError: If rule registration fails.
+        """
+        rules = self.generate_event_rules()
+        for rule in rules:
+            temp_path = None
+            try:
+                fd, temp_path = tempfile.mkstemp(
+                    prefix=f"serialwrap-event-rule-{rule['name']}-",
+                    suffix=".json"
+                )
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    json.dump(rule, f)
+                returncode, stdout, stderr = self.runner.run(self.serialwrap_cmd(
+                    "event", "add",
+                    "--file", temp_path
+                ))
+            finally:
+                if temp_path and os.path.exists(temp_path):
+                    os.unlink(temp_path)
+
+            if returncode != 0:
+                details = self.format_command_error(stdout, stderr)
+                raise ControllerError(f"Failed to add event rule {rule['name']}: {details}")
+
+    def enable_selector(self) -> None:
+        """Enable event matcher for this selector.
+
+        Raises:
+            ControllerError: If enable command fails.
+        """
+        returncode, stdout, stderr = self.runner.run(self.serialwrap_cmd(
+            "event", "enable",
+            "--selector", self.selector
+        ))
+
+        if returncode != 0:
+            details = self.format_command_error(stdout, stderr)
+            raise ControllerError(f"Failed to enable selector {self.selector}: {details}")
+
+    def disable_selector(self) -> None:
+        """Disable event matcher for this selector.
+
+        Raises:
+            ControllerError: If disable command fails.
+        """
+        returncode, stdout, stderr = self.runner.run(self.serialwrap_cmd(
+            "event", "disable",
+            "--selector", self.selector
+        ))
+
+        if returncode != 0:
+            details = self.format_command_error(stdout, stderr)
+            raise ControllerError(f"Failed to disable selector {self.selector}: {details}")
+
+    def reset_selector(self) -> None:
+        """Reset event state for this selector.
+
+        Raises:
+            ControllerError: If reset command fails.
+        """
+        returncode, stdout, stderr = self.runner.run(self.serialwrap_cmd(
+            "event", "reset",
+            "--selector", self.selector
+        ))
+
+        if returncode != 0:
+            details = self.format_command_error(stdout, stderr)
+            raise ControllerError(f"Failed to reset selector {self.selector}: {details}")
+
+    def check_other_selectors_enabled(self) -> Optional[bool]:
+        """Check if other COM selectors are still enabled.
+
+        Returns:
+            True if any other selector is enabled, False if none are enabled,
+            None if status could not be determined safely.
+        """
+        returncode, stdout, stderr = self.runner.run(self.serialwrap_cmd("event", "status"))
+
+        if returncode != 0:
+            details = self.format_command_error(stdout, stderr)
+            print(f"WARNING: Failed to query event status: {details}", file=sys.stderr)
+            return None
+
+        try:
+            status = json.loads(stdout)
+            if not isinstance(status, dict):
+                print("WARNING: Unexpected event status format: top-level JSON is not an object", file=sys.stderr)
+                return None
+
+            coms = status.get("coms")
+            if isinstance(coms, list):
+                for selector in coms:
+                    if not isinstance(selector, str):
+                        print("WARNING: Unexpected event status format: coms contains non-string entries", file=sys.stderr)
+                        return None
+                    if selector != self.selector:
+                        return True
+                return False
+
+            selectors = status.get("selectors", {})
+            if not isinstance(selectors, dict):
+                print("WARNING: Unexpected event status format: selectors is not an object", file=sys.stderr)
+                return None
+
+            for selector, info in selectors.items():
+                if not isinstance(info, dict):
+                    print(f"WARNING: Unexpected event status format for {selector}", file=sys.stderr)
+                    return None
+                if selector != self.selector and info.get("enabled"):
+                    return True
+
+            return False
+        except json.JSONDecodeError as e:
+            print(f"WARNING: Failed to parse event status JSON: {e}", file=sys.stderr)
+            return None
+        except (KeyError, TypeError) as e:
+            print(f"WARNING: Unexpected event status format: {e}", file=sys.stderr)
+            return None
+
+    def remove_event_rules(self) -> None:
+        """Remove shared event rules.
+
+        Raises:
+            ControllerError: If rule removal fails.
+        """
+        rules = self.generate_event_rules()
+        for rule in rules:
+            returncode, stdout, stderr = self.runner.run(self.serialwrap_cmd(
+                "event", "rm",
+                rule["rule_id"]
+            ))
+
+            if returncode != 0:
+                details = self.format_command_error(stdout, stderr)
+                raise ControllerError(f"Failed to remove event rule {rule['name']}: {details}")
+
+    def check_ready_state(self) -> bool:
+        """Check if session is in READY state."""
+        returncode, stdout, stderr = self.runner.run(self.serialwrap_cmd("session", "list"))
+
+        if returncode != 0:
+            return False
+
+        try:
+            data = json.loads(stdout)
+            sessions = data.get("sessions", [])
+            for session in sessions:
+                session_selector = session.get("selector", session.get("com"))
+                if session_selector == self.selector:
+                    return session.get("state") == "READY"
+            return False
+        except json.JSONDecodeError as e:
+            print(f"WARNING: Failed to parse session list JSON: {e}", file=sys.stderr)
+            return False
+        except (KeyError, TypeError) as e:
+            print(f"WARNING: Unexpected session list format: {e}", file=sys.stderr)
+            return False
+
+    def check_self_test(self) -> bool:
+        """Run self-test and check if OK."""
+        returncode, stdout, stderr = self.runner.run(self.serialwrap_cmd(
+            "session", "self-test",
+            "--selector", self.selector,
+            "--probe-timeout", "10"
+        ))
+
+        if returncode != 0:
+            return False
+
+        try:
+            data = json.loads(stdout)
+            return (
+                data.get("classification") == "OK" and
+                data.get("probe_ok") is True
+            )
+        except json.JSONDecodeError as e:
+            print(f"WARNING: Failed to parse self-test JSON: {e}", file=sys.stderr)
+            return False
+        except (KeyError, TypeError) as e:
+            print(f"WARNING: Unexpected self-test format: {e}", file=sys.stderr)
+            return False
+
+    def submit_normal_reboot(self) -> float:
+        """Submit normal reboot command.
+
+        Returns:
+            Timestamp of reboot submission.
+
+        Raises:
+            ControllerError: If reboot submission fails.
+        """
+        returncode, stdout, stderr = self.runner.run(self.serialwrap_cmd(
+            "cmd", "submit",
+            "--selector", self.selector,
+            "--source", "agent:reboot-controller",
+            "--mode", "line",
+            "--cmd", "reboot",
+            "--cmd-timeout", str(self.command_timeout_seconds),
+        ))
+
+        if returncode != 0:
+            details = self.format_command_error(stdout, stderr)
+            raise ControllerError(f"Failed to submit reboot command: {details}")
+
+        self.reboot_count += 1
+        return time.time()
+
+    def should_throttle_recovery(
+        self,
+        last_action: Optional[float],
+        throttle_seconds: int = 300
+    ) -> bool:
+        """Check if recovery should be throttled.
+
+        Args:
+            last_action: Timestamp of last reboot or fallback action.
+            throttle_seconds: Throttle period in seconds.
+
+        Returns:
+            True if should wait, False if can proceed.
+        """
+        if last_action is None:
+            return False
+
+        elapsed = time.time() - last_action
+        return elapsed < throttle_seconds
+
+    def run_session_recover(self) -> None:
+        """Run session recover command.
+
+        Raises:
+            ControllerError: If recover command fails.
+        """
+        returncode, stdout, stderr = self.runner.run(self.serialwrap_cmd(
+            "session", "recover",
+            "--selector", self.selector,
+            "--timeout", str(self.recover_timeout_seconds),
+        ))
+
+        if returncode != 0:
+            details = self.format_command_error(stdout, stderr)
+            raise ControllerError(f"Failed to run session recover for {self.selector}: {details}")
+
+    def check_log_tail_for_prompt(
+        self,
+        log_file: Path,
+        prompt: str,
+        tail_lines: int = 50
+    ) -> bool:
+        """Check log tail for specific prompt.
+
+        Args:
+            log_file: Path to log file.
+            prompt: Prompt string to search for.
+            tail_lines: Number of lines to check from end.
+
+        Returns:
+            True if prompt found in tail.
+        """
+        try:
+            from collections import deque
+
+            # Use bounded deque to keep only last N lines in memory
+            tail = deque(maxlen=tail_lines)
+
+            with open(log_file, 'r', encoding='utf-8', errors='ignore') as f:
+                for line in f:
+                    tail.append(line)
+
+            tail_content = ''.join(tail)
+            return prompt in tail_content
+        except OSError as e:
+            print(f"WARNING: Cannot read {log_file}: {e}", file=sys.stderr)
+            return False
+
+    def find_prompted_minicom_log(self, max_age_seconds: int = 600) -> Optional[Path]:
+        """Find a recent minicom log whose tail already shows a usable prompt."""
+        log_file = self.find_latest_selector_log(max_age_seconds=max_age_seconds)
+        if not log_file:
+            return None
+
+        prompt_checks = ("=>", "root@prplOS:/#")
+        if any(self.check_log_tail_for_prompt(log_file, prompt) for prompt in prompt_checks):
+            return log_file
+
+        return None
+
+    def find_latest_selector_log(self, max_age_seconds: Optional[int] = 600) -> Optional[Path]:
+        """Find the newest minicom log for this selector, optionally bounded by age."""
+        pattern = f"mini_{self.selector}_*.log"
+        current_time = time.time()
+        latest_candidate: Optional[tuple[float, Path]] = None
+
+        for log_file in self.log_dir.glob(pattern):
+            try:
+                mtime = log_file.stat().st_mtime
+            except OSError as e:
+                print(f"WARNING: Cannot stat {log_file}: {e}", file=sys.stderr)
+                continue
+            if max_age_seconds is not None and current_time - mtime > max_age_seconds:
+                continue
+            if latest_candidate is None or mtime > latest_candidate[0]:
+                latest_candidate = (mtime, log_file)
+
+        if latest_candidate is None:
+            return None
+
+        return latest_candidate[1]
+
+    def iter_previous_run_state_dirs(self):
+        """Iterate previously created run-state directories for this selector."""
+        return Path("/tmp").glob(f"serialwrap-reboot-test.{self.selector}.*")
+
+    def find_trusted_previous_active_log(self, max_age_seconds: int = 600) -> Optional[Path]:
+        """Reuse a prior active log only when it matches the newest current selector log."""
+        latest_log = self.find_latest_selector_log(max_age_seconds=None)
+        if not latest_log or not latest_log.exists():
+            return None
+
+        log_dir_resolved = self.log_dir.resolve()
+        latest_resolved = latest_log.resolve()
+        try:
+            latest_resolved.relative_to(log_dir_resolved)
+        except ValueError:
+            return None
+
+        for state_dir in self.iter_previous_run_state_dirs():
+            state_file = state_dir / "active_minicom_log.txt"
+            try:
+                stored_path_text = state_file.read_text(encoding="utf-8").strip()
+            except OSError:
+                continue
+            if not stored_path_text:
+                continue
+
+            stored_path = Path(stored_path_text)
+            if not stored_path.exists():
+                continue
+
+            stored_resolved = stored_path.resolve()
+            try:
+                stored_resolved.relative_to(log_dir_resolved)
+            except ValueError:
+                continue
+
+            if stored_resolved == latest_resolved:
+                return latest_log
+
+        return None
+
+    def send_raw_broker_command(self, command: str) -> float:
+        """Send raw console command through interactive session APIs.
+
+        Args:
+            command: Command string to send.
+
+        Returns:
+            Timestamp of command submission.
+
+        Raises:
+            ControllerError: If broker command fails.
+        """
+        returncode, stdout, stderr = self.runner.run(self.serialwrap_cmd(
+            "session", "interactive-open",
+            "--selector", self.selector,
+            "--owner", "agent:reboot-controller",
+            "--timeout", "30"
+        ))
+        data = self.parse_json_object(stdout)
+        if returncode != 0:
+            details = self.format_command_error(stdout, stderr)
+            error = ControllerError(
+                f"Failed to open interactive session for '{command}' on {self.selector}: {details}",
+                error_code=data.get("error_code") if data else None,
+                payload=data,
+            )
+            if error.error_code != "SESSION_NOT_READY":
+                raise error
+
+            attach_rc, attach_stdout, attach_stderr = self.runner.run(self.serialwrap_cmd(
+                "session", "console-attach",
+                "--selector", self.selector,
+                "--label", "human:agent-reboot-controller",
+            ))
+            attach_data = self.parse_json_object(attach_stdout)
+            if attach_rc != 0:
+                details = self.format_command_error(attach_stdout, attach_stderr)
+                raise ControllerError(
+                    f"Failed to attach console for '{command}' on {self.selector}: {details}",
+                    error_code=attach_data.get("error_code") if attach_data else None,
+                    payload=attach_data,
+                )
+
+            if not attach_data:
+                raise ControllerError(
+                    f"Failed to parse console-attach response for {self.selector}: expected JSON object"
+                )
+
+            client_id = attach_data.get("client_id")
+            fd = None
+            result_time = None
+            pending_error = None
+            detach_error = None
+            try:
+                vtty = attach_data.get("vtty")
+                interactive_owner = attach_data.get("interactive_owner") is True
+                if not interactive_owner:
+                    raise ControllerError(
+                        f"Console attach for {self.selector} did not grant interactive ownership for '{command}'",
+                        payload=attach_data,
+                    )
+                if not client_id or not vtty:
+                    raise ControllerError(
+                        f"Failed to parse console-attach response for {self.selector}: missing client_id or vtty",
+                        payload=attach_data,
+                    )
+
+                payload = f"{command}\n".encode("utf-8")
+                fd = os.open(vtty, os.O_WRONLY)
+                written = os.write(fd, payload)
+                if written != len(payload):
+                    raise ControllerError(
+                        f"Failed to write raw broker command '{command}' to {self.selector}: short write"
+                    )
+                result_time = time.time()
+            except OSError as e:
+                pending_error = ControllerError(
+                    f"Failed to write raw broker command '{command}' to {self.selector}: {e}"
+                )
+            except ControllerError as e:
+                pending_error = e
+            finally:
+                if fd is not None:
+                    os.close(fd)
+
+                if client_id:
+                    detach_rc, detach_stdout, detach_stderr = self.runner.run(self.serialwrap_cmd(
+                        "session", "console-detach",
+                        "--selector", self.selector,
+                        "--client-id", str(client_id),
+                    ))
+                    detach_data = self.parse_json_object(detach_stdout)
+                    if detach_rc != 0:
+                        if detach_data and detach_data.get("error_code") == "CONSOLE_NOT_FOUND":
+                            detach_error = None
+                        else:
+                            details = self.format_command_error(detach_stdout, detach_stderr)
+                            detach_error = ControllerError(
+                                f"Failed to detach console for {self.selector}: {details}",
+                                error_code=detach_data.get("error_code") if detach_data else None,
+                                payload=detach_data,
+                            )
+
+            if pending_error is not None:
+                raise pending_error
+            if detach_error is not None:
+                raise detach_error
+
+            return result_time
+
+        try:
+            data = json.loads(stdout)
+            interactive_id = data["interactive_id"]
+        except (json.JSONDecodeError, KeyError, TypeError) as e:
+            raise ControllerError(f"Failed to parse interactive-open response for {self.selector}: {e}")
+
+        pending_error = None
+        close_error = None
+        result_time = None
+        try:
+            returncode, stdout, stderr = self.runner.run(self.serialwrap_cmd(
+                "session", "interactive-send",
+                "--interactive-id", interactive_id,
+                "--data", f"{command}\n",
+                "--encoding", "plain"
+            ))
+            if returncode != 0:
+                details = self.format_command_error(stdout, stderr)
+                pending_error = ControllerError(
+                    f"Failed to send raw broker command '{command}' to {self.selector}: {details}"
+                )
+            else:
+                result_time = time.time()
+        finally:
+            close_rc, close_stdout, close_stderr = self.runner.run(self.serialwrap_cmd(
+                "session", "interactive-close",
+                "--interactive-id", interactive_id
+            ))
+            if close_rc != 0:
+                details = self.format_command_error(close_stdout, close_stderr)
+                close_error = ControllerError(f"Failed to close interactive session for {self.selector}: {details}")
+
+        if pending_error is not None:
+            raise pending_error
+        if close_error is not None:
+            raise close_error
+
+        return result_time
+
+    def decide_reboot_action(
+        self,
+        last_action: Optional[float]
+    ) -> Dict[str, Any]:
+        """Decide next reboot action.
+
+        Args:
+            last_action: Timestamp of last reboot or fallback action.
+
+        Returns:
+            Dictionary with action type and details.
+        """
+        # Check if READY and self-test OK
+        if self.check_ready_state() and self.check_self_test():
+            return {"type": "normal_reboot"}
+
+        # Not READY - check throttle
+        if self.should_throttle_recovery(last_action):
+            return {"type": "wait"}
+
+        # Run recover
+        try:
+            self.run_session_recover()
+        except ControllerError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+
+        # Check if now ready
+        if self.check_ready_state():
+            return {"type": "wait"}  # Will reboot on next cycle
+
+        # Check log tail for prompts
+        if self.active_log_path:
+            if self.check_log_tail_for_prompt(self.active_log_path, "=>"):
+                return {"type": "raw_reset"}
+            elif self.check_log_tail_for_prompt(self.active_log_path, "root@prplOS:/#"):
+                return {"type": "raw_reboot"}
+
+        return {"type": "wait"}
+
+    def startup(self) -> bool:
+        """Run startup sequence.
+
+        Returns:
+            True if startup succeeded, False otherwise.
+        """
+        # 1. Check serialwrap event support
+        if not self.check_serialwrap_event_support():
+            print("ERROR: serialwrap event subcommand not available", file=sys.stderr)
+            return False
+
+        # 2. Check daemon status
+        if not self.check_daemon_status():
+            print("ERROR: serialwrap daemon not running", file=sys.stderr)
+            return False
+
+        active_log: Optional[Path] = None
+
+        # 3. Send marker command
+        try:
+            marker = self.send_marker_command()
+        except ControllerError as e:
+            if getattr(e, "error_code", None) != "SESSION_NOT_READY":
+                print(f"ERROR: {e}", file=sys.stderr)
+                return False
+            active_log = self.find_prompted_minicom_log()
+            if not active_log:
+                active_log = self.find_trusted_previous_active_log()
+            if not active_log:
+                print(f"ERROR: {e}", file=sys.stderr)
+                return False
+        else:
+            # 4. Find active minicom log
+            active_log = self.find_active_minicom_log(marker)
+            if not active_log:
+                active_log = self.find_prompted_minicom_log()
+            if not active_log:
+                active_log = self.find_trusted_previous_active_log()
+
+        if not active_log:
+            print(f"ERROR: No active minicom log found for {self.selector}", file=sys.stderr)
+            return False
+
+        # Set active_log_path for use in reboot loop
+        self.active_log_path = active_log
+
+        # 5. Derive report path
+        report_path = self.derive_report_path(active_log)
+
+        # 6. Create run-state directory
+        self.state_dir = self.create_run_state_directory()
+
+        # Wrap everything after state creation to ensure cleanup on failure
+        try:
+            # 7. Store run state
+            self.store_run_state(self.state_dir, active_log, report_path)
+
+            # 8. Register event rules
+            self.register_event_rules()
+
+            # 9. Enable this selector
+            self.enable_selector()
+
+            # 10. Register signal handlers
+            self.register_signal_handlers()
+
+            return True
+        except ControllerError as e:
+            # Cleanup on any failure after state dir creation
+            print(f"ERROR: {e}", file=sys.stderr)
+            self._cleanup_on_startup_failure()
+            return False
+
+    def run_loop(self) -> None:
+        """Run one iteration of the reboot loop."""
+        # Decide next action
+        action = self.decide_reboot_action(self.last_action_time)
+
+        # Execute action
+        if action['type'] == 'normal_reboot':
+            try:
+                self.last_action_time = self.submit_normal_reboot()
+                self.sleep_fn(self.loop_delay)
+            except ControllerError as e:
+                print(f"ERROR: {e}", file=sys.stderr)
+                self.sleep_fn(self.loop_delay)
+        elif action['type'] == 'raw_reset':
+            try:
+                self.last_action_time = self.send_raw_broker_command("reset")
+            except ControllerError as e:
+                print(f"ERROR: {e}", file=sys.stderr)
+            self.sleep_fn(self.loop_delay)
+        elif action['type'] == 'raw_reboot':
+            try:
+                self.last_action_time = self.send_raw_broker_command("reboot -f")
+            except ControllerError as e:
+                print(f"ERROR: {e}", file=sys.stderr)
+            self.sleep_fn(self.loop_delay)
+        elif action['type'] == 'wait':
+            self.sleep_fn(self.loop_delay)
+
+    def _cleanup_on_startup_failure(self) -> None:
+        """Best-effort cleanup when startup fails after state creation.
+
+        Attempts to clean up state directory and event rules. Errors are logged
+        as warnings but cleanup continues through all steps.
+        """
+        # Try to disable and reset selector (may not be enabled yet)
+        try:
+            self.disable_selector()
+        except ControllerError as e:
+            print(f"WARNING: Failed to disable selector during startup cleanup: {e}", file=sys.stderr)
+
+        try:
+            self.reset_selector()
+        except ControllerError as e:
+            print(f"WARNING: Failed to reset selector during startup cleanup: {e}", file=sys.stderr)
+
+        # Try to remove event rules if no other selectors are enabled
+        try:
+            other_selectors_enabled = self.check_other_selectors_enabled()
+            if other_selectors_enabled is False:
+                self.remove_event_rules()
+        except ControllerError as e:
+            print(f"WARNING: Failed to remove event rules during startup cleanup: {e}", file=sys.stderr)
+
+        # Always try to remove state directory
+        if self.state_dir and self.state_dir.exists():
+            try:
+                import shutil
+                shutil.rmtree(self.state_dir)
+            except OSError as e:
+                print(f"WARNING: Failed to remove state directory during startup cleanup: {e}", file=sys.stderr)
+
+    def cleanup(self) -> None:
+        """Cleanup on exit.
+
+        Attempts all cleanup steps. Errors are logged but don't prevent
+        state directory removal.
+        """
+        # Disable and reset this selector
+        try:
+            self.disable_selector()
+        except ControllerError as e:
+            print(f"WARNING: Failed to disable selector during cleanup: {e}", file=sys.stderr)
+
+        try:
+            self.reset_selector()
+        except ControllerError as e:
+            print(f"WARNING: Failed to reset selector during cleanup: {e}", file=sys.stderr)
+
+        # Check if other selectors are still enabled
+        try:
+            other_selectors_enabled = self.check_other_selectors_enabled()
+            if other_selectors_enabled is False:
+                # Remove shared rules
+                self.remove_event_rules()
+        except ControllerError as e:
+            print(f"WARNING: Failed to remove event rules during cleanup: {e}", file=sys.stderr)
+
+        # Remove state directory (always attempt this)
+        if self.state_dir and self.state_dir.exists():
+            import shutil
+            try:
+                shutil.rmtree(self.state_dir)
+            except OSError as e:
+                print(f"WARNING: Failed to remove state directory: {e}", file=sys.stderr)
+
+    def _signal_handler(self, signum: int, frame: Any) -> None:
+        """Handle signals."""
+        self._stop_requested = True
+        self.cleanup()
+        sys.exit(0)
+
+    def register_signal_handlers(self) -> None:
+        """Register signal handlers for SIGINT and SIGTERM."""
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+
+    def exit_gracefully(self) -> None:
+        """Exit gracefully with cleanup."""
+        self.cleanup()
+
+    def should_stop(self) -> bool:
+        """Check if controller should stop.
+
+        Returns:
+            True if stop condition met.
+        """
+        if self._stop_requested:
+            return True
+
+        # Check hours limit
+        if self.hours_limit is not None:
+            elapsed_hours = (time.time() - self.start_time) / 3600
+            if elapsed_hours >= self.hours_limit:
+                return True
+
+        # Check count limit
+        if self.count_limit is not None:
+            if self.reboot_count >= self.count_limit:
+                return True
+
+        return False
+
+
+def parse_args(argv):
+    """Parse command-line arguments for the reboot controller.
+
+    Args:
+        argv: List of command-line arguments (excluding program name).
+
+    Returns:
+        Namespace object with parsed arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="Control reboot testing for a single COM selector."
+    )
+    parser.add_argument(
+        "--selector",
+        required=True,
+        help="COM selector (e.g., COM0, COM1)"
+    )
+    parser.add_argument(
+        "--hours",
+        type=positive_int,
+        help="Stop after N hours"
+    )
+    parser.add_argument(
+        "--count",
+        type=positive_int,
+        help="Stop after N completed reboot attempts"
+    )
+
+    args = parser.parse_args(argv)
+
+    # Validate selector format
+    if not re.match(r'^COM[0-9]+$', args.selector):
+        parser.error(f"Invalid selector: {args.selector}. Must match pattern COM[0-9]+")
+
+    return args
+
+
+def main_with_runner(
+    argv: List[str],
+    runner: Optional[Any] = None,
+    log_dir: Optional[Path] = None
+) -> int:
+    """Main entry point with injectable runner for testing.
+
+    Args:
+        argv: Command-line arguments.
+        runner: Optional command runner.
+        log_dir: Optional log directory.
+
+    Returns:
+        Exit code.
+    """
+    args = parse_args(argv)
+
+    # Create controller
+    controller = RebootController(
+        selector=args.selector,
+        runner=runner,
+        log_dir=log_dir,
+        hours_limit=args.hours,
+        count_limit=args.count
+    )
+
+    # Run startup
+    if not controller.startup():
+        return 1
+
+    # Run loop until stop condition
+    try:
+        try:
+            while not controller.should_stop():
+                controller.run_loop()
+        except KeyboardInterrupt:
+            print("\nInterrupted by user", file=sys.stderr)
+    finally:
+        controller.cleanup()
+    return 0
+
+
+def main():
+    """Main entry point for the reboot controller."""
+    return main_with_runner(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/serialwrap_reboot_test/event_handler.py
+++ b/serialwrap_reboot_test/event_handler.py
@@ -1,0 +1,732 @@
+"""Event handler module for serialwrap-event-handler."""
+
+import contextlib
+import fcntl
+import json
+import os
+import re
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Dict, Any, List, Tuple, Iterator, TextIO
+
+
+SELECTOR_PATTERN = re.compile(r"^COM[0-9]+$")
+
+EVENT_MATCH_TEXT = {
+    "brcm-therm": "brcm-therm",
+    "link-down": "Link is Down",
+    "Link is Down": "Link is Down",
+    "pstate": "pstate",
+    "kernel-panic": "Kernel panic",
+    "Kernel panic": "Kernel panic",
+    "smc-bootloader": "SMC bootloader",
+    "SMC bootloader": "SMC bootloader",
+}
+
+
+@contextlib.contextmanager
+def _locked_file(lock_path: Path):
+    """Context manager for file locking.
+
+    Args:
+        lock_path: Path to lock file.
+
+    Yields:
+        None (lock is held during context).
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_fd = None
+    try:
+        lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        if lock_fd is not None:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                os.close(lock_fd)
+            except OSError:
+                pass
+
+
+def write_text_atomic(file_path: Path, content: str) -> None:
+    """Write text to file atomically using temp file and rename.
+
+    Args:
+        file_path: Path to target file.
+        content: Text content to write.
+
+    Raises:
+        IOError: On write failure.
+    """
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, temp_path = tempfile.mkstemp(
+        dir=file_path.parent,
+        prefix=f".tmp_{file_path.name}_",
+        suffix=".tmp"
+    )
+
+    try:
+        with os.fdopen(fd, 'w') as f:
+            f.write(content)
+
+        # Atomic rename
+        os.replace(temp_path, file_path)
+    except (IOError, OSError) as e:
+        # Clean up temp file on error
+        try:
+            os.unlink(temp_path)
+        except OSError:
+            pass
+        raise IOError(f"Failed to write file atomically: {e}")
+
+
+def _normalize_event_name(payload: Dict[str, Any]) -> Optional[str]:
+    """Return report event name from old or current serialwrap payload fields."""
+    event = payload.get("event")
+    if event is not None:
+        if not isinstance(event, str):
+            return None
+        return EVENT_MATCH_TEXT.get(event)
+
+    candidates = [
+        payload.get("matched_text"),
+        payload.get("rule_name"),
+    ]
+    rule_id = payload.get("rule_id")
+    if isinstance(rule_id, str) and "." in rule_id:
+        candidates.append(rule_id.rsplit(".", 1)[1])
+
+    for candidate in candidates:
+        if isinstance(candidate, str):
+            normalized = EVENT_MATCH_TEXT.get(candidate)
+            if normalized is not None:
+                return normalized
+    return None
+
+
+def _event_timestamp(payload: Dict[str, Any]) -> str:
+    """Return ISO trigger timestamp from old or current serialwrap payload fields."""
+    timestamp = payload.get("timestamp")
+    if isinstance(timestamp, str) and timestamp:
+        return timestamp
+
+    matched_at = payload.get("matched_at", payload.get("trigger_ts"))
+    if isinstance(matched_at, (int, float)):
+        value = float(matched_at)
+        if value > 10_000_000_000:
+            value = value / 1000.0
+        return datetime.fromtimestamp(value, timezone.utc).astimezone().isoformat()
+
+    return datetime.now(timezone.utc).astimezone().isoformat()
+
+
+def parse_event_payload(payload_str: str) -> Optional[Dict[str, Any]]:
+    """Parse event payload from JSON string.
+
+    Args:
+        payload_str: JSON string containing event payload.
+
+    Returns:
+        Parsed payload dict if valid with selector and event, None otherwise.
+    """
+    if not payload_str or not payload_str.strip():
+        return None
+
+    try:
+        payload = json.loads(payload_str)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    selector = payload.get("selector")
+    if not isinstance(selector, str) or not SELECTOR_PATTERN.match(selector):
+        return None
+
+    normalized_event = _normalize_event_name(payload)
+    if normalized_event is None:
+        return None
+
+    payload["event"] = normalized_event
+    payload["timestamp"] = _event_timestamp(payload)
+    return payload
+
+
+def _is_path_within_directory(path: Path, directory: Path) -> bool:
+    """Check if path is within directory (no path traversal).
+
+    Args:
+        path: Path to check.
+        directory: Directory that should contain the path.
+
+    Returns:
+        True if path is within directory, False otherwise.
+    """
+    try:
+        path_resolved = path.resolve()
+        dir_resolved = directory.resolve()
+        return path_resolved.is_relative_to(dir_resolved)
+    except (ValueError, RuntimeError, OSError):
+        return False
+
+
+def derive_report_path_from_log(selector: str, log_path: Path) -> Optional[Path]:
+    """Derive report path from minicom log path.
+
+    Args:
+        selector: COM selector (e.g., COM0, COM1).
+        log_path: Path to minicom log file.
+
+    Returns:
+        Report path if log name is standard format, None otherwise.
+    """
+    log_name = log_path.name
+
+    # Expected format: mini_<selector>_<timestamp>.log
+    parts = log_name.split('_')
+    if len(parts) < 3:
+        return None
+
+    if not log_name.startswith(f"mini_{selector}_"):
+        return None
+
+    if not log_name.endswith('.log'):
+        return None
+
+    # Extract timestamp part (everything after mini_<selector>_)
+    prefix = f"mini_{selector}_"
+    timestamp_part = log_name[len(prefix):].replace('.log', '')
+
+    if not timestamp_part:
+        return None
+
+    report_name = f"event-triggered_{selector}_{timestamp_part}.md"
+    return log_path.parent / report_name
+
+
+def validate_report_path_for_log(
+    selector: str,
+    log_path: Path,
+    report_path: Path,
+    log_dir: Path
+) -> bool:
+    """Validate a state-provided report path against the active log.
+
+    Args:
+        selector: COM selector.
+        log_path: Active minicom log path.
+        report_path: State-provided report path.
+        log_dir: Directory containing minicom logs and reports.
+
+    Returns:
+        True if report_path is safe and matches the active log timestamp.
+    """
+    if not _is_path_within_directory(report_path, log_dir):
+        return False
+
+    derived_path = derive_report_path_from_log(selector, log_path)
+    if derived_path is None:
+        return False
+
+    try:
+        return report_path.resolve() == derived_path.resolve()
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def resolve_active_state(
+    selector: str,
+    state_root: Path = Path("/tmp"),
+    log_dir: Optional[Path] = None
+) -> Tuple[Optional[Path], Optional[Path]]:
+    """Resolve active log and report path for selector.
+
+    Resolution order:
+    1. Current-run state in state_root/serialwrap-reboot-test.<selector>.<pid>/
+       - Read active_minicom_log.txt and optionally report_path.txt
+       - Validate log path is within log_dir (security check)
+    2. Fallback to latest mini_<selector>_*.log in log_dir updated within 10 minutes.
+
+    Args:
+        selector: COM selector (e.g., COM0, COM1).
+        state_root: Root directory for state files (default /tmp).
+        log_dir: Directory containing minicom logs (default ~/b-log).
+
+    Returns:
+        Tuple of (active_log_path, report_path) or (None, None) if not found.
+        report_path is from state or derived from log, may be None if derivation fails.
+    """
+    if log_dir is None:
+        log_dir = Path.home() / "b-log"
+
+    # Try current-run state
+    pattern = f"serialwrap-reboot-test.{selector}.*"
+    for state_dir in state_root.glob(pattern):
+        if not state_dir.is_dir():
+            continue
+
+        active_log_file = state_dir / "active_minicom_log.txt"
+        if not active_log_file.exists():
+            continue
+
+        log_path_str = active_log_file.read_text().strip()
+        log_path = Path(log_path_str)
+
+        # Security check: validate path is within log_dir
+        if not log_path.exists():
+            continue
+
+        if not _is_path_within_directory(log_path, log_dir):
+            print(
+                f"Warning: Rejected log path outside log_dir: {log_path}",
+                file=sys.stderr
+            )
+            continue
+
+        # Check for report_path.txt in state
+        report_path_file = state_dir / "report_path.txt"
+        if report_path_file.exists():
+            report_path_str = report_path_file.read_text().strip()
+            report_path = Path(report_path_str)
+            if validate_report_path_for_log(selector, log_path, report_path, log_dir):
+                return log_path, report_path
+            print(
+                f"Warning: Rejected report path inconsistent with active log: {report_path}",
+                file=sys.stderr
+            )
+
+        # No report_path.txt, derive it
+        report_path = derive_report_path_from_log(selector, log_path)
+        return log_path, report_path
+
+    # Fallback to recent log in log_dir
+    pattern = f"mini_{selector}_*.log"
+    candidates = []
+
+    for log_path in log_dir.glob(pattern):
+        if not log_path.is_file():
+            continue
+
+        mtime = log_path.stat().st_mtime
+        age_minutes = (time.time() - mtime) / 60.0
+
+        if age_minutes <= 10:
+            candidates.append((mtime, log_path))
+
+    if candidates:
+        candidates.sort(reverse=True)
+        log_path = candidates[0][1]
+        report_path = derive_report_path_from_log(selector, log_path)
+        return log_path, report_path
+
+    return None, None
+
+
+def resolve_active_log(
+    selector: str,
+    state_root: Path = Path("/tmp"),
+    log_dir: Optional[Path] = None
+) -> Optional[Path]:
+    """Resolve active minicom log for selector.
+
+    Deprecated: Use resolve_active_state() instead.
+
+    Resolution order:
+    1. Current-run state in state_root/serialwrap-reboot-test.<selector>.<pid>/
+    2. Fallback to latest mini_<selector>_*.log in log_dir updated within 10 minutes.
+
+    Args:
+        selector: COM selector (e.g., COM0, COM1).
+        state_root: Root directory for state files (default /tmp).
+        log_dir: Directory containing minicom logs (default ~/b-log).
+
+    Returns:
+        Path to active log if found and exists, None otherwise.
+    """
+    log_path, _ = resolve_active_state(selector, state_root=state_root, log_dir=log_dir)
+    return log_path
+
+
+def scan_log_for_events(
+    log_file: TextIO,
+    event_pattern: str,
+    start_line: int = 0
+) -> Iterator[Tuple[int, str]]:
+    """Scan log file for event matches.
+
+    Args:
+        log_file: Open text file to scan.
+        event_pattern: Text pattern to search for.
+        start_line: Line number to start scanning from (0-indexed, exclusive).
+
+    Yields:
+        Tuples of (line_number, line_text) for matches (1-indexed line numbers).
+    """
+    for line_num, line in enumerate(log_file, start=1):
+        if line_num <= start_line:
+            continue
+
+        if event_pattern in line:
+            yield (line_num, line.rstrip('\n'))
+
+
+def load_scan_cursors(cursor_file: Path) -> Dict[str, int]:
+    """Load scan cursors from file.
+
+    Args:
+        cursor_file: Path to cursor state file.
+
+    Returns:
+        Dictionary mapping event names to last matched line numbers.
+    """
+    if not cursor_file.exists():
+        return {}
+
+    try:
+        with cursor_file.open() as f:
+            return json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"Warning: Failed to parse cursor file {cursor_file}: {e}", file=sys.stderr)
+        return {}
+    except IOError as e:
+        print(f"Warning: Failed to read cursor file {cursor_file}: {e}", file=sys.stderr)
+        return {}
+
+
+def _save_scan_cursors_unlocked(cursor_file: Path, cursors: Dict[str, int]) -> None:
+    """Save scan cursors to file WITHOUT locking (internal helper).
+
+    Used when caller already holds a lock. Merges with existing data.
+
+    Args:
+        cursor_file: Path to cursor state file.
+        cursors: Dictionary mapping event names to line numbers to save/update.
+
+    Raises:
+        IOError: On save failure.
+    """
+    cursor_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # Load existing cursors and merge
+    existing = load_scan_cursors(cursor_file)
+    existing.update(cursors)
+
+    # Atomic write: write to temp file then rename
+    fd, temp_path = tempfile.mkstemp(
+        dir=cursor_file.parent,
+        prefix=".tmp_cursors_",
+        suffix=".json"
+    )
+
+    try:
+        with os.fdopen(fd, 'w') as f:
+            json.dump(existing, f, indent=2)
+
+        # Atomic rename
+        os.replace(temp_path, cursor_file)
+    except (IOError, OSError, json.JSONEncodeError) as e:
+        # Clean up temp file on error
+        try:
+            os.unlink(temp_path)
+        except OSError:
+            pass
+        raise IOError(f"Failed to save cursors: {e}")
+
+
+def save_scan_cursors(cursor_file: Path, cursors: Dict[str, int]) -> None:
+    """Save scan cursors to file with locking, merging with existing data.
+
+    Args:
+        cursor_file: Path to cursor state file.
+        cursors: Dictionary mapping event names to line numbers to save/update.
+
+    Raises:
+        IOError: On save failure.
+    """
+    cursor_file.parent.mkdir(parents=True, exist_ok=True)
+    lock_file = cursor_file.parent / f"{cursor_file.name}.lock"
+
+    with _locked_file(lock_file):
+        _save_scan_cursors_unlocked(cursor_file, cursors)
+
+
+def load_report_data(report_path: Path) -> Dict[str, Any]:
+    """Load existing report data.
+
+    Args:
+        report_path: Path to report markdown file.
+
+    Returns:
+        Dictionary with 'events' (list) and 'summary' (dict) keys.
+    """
+    data = {
+        "events": [],
+        "summary": {}
+    }
+
+    if not report_path.exists():
+        return data
+
+    content = report_path.read_text()
+
+    # Parse summary table
+    summary_match = re.search(
+        r'## Summary.*?\| Event \| Count \|.*?\n\| --- \| ---: \| ---: \|\n(.*?)(?=\n##|\Z)',
+        content,
+        re.DOTALL
+    )
+    if summary_match:
+        for line in summary_match.group(1).strip().split('\n'):
+            parts = [p.strip() for p in line.split('|')]
+            if len(parts) >= 3:
+                event_name = parts[1]
+                try:
+                    count = int(parts[2])
+                    data["summary"][event_name] = count
+                except ValueError as e:
+                    print(f"Warning: Malformed summary row in {report_path}, skipping: {line.strip()}", file=sys.stderr)
+
+    # Parse event table
+    events_match = re.search(
+        r'## Events.*?\| Log name \| Log line number \|.*?\n\| --- \| ---: \| --- \| --- \|\n(.*?)(?=\n##|\Z)',
+        content,
+        re.DOTALL
+    )
+    if events_match:
+        for line in events_match.group(1).strip().split('\n'):
+            parts = [p.strip() for p in line.split('|')]
+            if len(parts) >= 5:
+                try:
+                    event_entry = {
+                        "log_name": parts[1],
+                        "line_number": int(parts[2]),
+                        "timestamp": parts[3],
+                        "event": parts[4]
+                    }
+                    data["events"].append(event_entry)
+                except (ValueError, IndexError) as e:
+                    print(f"Warning: Malformed event row in {report_path}, skipping: {line.strip()}", file=sys.stderr)
+
+    return data
+
+
+def generate_report_content(
+    log_name: str,
+    events: List[Dict[str, Any]],
+    summary: Dict[str, int]
+) -> str:
+    """Generate report markdown content.
+
+    Args:
+        log_name: Name of the minicom log file.
+        events: List of event dictionaries with log_name, line_number, timestamp, event.
+        summary: Dictionary mapping event names to counts.
+
+    Returns:
+        Report markdown content as string.
+    """
+    now = datetime.now(timezone.utc).astimezone().isoformat()
+
+    # Calculate probabilities
+    denominator = summary.get("SMC bootloader", 0)
+
+    # Define event order
+    event_order = [
+        "brcm-therm",
+        "Link is Down",
+        "pstate",
+        "Kernel panic",
+        "SMC bootloader"
+    ]
+
+    lines = [
+        "# Event Triggered Report",
+        "",
+        f"Log: {log_name}",
+        f"Generated: {now}",
+        "",
+        "## Summary",
+        "",
+        f"Denominator: SMC bootloader = {denominator}",
+        "",
+        "| Event | Count | Probability vs SMC bootloader |",
+        "| --- | ---: | ---: |",
+    ]
+
+    for event_name in event_order:
+        count = summary.get(event_name, 0)
+        if denominator == 0:
+            # When denominator is 0, all events show N/A
+            prob_str = "N/A"
+        else:
+            prob = (count / denominator) * 100
+            prob_str = f"{prob:.2f}%"
+
+        lines.append(f"| {event_name} | {count} | {prob_str} |")
+
+    lines.extend([
+        "",
+        "## Events",
+        "",
+        "| Log name | Log line number | Event trigger time | Event |",
+        "| --- | ---: | --- | --- |",
+    ])
+
+    for event in events:
+        lines.append(
+            f"| {event['log_name']} | {event['line_number']} | "
+            f"{event['timestamp']} | {event['event']} |"
+        )
+
+    return '\n'.join(lines) + '\n'
+
+
+def handle_event(
+    payload: Dict[str, Any],
+    state_root: Path = Path("/tmp"),
+    log_dir: Optional[Path] = None
+) -> int:
+    """Handle a single event.
+
+    Args:
+        payload: Parsed event payload dictionary.
+        state_root: Root directory for state files.
+        log_dir: Directory containing minicom logs.
+
+    Returns:
+        0 on success, non-zero on error.
+    """
+    selector = payload["selector"]
+    event_name = payload["event"]
+    event_timestamp = payload.get("timestamp", datetime.now(timezone.utc).astimezone().isoformat())
+
+    if log_dir is None:
+        log_dir = Path.home() / "b-log"
+
+    try:
+        # Resolve active log and report path
+        log_path, report_path = resolve_active_state(selector, state_root=state_root, log_dir=log_dir)
+        if log_path is None:
+            print(f"Error: Could not resolve active log for selector {selector}", file=sys.stderr)
+            return 1
+
+        # Validate or derive report path
+        if report_path is None:
+            report_path = derive_report_path_from_log(selector, log_path)
+            if report_path is None:
+                print(
+                    f"Error: Could not derive report path from log: {log_path.name}",
+                    file=sys.stderr
+                )
+                return 1
+
+        # Derive cursor file path from log name
+        log_basename = log_path.name
+        # Extract timestamp part safely
+        parts = log_basename.split('_')
+        if len(parts) >= 3:
+            timestamp_part = log_basename.split('_', 2)[2].replace('.log', '')
+        else:
+            print(
+                f"Error: Cannot derive cursor file from non-standard log name: {log_basename}",
+                file=sys.stderr
+            )
+            return 1
+
+        cursor_file = log_dir / f".event-cursors_{selector}_{timestamp_part}.json"
+
+        # Use a lock file based on report path to coordinate report+cursor updates
+        lock_file = report_path.parent / f".{report_path.name}.lock"
+
+        with _locked_file(lock_file):
+            # Load cursors inside lock to prevent race
+            cursors = load_scan_cursors(cursor_file)
+            start_line = cursors.get(event_name, 0)
+
+            # Scan log for next match (streaming - only consume first match)
+            try:
+                with log_path.open() as f:
+                    match_iter = scan_log_for_events(f, event_name, start_line=start_line)
+                    try:
+                        line_number, line_text = next(match_iter)
+                    except StopIteration:
+                        print(f"Warning: No new matches for event '{event_name}' in {log_path}", file=sys.stderr)
+                        return 0
+            except (IOError, OSError) as e:
+                print(f"Error: Failed to read log file {log_path}: {e}", file=sys.stderr)
+                return 1
+
+            # Load existing report data
+            report_data = load_report_data(report_path)
+
+            # Add new event
+            report_data["events"].append({
+                "log_name": log_basename,
+                "line_number": line_number,
+                "timestamp": event_timestamp,
+                "event": event_name
+            })
+
+            # Update summary
+            report_data["summary"][event_name] = report_data["summary"].get(event_name, 0) + 1
+
+            # Generate and write report atomically
+            content = generate_report_content(
+                log_basename,
+                report_data["events"],
+                report_data["summary"]
+            )
+
+            try:
+                write_text_atomic(report_path, content)
+            except IOError as e:
+                print(f"Error: Failed to write report {report_path}: {e}", file=sys.stderr)
+                return 1
+
+            # Update cursor after successful report write (under same lock, no nested lock)
+            try:
+                _save_scan_cursors_unlocked(cursor_file, {event_name: line_number})
+            except IOError as e:
+                print(f"Error: Failed to save cursor: {e}", file=sys.stderr)
+                return 1
+
+        return 0
+
+    except PermissionError as e:
+        print(f"Error: Permission denied: {e}", file=sys.stderr)
+        return 1
+    except (IOError, OSError) as e:
+        print(f"Error: I/O error: {e}", file=sys.stderr)
+        return 1
+
+
+def main():
+    """Main entry point for the event handler."""
+    try:
+        # Read payload from stdin
+        payload_str = sys.stdin.read()
+
+        # Parse payload
+        payload = parse_event_payload(payload_str)
+        if payload is None:
+            print("Error: Invalid event payload", file=sys.stderr)
+            return 1
+
+        # Handle event
+        return handle_event(payload)
+
+    except KeyboardInterrupt:
+        return 130
+    except IOError as e:
+        print(f"Error: I/O error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/serialwrap_reboot_test/fault_installer.py
+++ b/serialwrap_reboot_test/fault_installer.py
@@ -1,0 +1,442 @@
+"""Fault installer module for serialwrap-fault-install."""
+
+import sys
+import argparse
+import base64
+import re
+import shlex
+from typing import List, Tuple
+
+from .constants import SERIALWRAP_CMD
+
+
+def build_fault_injector_script() -> str:
+    """Build the target fault injector script content.
+
+    Returns a shell script that runs at boot with 10% probability,
+    choosing equally among four fault types: thermal notification,
+    5G ethernet AN rerun, process coredump, and system crash coredump.
+    """
+    return '''#!/bin/sh
+# Serialwrap fault injector - runs once at boot
+# Silent execution - redirects to /dev/null except for intentional fault output
+
+# POSIX-compatible random number helper using /dev/urandom
+# Reads 2 bytes as unsigned 16-bit integer (0-65535)
+# Returns 0 if /dev/urandom or od fails
+get_random() {
+    value=$(od -An -N2 -tu2 /dev/urandom 2>/dev/null | tr -d ' ')
+    case "$value" in
+        ''|*[!0-9]*) echo 0 ;;
+        *) echo "$value" ;;
+    esac
+}
+
+# 10% probability gate: trigger fault if random % 10 == 0
+GATE_RAND=$(get_random)
+if [ $(( $GATE_RAND % 10 )) -ne 0 ]; then
+    exit 0
+fi
+
+# Choose fault type: 0-3 for equal 25% probability among four faults
+FAULT_TYPE_RAND=$(get_random)
+FAULT_TYPE=$(( $FAULT_TYPE_RAND % 4 ))
+
+case $FAULT_TYPE in
+    0)
+        # Thermal notification - write to /dev/console
+        echo "bcm_thermal_drv brcm-therm: Trip 0: threshold=105000 mC hysteresis=2000 mC" > /dev/console
+        ;;
+    1)
+        # 5G ethernet AN rerun - PHY reset
+        ethctl eth0 phy-reset > /dev/null 2>&1
+        ;;
+    2)
+        # Process coredump - collect all PIDs > 4000 and randomly select one
+        ALL_PIDS=$(ps aux | awk '$2 > 4000 {print $2}')
+        if [ -z "$ALL_PIDS" ]; then
+            # No eligible process, exit silently
+            exit 0
+        fi
+        # Count PIDs and randomly select one
+        PID_COUNT=$(echo "$ALL_PIDS" | wc -l)
+        PID_RAND=$(get_random)
+        RANDOM_LINE=$(( ($PID_RAND % $PID_COUNT) + 1 ))
+        TARGET_PID=$(echo "$ALL_PIDS" | sed -n "${RANDOM_LINE}p")
+        kill -SIGABRT "$TARGET_PID" > /dev/null 2>&1
+        ;;
+    3)
+        # System crash coredump - kernel panic via sysrq
+        echo c > /proc/sysrq-trigger
+        ;;
+esac
+
+exit 0
+'''
+
+
+def build_init_script() -> str:
+    """Build the init script content for /etc/init.d.
+
+    Returns a shell script that calls the fault injector on start.
+    """
+    return '''#!/bin/sh
+# Init script for serialwrap-fault-injector
+# Run at boot via S50 symlink
+
+case "$1" in
+    start)
+        /usr/sbin/serialwrap-fault-injector > /dev/null 2>&1
+        ;;
+    stop|restart|reload)
+        # No-op - injector runs once at boot
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|reload}"
+        exit 1
+        ;;
+esac
+
+exit 0
+'''
+
+
+def short_write_commands(path: str, content: str, mode: str) -> List[str]:
+    """Generate fallback commands for writing files without heredoc.
+
+    Uses base64 encoding and chunked writes to avoid large UART transfers.
+
+    Args:
+        path: Target file path
+        content: File content to write
+        mode: File permissions (e.g., "0755")
+
+    Returns:
+        List of shell commands to execute via serialwrap
+    """
+    # Validate mode parameter (must be 3-4 octal digits)
+    if not re.match(r'^0?[0-7]{3}$', mode):
+        raise ValueError(f"Invalid mode '{mode}': must be 3-4 octal digits (e.g., '0755', '644')")
+
+    commands = []
+
+    # Quote paths to prevent command injection
+    quoted_path = shlex.quote(path)
+
+    # Remove any existing file
+    commands.append(f"rm -f {quoted_path}")
+
+    # Encode content as base64 to handle special characters safely
+    encoded = base64.b64encode(content.encode()).decode()
+
+    # Create temp file for base64 content
+    temp_b64 = f"{path}.b64"
+    quoted_temp_b64 = shlex.quote(temp_b64)
+    commands.append(f"rm -f {quoted_temp_b64}")
+
+    # Write base64 content in chunks (max 200 chars per command for UART safety)
+    chunk_size = 200
+    for i in range(0, len(encoded), chunk_size):
+        chunk = encoded[i:i+chunk_size]
+        commands.append(f"echo '{chunk}' >> {quoted_temp_b64}")
+
+    # Decode base64 to final file
+    commands.append(f"base64 -d {quoted_temp_b64} > {quoted_path}")
+    commands.append(f"rm -f {quoted_temp_b64}")
+
+    # Set permissions
+    commands.append(f"chmod {mode} {quoted_path}")
+
+    return commands
+
+
+def parse_args(args: List[str]):
+    """Parse command-line arguments for fault installer.
+
+    Args:
+        args: Command-line arguments (typically sys.argv[1:])
+
+    Returns:
+        Parsed arguments namespace
+    """
+    parser = argparse.ArgumentParser(
+        description='Install serialwrap fault injector to target device'
+    )
+    parser.add_argument(
+        '--selector',
+        required=True,
+        help='COM selector (e.g., COM0, COM1)',
+        type=str
+    )
+
+    parsed = parser.parse_args(args)
+
+    # Validate selector format: COMx where x is a digit
+    if not re.match(r'^COM\d+$', parsed.selector):
+        parser.error(f"Invalid selector format: {parsed.selector}. Expected COM<digit>")
+
+    return parsed
+
+
+class CommandRunner:
+    """Interface for running commands on target via serialwrap."""
+
+    def __init__(self, selector: str):
+        """Initialize runner with COM selector.
+
+        Args:
+            selector: COM port selector (e.g., COM1)
+        """
+        self.selector = selector
+        self.serialwrap_cmd = SERIALWRAP_CMD
+
+    def run_host(self, args: List[str]) -> Tuple[int, str, str]:
+        """Run a host-side serialwrap command (e.g., file operations).
+
+        Args:
+            args: Full command arguments including serialwrap subcommand
+
+        Returns:
+            Tuple of (exit_code, stdout, stderr)
+        """
+        import subprocess
+        try:
+            result = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+            return (result.returncode, result.stdout, result.stderr)
+        except subprocess.TimeoutExpired as e:
+            return (1, "", f"Command timed out: {e}")
+        except FileNotFoundError as e:
+            return (1, "", f"Serialwrap command not found: {e}")
+        except OSError as e:
+            return (1, "", f"OS error running command: {e}")
+
+    def run_target(self, cmd: str) -> Tuple[int, str, str]:
+        """Run a command on target via serialwrap cmd submit.
+
+        Args:
+            cmd: Shell command to execute on target
+
+        Returns:
+            Tuple of (exit_code, stdout, stderr)
+        """
+        import subprocess
+        try:
+            result = subprocess.run(
+                [self.serialwrap_cmd, 'cmd', 'submit',
+                 '--selector', self.selector,
+                 '--mode', 'line',
+                 '--cmd', cmd],
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+            return (result.returncode, result.stdout, result.stderr)
+        except subprocess.TimeoutExpired as e:
+            return (1, "", f"Command timed out: {e}")
+        except FileNotFoundError as e:
+            return (1, "", f"Serialwrap command not found: {e}")
+        except OSError as e:
+            return (1, "", f"OS error running command: {e}")
+
+    def run(self, cmd: str) -> Tuple[int, str, str]:
+        """Backward compatibility: run command on target.
+
+        Args:
+            cmd: Shell command to execute on target
+
+        Returns:
+            Tuple of (exit_code, stdout, stderr)
+        """
+        return self.run_target(cmd)
+
+
+class FaultInstaller:
+    """Fault installer for target device."""
+
+    INJECTOR_PATH = "/usr/sbin/serialwrap-fault-injector"
+    INIT_PATH = "/etc/init.d/serialwrap-fault-injector"
+    SYMLINK_PATH = "/etc/rc.d/S50serialwrap-fault-injector"
+
+    def __init__(self, selector: str, runner: CommandRunner = None):
+        """Initialize installer.
+
+        Args:
+            selector: COM selector
+            runner: Command runner (defaults to CommandRunner(selector))
+        """
+        self.selector = selector
+        self.runner = runner or CommandRunner(selector)
+
+    def check_target_directories(self) -> bool:
+        """Check that required target directories exist.
+
+        Returns:
+            True if directories exist, False otherwise
+        """
+        # Check /etc/init.d
+        rc, _, _ = self.runner.run("test -d /etc/init.d")
+        if rc != 0:
+            print("ERROR: /etc/init.d does not exist on target", file=sys.stderr)
+            return False
+
+        # Check /etc/rc.d
+        rc, _, _ = self.runner.run("test -d /etc/rc.d")
+        if rc != 0:
+            print("ERROR: /etc/rc.d does not exist on target", file=sys.stderr)
+            return False
+
+        return True
+
+    def transfer_file(self, local_content: str, remote_path: str, mode: str) -> bool:
+        """Transfer file to target, trying file transfer first, then fallback.
+
+        Args:
+            local_content: Content to write
+            remote_path: Target file path
+            mode: File permissions
+
+        Returns:
+            True if successful, False otherwise
+        """
+        import tempfile
+        import os
+
+        # Try preferred file transfer first via serialwrap file send
+        temp_file = None
+        try:
+            # Create temporary file with content
+            fd, temp_file = tempfile.mkstemp(prefix='fault_installer_', suffix='.tmp')
+            try:
+                os.write(fd, local_content.encode())
+            finally:
+                os.close(fd)
+
+            # Try serialwrap file send using host-side runner
+            serialwrap_cmd = getattr(self.runner, 'serialwrap_cmd', SERIALWRAP_CMD)
+            rc, _, _ = self.runner.run_host([
+                serialwrap_cmd, 'file', 'send',
+                '--selector', self.selector,
+                temp_file, remote_path
+            ])
+
+            if rc == 0:
+                # File transfer succeeded, set permissions using target runner
+                rc_chmod, _, _ = self.runner.run_target(f"chmod {mode} {shlex.quote(remote_path)}")
+                return rc_chmod == 0
+
+            # File transfer failed, try fallback
+
+        finally:
+            # Clean up temp file
+            if temp_file and os.path.exists(temp_file):
+                try:
+                    os.unlink(temp_file)
+                except OSError:
+                    pass
+
+        # Use fallback short-write commands (all run on target)
+        commands = short_write_commands(remote_path, local_content, mode)
+        for cmd in commands:
+            rc, _, _ = self.runner.run_target(cmd)
+            if rc != 0:
+                return False
+        return True
+
+    def install(self) -> bool:
+        """Install fault injector to target.
+
+        Returns:
+            True if successful, False otherwise
+        """
+        # Check directories
+        if not self.check_target_directories():
+            return False
+
+        # Transfer fault injector script
+        injector_content = build_fault_injector_script()
+        if not self.transfer_file(injector_content, self.INJECTOR_PATH, "0755"):
+            print(f"ERROR: Failed to transfer {self.INJECTOR_PATH}", file=sys.stderr)
+            return False
+
+        # Transfer init script
+        init_content = build_init_script()
+        if not self.transfer_file(init_content, self.INIT_PATH, "0755"):
+            print(f"ERROR: Failed to transfer {self.INIT_PATH}", file=sys.stderr)
+            return False
+
+        # Create symlink
+        rc, _, _ = self.runner.run(f"ln -sf {shlex.quote(self.INIT_PATH)} {shlex.quote(self.SYMLINK_PATH)}")
+        if rc != 0:
+            print(f"ERROR: Failed to create symlink {self.SYMLINK_PATH}", file=sys.stderr)
+            return False
+
+        # Verify installation
+        if not self.verify():
+            return False
+
+        return True
+
+    def verify(self) -> bool:
+        """Verify installation.
+
+        Returns:
+            True if verification passes, False otherwise
+        """
+        # Check injector exists and is executable
+        rc, _, _ = self.runner.run(f"test -x {shlex.quote(self.INJECTOR_PATH)}")
+        if rc != 0:
+            print(f"ERROR: {self.INJECTOR_PATH} not executable", file=sys.stderr)
+            return False
+
+        # Check init script exists and is executable
+        rc, _, _ = self.runner.run(f"test -x {shlex.quote(self.INIT_PATH)}")
+        if rc != 0:
+            print(f"ERROR: {self.INIT_PATH} not executable", file=sys.stderr)
+            return False
+
+        # Check symlink exists
+        rc, _, _ = self.runner.run(f"test -L {shlex.quote(self.SYMLINK_PATH)}")
+        if rc != 0:
+            print(f"ERROR: {self.SYMLINK_PATH} symlink missing", file=sys.stderr)
+            return False
+
+        # Check symlink target
+        rc, stdout, _ = self.runner.run(f"readlink {shlex.quote(self.SYMLINK_PATH)}")
+        if rc != 0:
+            print(f"ERROR: Cannot read {self.SYMLINK_PATH} symlink target", file=sys.stderr)
+            return False
+
+        target = stdout.strip()
+        if target != self.INIT_PATH:
+            print(f"ERROR: {self.SYMLINK_PATH} points to {target}, expected {self.INIT_PATH}", file=sys.stderr)
+            return False
+
+        return True
+
+
+def main():
+    """Main entry point for the fault installer."""
+    try:
+        args = parse_args(sys.argv[1:])
+    except SystemExit as e:
+        return e.code if e.code is not None else 1
+
+    installer = FaultInstaller(args.selector)
+
+    print(f"Installing fault injector to {args.selector}...", file=sys.stderr)
+
+    if installer.install():
+        print(f"Installation successful on {args.selector}", file=sys.stderr)
+        return 0
+    else:
+        print(f"Installation failed on {args.selector}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_controller_args.py
+++ b/tests/test_controller_args.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Test controller argument parsing."""
+
+import sys
+import unittest
+from io import StringIO
+
+
+class TestControllerArgumentParsing(unittest.TestCase):
+    """Test argument parsing for serialwrap-reboot-controller."""
+
+    def test_import_controller(self):
+        """Test that controller module can be imported."""
+        from serialwrap_reboot_test import controller
+        self.assertIsNotNone(controller)
+
+    def test_parse_args_requires_selector(self):
+        """Test that --selector is required."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        with self.assertRaises(SystemExit) as cm:
+            parse_args([])
+
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_parse_args_with_selector(self):
+        """Test parsing with required --selector argument."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        args = parse_args(["--selector", "COM0"])
+        self.assertEqual(args.selector, "COM0")
+        self.assertIsNone(args.hours)
+        self.assertIsNone(args.count)
+
+    def test_parse_args_with_hours_limit(self):
+        """Test parsing with optional --hours argument."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        args = parse_args(["--selector", "COM1", "--hours", "96"])
+        self.assertEqual(args.selector, "COM1")
+        self.assertEqual(args.hours, 96)
+        self.assertIsNone(args.count)
+
+    def test_parse_args_with_count_limit(self):
+        """Test parsing with optional --count argument."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        args = parse_args(["--selector", "COM0", "--count", "10"])
+        self.assertEqual(args.selector, "COM0")
+        self.assertIsNone(args.hours)
+        self.assertEqual(args.count, 10)
+
+    def test_parse_args_with_both_limits(self):
+        """Test parsing with both --hours and --count arguments."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        args = parse_args(["--selector", "COM1", "--hours", "24", "--count", "50"])
+        self.assertEqual(args.selector, "COM1")
+        self.assertEqual(args.hours, 24)
+        self.assertEqual(args.count, 50)
+
+    def test_parse_args_hours_rejects_non_integer(self):
+        """Test that --hours rejects non-integer values."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        with self.assertRaises(SystemExit) as cm:
+            parse_args(["--selector", "COM0", "--hours", "not-a-number"])
+
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_parse_args_hours_rejects_float(self):
+        """Test that --hours rejects float values."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        with self.assertRaises(SystemExit) as cm:
+            parse_args(["--selector", "COM0", "--hours", "3.14"])
+
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_parse_args_hours_rejects_zero(self):
+        """Test that --hours rejects zero."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        with self.assertRaises(SystemExit) as cm:
+            parse_args(["--selector", "COM0", "--hours", "0"])
+
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_parse_args_hours_rejects_negative(self):
+        """Test that --hours rejects negative values."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        with self.assertRaises(SystemExit) as cm:
+            parse_args(["--selector", "COM0", "--hours", "-1"])
+
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_parse_args_count_rejects_non_integer(self):
+        """Test that --count rejects non-integer values."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        with self.assertRaises(SystemExit) as cm:
+            parse_args(["--selector", "COM0", "--count", "not-a-number"])
+
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_parse_args_count_rejects_float(self):
+        """Test that --count rejects float values."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        with self.assertRaises(SystemExit) as cm:
+            parse_args(["--selector", "COM0", "--count", "2.5"])
+
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_parse_args_count_rejects_zero(self):
+        """Test that --count rejects zero."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        with self.assertRaises(SystemExit) as cm:
+            parse_args(["--selector", "COM0", "--count", "0"])
+
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_parse_args_count_rejects_negative(self):
+        """Test that --count rejects negative values."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        with self.assertRaises(SystemExit) as cm:
+            parse_args(["--selector", "COM0", "--count", "-1"])
+
+        self.assertNotEqual(cm.exception.code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_controller_cleanup.py
+++ b/tests/test_controller_cleanup.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Test controller cleanup and signal handling (Task 2.5)."""
+
+import os
+import signal
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
+import json
+
+
+class FakeCommandRunner:
+    """Fake command runner for testing without invoking real serialwrap."""
+
+    def __init__(self):
+        self.commands = []
+        self.responses = {}
+        self.call_count = {}
+
+    def run(self, cmd, **kwargs):
+        """Record command and return configured response."""
+        self.commands.append(cmd)
+        cmd_str = ' '.join(cmd) if isinstance(cmd, list) else cmd
+
+        # Track call count
+        self.call_count[cmd_str] = self.call_count.get(cmd_str, 0) + 1
+
+        # Check custom responses first
+        for pattern, response in self.responses.items():
+            if pattern in cmd_str:
+                return response
+
+        # Default responses
+        return (0, "", "")
+
+    def set_response(self, pattern, returncode, stdout, stderr=""):
+        """Configure response for commands matching pattern."""
+        self.responses[pattern] = (returncode, stdout, stderr)
+
+
+class TestControllerCleanup(unittest.TestCase):
+    """Test controller cleanup and signal handling."""
+
+    def test_cleanup_disables_selector(self):
+        """Test cleanup disables the controller's selector."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        controller.cleanup()
+
+        # Should have called disable
+        disable_found = False
+        for cmd in runner.commands:
+            cmd_str = ' '.join(cmd)
+            if 'event' in cmd_str and 'disable' in cmd_str and 'COM0' in cmd_str:
+                disable_found = True
+                break
+        self.assertTrue(disable_found)
+
+    def test_cleanup_resets_selector(self):
+        """Test cleanup resets the controller's selector."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM1", runner=runner)
+
+        controller.cleanup()
+
+        # Should have called reset
+        reset_found = False
+        for cmd in runner.commands:
+            cmd_str = ' '.join(cmd)
+            if 'event' in cmd_str and 'reset' in cmd_str and 'COM1' in cmd_str:
+                reset_found = True
+                break
+        self.assertTrue(reset_found)
+
+    def test_cleanup_removes_rules_when_last_active(self):
+        """Test cleanup removes rules when this is the last active selector."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+
+        # Simulate no other selectors enabled
+        status_output = json.dumps({
+            "selectors": {
+                "COM0": {"enabled": False},
+                "COM1": {"enabled": False}
+            }
+        })
+        runner.set_response('event status', 0, status_output)
+
+        controller = RebootController("COM0", runner=runner)
+        controller.cleanup()
+
+        # Should have removed rules
+        rm_commands = [cmd for cmd in runner.commands if 'event' in ' '.join(cmd) and 'rm' in ' '.join(cmd)]
+        self.assertEqual(len(rm_commands), 5)
+
+    def test_cleanup_keeps_rules_when_other_active(self):
+        """Test cleanup keeps rules when other selector is still active."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+
+        # Simulate COM1 still enabled
+        status_output = json.dumps({
+            "selectors": {
+                "COM0": {"enabled": False},
+                "COM1": {"enabled": True}
+            }
+        })
+        runner.set_response('event status', 0, status_output)
+
+        controller = RebootController("COM0", runner=runner)
+        controller.cleanup()
+
+        # Should NOT have removed rules
+        rm_commands = [cmd for cmd in runner.commands if 'event' in ' '.join(cmd) and 'rm' in ' '.join(cmd)]
+        self.assertEqual(len(rm_commands), 0)
+
+    def test_cleanup_removes_tmp_state_directory(self):
+        """Test cleanup removes /tmp state directory."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_dir = Path(tmpdir) / "state"
+            state_dir.mkdir()
+
+            # Create some files
+            (state_dir / "test.txt").write_text("data")
+
+            runner = FakeCommandRunner()
+            controller = RebootController("COM1", runner=runner)
+            controller.state_dir = state_dir
+
+            self.assertTrue(state_dir.exists())
+
+            controller.cleanup()
+
+            # Directory should be removed
+            self.assertFalse(state_dir.exists())
+
+    def test_register_signal_handlers(self):
+        """Test registering SIGINT and SIGTERM handlers."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        # Mock signal.signal to track calls
+        original_signal = signal.signal
+        signal_calls = []
+
+        def mock_signal(signum, handler):
+            signal_calls.append((signum, handler))
+            return original_signal(signum, handler)
+
+        with patch('signal.signal', side_effect=mock_signal):
+            controller.register_signal_handlers()
+
+        # Should have registered handlers for SIGINT and SIGTERM
+        signal_nums = [s[0] for s in signal_calls]
+        self.assertIn(signal.SIGINT, signal_nums)
+        self.assertIn(signal.SIGTERM, signal_nums)
+
+    def test_signal_handler_calls_cleanup(self):
+        """Test signal handler triggers cleanup."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM1", runner=runner)
+
+        # Track cleanup calls
+        cleanup_called = False
+        original_cleanup = controller.cleanup
+
+        def mock_cleanup():
+            nonlocal cleanup_called
+            cleanup_called = True
+            # Don't call original to avoid side effects
+
+        controller.cleanup = mock_cleanup
+        controller.register_signal_handlers()
+
+        # Simulate receiving SIGINT - expect SystemExit
+        handler = controller._signal_handler
+        with self.assertRaises(SystemExit) as cm:
+            handler(signal.SIGINT, None)
+
+        # Cleanup should have been called
+        self.assertTrue(cleanup_called)
+        self.assertEqual(cm.exception.code, 0)
+
+    def test_normal_exit_cleanup(self):
+        """Test cleanup is called on normal exit."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        # Track cleanup calls
+        cleanup_called = False
+
+        def mock_cleanup():
+            nonlocal cleanup_called
+            cleanup_called = True
+
+        controller.cleanup = mock_cleanup
+
+        # Simulate normal exit
+        controller.exit_gracefully()
+
+        # Cleanup should have been called
+        self.assertTrue(cleanup_called)
+
+    def test_stop_condition_hours_limit(self):
+        """Test stop condition with hours limit."""
+        from serialwrap_reboot_test.controller import RebootController
+        import time
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner, hours_limit=1)
+
+        # Set start time to 2 hours ago
+        controller.start_time = time.time() - 7200
+
+        result = controller.should_stop()
+
+        self.assertTrue(result)
+
+    def test_stop_condition_count_limit(self):
+        """Test stop condition with count limit."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM1", runner=runner, count_limit=5)
+
+        # Set reboot count to 5
+        controller.reboot_count = 5
+
+        result = controller.should_stop()
+
+        self.assertTrue(result)
+
+    def test_stop_condition_infinite_run(self):
+        """Test infinite run behavior (no stop conditions)."""
+        from serialwrap_reboot_test.controller import RebootController
+        import time
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        # No limits set, should never stop
+        controller.start_time = time.time() - 86400  # 1 day ago
+        controller.reboot_count = 1000
+
+        result = controller.should_stop()
+
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_controller_error_handling.py
+++ b/tests/test_controller_error_handling.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Focused tests for error handling on critical serialwrap commands."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+import sys
+
+
+class FakeCommandRunner:
+    """Fake command runner for testing."""
+
+    def __init__(self):
+        self.commands = []
+        self.responses = {}
+
+    def run(self, cmd, **kwargs):
+        """Record command and return configured response."""
+        self.commands.append(cmd)
+        cmd_str = ' '.join(cmd) if isinstance(cmd, list) else cmd
+
+        # Check custom responses first
+        for pattern, response in self.responses.items():
+            if pattern in cmd_str:
+                return response
+
+        # Default success
+        return (0, "", "")
+
+    def set_response(self, pattern, returncode, stdout, stderr=""):
+        """Configure response for commands matching pattern."""
+        self.responses[pattern] = (returncode, stdout, stderr)
+
+
+class TestCriticalCommandErrorHandling(unittest.TestCase):
+    """Test error handling for critical serialwrap commands."""
+
+    def test_enable_selector_failure(self):
+        """Test enable_selector raises ControllerError on failure."""
+        from serialwrap_reboot_test.controller import RebootController, ControllerError
+
+        runner = FakeCommandRunner()
+        runner.set_response('event enable', 1, "", "Failed to enable")
+
+        controller = RebootController("COM0", runner=runner)
+
+        with self.assertRaises(ControllerError) as cm:
+            controller.enable_selector()
+
+        self.assertIn("enable", str(cm.exception).lower())
+
+    def test_disable_selector_failure(self):
+        """Test disable_selector raises ControllerError on failure."""
+        from serialwrap_reboot_test.controller import RebootController, ControllerError
+
+        runner = FakeCommandRunner()
+        runner.set_response('event disable', 1, "", "Failed to disable")
+
+        controller = RebootController("COM1", runner=runner)
+
+        with self.assertRaises(ControllerError) as cm:
+            controller.disable_selector()
+
+        self.assertIn("disable", str(cm.exception).lower())
+
+    def test_reset_selector_failure(self):
+        """Test reset_selector raises ControllerError on failure."""
+        from serialwrap_reboot_test.controller import RebootController, ControllerError
+
+        runner = FakeCommandRunner()
+        runner.set_response('event reset', 1, "", "Failed to reset")
+
+        controller = RebootController("COM0", runner=runner)
+
+        with self.assertRaises(ControllerError) as cm:
+            controller.reset_selector()
+
+        self.assertIn("reset", str(cm.exception).lower())
+
+    def test_remove_event_rules_failure(self):
+        """Test remove_event_rules raises ControllerError on failure."""
+        from serialwrap_reboot_test.controller import RebootController, ControllerError
+
+        runner = FakeCommandRunner()
+        runner.set_response('event rm', 1, "", "Failed to remove rule")
+
+        controller = RebootController("COM1", runner=runner)
+
+        with self.assertRaises(ControllerError) as cm:
+            controller.remove_event_rules()
+
+        self.assertIn("remove", str(cm.exception).lower())
+
+    def test_run_session_recover_failure(self):
+        """Test run_session_recover raises ControllerError on failure."""
+        from serialwrap_reboot_test.controller import RebootController, ControllerError
+
+        runner = FakeCommandRunner()
+        runner.set_response('session recover', 1, "", "Failed to recover")
+
+        controller = RebootController("COM0", runner=runner)
+
+        with self.assertRaises(ControllerError) as cm:
+            controller.run_session_recover()
+
+        self.assertIn("recover", str(cm.exception).lower())
+
+    def test_run_session_recover_failure_uses_stdout_error_payload(self):
+        """Test recover failure surfaces JSON stdout error details when stderr is empty."""
+        from serialwrap_reboot_test.controller import RebootController, ControllerError
+
+        runner = FakeCommandRunner()
+        runner.set_response(
+            'session recover',
+            2,
+            json.dumps({"ok": False, "error_code": "TIMEOUT"}),
+            "",
+        )
+
+        controller = RebootController("COM0", runner=runner)
+
+        with self.assertRaises(ControllerError) as cm:
+            controller.run_session_recover()
+
+        self.assertIn("TIMEOUT", str(cm.exception))
+
+    def test_send_raw_broker_command_failure(self):
+        """Test send_raw_broker_command raises ControllerError on failure."""
+        from serialwrap_reboot_test.controller import RebootController, ControllerError
+
+        runner = FakeCommandRunner()
+        runner.set_response('session interactive-open', 0, json.dumps({"interactive_id": "agent-int"}))
+        runner.set_response('session interactive-send', 1, "", "Failed to send raw command")
+        runner.set_response('session interactive-close', 0, json.dumps({"ok": True}))
+
+        controller = RebootController("COM1", runner=runner)
+
+        with self.assertRaises(ControllerError) as cm:
+            controller.send_raw_broker_command("reset")
+
+        self.assertIn("broker", str(cm.exception).lower())
+        self.assertTrue(any('session interactive-close' in ' '.join(cmd) for cmd in runner.commands))
+
+    def test_cleanup_continues_despite_disable_failure(self):
+        """Test cleanup removes state dir even if disable fails."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            runner.set_response('event disable', 1, "", "Failed to disable")
+
+            controller = RebootController("COM0", runner=runner)
+
+            # Create state directory
+            state_dir = Path(tmpdir) / "state"
+            state_dir.mkdir()
+            controller.state_dir = state_dir
+
+            self.assertTrue(state_dir.exists())
+
+            # Cleanup should attempt disable/reset, but still remove state
+            # Should not raise despite disable failure
+            controller.cleanup()
+
+            # State directory should be removed
+            self.assertFalse(state_dir.exists())
+
+    def test_cleanup_continues_despite_reset_failure(self):
+        """Test cleanup removes state dir even if reset fails."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            runner.set_response('event reset', 1, "", "Failed to reset")
+            runner.set_response('event status', 0,
+                json.dumps({"selectors": {"COM0": {"enabled": False}}}))
+
+            controller = RebootController("COM1", runner=runner)
+
+            # Create state directory
+            state_dir = Path(tmpdir) / "state"
+            state_dir.mkdir()
+            controller.state_dir = state_dir
+
+            self.assertTrue(state_dir.exists())
+
+            # Cleanup should attempt disable/reset, but still remove state
+            controller.cleanup()
+
+            # State directory should be removed
+            self.assertFalse(state_dir.exists())
+
+    def test_cleanup_continues_despite_rule_removal_failure(self):
+        """Test cleanup removes state dir even if rule removal fails."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            runner.set_response('event rm', 1, "", "Failed to remove rule")
+            runner.set_response('event status', 0,
+                json.dumps({"selectors": {"COM0": {"enabled": False}}}))
+
+            controller = RebootController("COM0", runner=runner)
+
+            # Create state directory
+            state_dir = Path(tmpdir) / "state"
+            state_dir.mkdir()
+            controller.state_dir = state_dir
+
+            self.assertTrue(state_dir.exists())
+
+            # Cleanup should still remove state
+            controller.cleanup()
+
+            # State directory should be removed
+            self.assertFalse(state_dir.exists())
+
+    def test_run_loop_handles_session_recover_failure(self):
+        """Test run_loop handles session recover failure gracefully."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = Path(tmpdir) / "mini_COM0_test.log"
+            log_file.write_text("boot log\n")
+
+            runner = FakeCommandRunner()
+            runner.set_response('session list', 0,
+                json.dumps({"sessions": [{"selector": "COM0", "state": "RECOVERY"}]}))
+            runner.set_response('session recover', 1, "", "Failed to recover")
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+            controller.active_log_path = log_file
+            controller.last_action_time = None  # Trigger recovery
+
+            # Mock sleep and stderr
+            sleep_called = []
+            controller.sleep_fn = lambda s: sleep_called.append(s)
+
+            stderr_output = []
+            original_stderr = sys.stderr.write
+            def mock_stderr(msg):
+                stderr_output.append(msg)
+                return original_stderr(msg)
+
+            with patch('sys.stderr.write', mock_stderr):
+                # Should not raise, should handle gracefully
+                controller.run_loop()
+
+            # Should have slept (error handling)
+            self.assertTrue(len(sleep_called) > 0)
+
+            # Should have printed error
+            self.assertTrue(any('ERROR' in msg or 'recover' in msg for msg in stderr_output))
+
+    def test_run_loop_handles_raw_reset_failure(self):
+        """Test run_loop handles raw reset failure gracefully."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = Path(tmpdir) / "mini_COM1_test.log"
+            log_file.write_text("boot log\n=>\n")
+
+            runner = FakeCommandRunner()
+            runner.set_response('session list', 0,
+                json.dumps({"sessions": [{"selector": "COM1", "state": "RECOVERY"}]}))
+            runner.set_response('session interactive-open', 0, json.dumps({"interactive_id": "agent-int"}))
+            runner.set_response('session interactive-send', 1, "", "Failed to send raw command")
+
+            controller = RebootController("COM1", runner=runner, log_dir=tmpdir)
+            controller.active_log_path = log_file
+            controller.last_action_time = None  # Force past throttle
+
+            # Mock sleep
+            sleep_called = []
+            controller.sleep_fn = lambda s: sleep_called.append(s)
+
+            stderr_output = []
+            original_stderr = sys.stderr.write
+            def mock_stderr(msg):
+                stderr_output.append(msg)
+                return original_stderr(msg)
+
+            with patch('sys.stderr.write', mock_stderr):
+                # Should not raise, should handle gracefully
+                controller.run_loop()
+
+            # Should have slept
+            self.assertTrue(len(sleep_called) > 0)
+
+            # Should have printed error
+            self.assertTrue(any('ERROR' in msg or 'broker' in msg for msg in stderr_output))
+
+    def test_run_loop_handles_raw_reboot_failure(self):
+        """Test run_loop handles raw reboot failure gracefully."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = Path(tmpdir) / "mini_COM0_test.log"
+            log_file.write_text("boot log\nroot@prplOS:/# \n")
+
+            runner = FakeCommandRunner()
+            runner.set_response('session list', 0,
+                json.dumps({"sessions": [{"selector": "COM0", "state": "RECOVERY"}]}))
+            runner.set_response('session interactive-open', 0, json.dumps({"interactive_id": "agent-int"}))
+            runner.set_response('session interactive-send', 1, "", "Failed to send raw reboot")
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+            controller.active_log_path = log_file
+            controller.last_action_time = None
+
+            # Mock sleep
+            sleep_called = []
+            controller.sleep_fn = lambda s: sleep_called.append(s)
+
+            stderr_output = []
+            original_stderr = sys.stderr.write
+            def mock_stderr(msg):
+                stderr_output.append(msg)
+                return original_stderr(msg)
+
+            with patch('sys.stderr.write', mock_stderr):
+                # Should not raise
+                controller.run_loop()
+
+            # Should have slept
+            self.assertTrue(len(sleep_called) > 0)
+
+            # Should have printed error
+            self.assertTrue(any('ERROR' in msg or 'broker' in msg or 'reboot' in msg for msg in stderr_output))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_controller_events.py
+++ b/tests/test_controller_events.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Test controller event rule management (Task 2.3)."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+class FakeCommandRunner:
+    """Fake command runner for testing without invoking real serialwrap."""
+
+    def __init__(self):
+        self.commands = []
+        self.responses = {}
+        self.call_count = {}
+
+    def run(self, cmd, **kwargs):
+        """Record command and return configured response."""
+        self.commands.append(cmd)
+        cmd_str = ' '.join(cmd) if isinstance(cmd, list) else cmd
+
+        # Track call count
+        self.call_count[cmd_str] = self.call_count.get(cmd_str, 0) + 1
+
+        # Check custom responses first
+        for pattern, response in self.responses.items():
+            if pattern in cmd_str:
+                return response
+
+        # Default responses
+        return (0, "", "")
+
+    def set_response(self, pattern, returncode, stdout, stderr=""):
+        """Configure response for commands matching pattern."""
+        self.responses[pattern] = (returncode, stdout, stderr)
+
+
+class TestControllerEventRules(unittest.TestCase):
+    """Test controller event rule management."""
+
+    def test_generate_event_rule_json(self):
+        """Test generating event rule JSON for shared rules."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        rules = controller.generate_event_rules()
+
+        # Should have 5 shared rules
+        self.assertEqual(len(rules), 5)
+
+        # Check rule structure
+        rule_names = [r['name'] for r in rules]
+        self.assertIn('brcm-therm', rule_names)
+        self.assertIn('link-down', rule_names)
+        self.assertIn('pstate', rule_names)
+        self.assertIn('kernel-panic', rule_names)
+        self.assertIn('smc-bootloader', rule_names)
+
+        # Check that each rule has both COM0 and COM1 selectors
+        for rule in rules:
+            self.assertIn('COM0', rule['selectors'])
+            self.assertIn('COM1', rule['selectors'])
+            self.assertEqual(rule['kind'], 'tool')
+
+    def test_generate_event_rules_use_runtime_event_schema(self):
+        """Generate rules compatible with serialwrap event file schema."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        rule = controller.generate_event_rules()[0]
+
+        self.assertIn("schema_version", rule)
+        self.assertIn("owner", rule)
+        self.assertIn("rule_id", rule)
+        self.assertIn("pattern", rule)
+        self.assertIn("handler", rule)
+        self.assertEqual(rule["schema_version"], 1)
+        self.assertEqual(rule["owner"], "agent-reboot-controller")
+        self.assertEqual(rule["rule_id"], "agent-reboot-controller.brcm-therm")
+        self.assertEqual(rule["kind"], "tool")
+        self.assertEqual(rule["pattern"]["kind"], "contains")
+        self.assertEqual(rule["pattern"]["value"], "brcm-therm")
+        self.assertEqual(rule["handler"]["exec"], ["serialwrap-event-handler"])
+        self.assertFalse(rule["auto_enable_com_on_load"])
+
+    def test_brcm_therm_rule_match(self):
+        """Test brcm-therm rule has correct match pattern."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        rules = controller.generate_event_rules()
+        brcm_rule = next(r for r in rules if r['name'] == 'brcm-therm')
+
+        self.assertEqual(brcm_rule['pattern']['value'], 'brcm-therm')
+
+    def test_link_down_rule_match(self):
+        """Test link-down rule has correct match pattern."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM1", runner=runner)
+
+        rules = controller.generate_event_rules()
+        link_rule = next(r for r in rules if r['name'] == 'link-down')
+
+        self.assertEqual(link_rule['pattern']['value'], 'Link is Down')
+
+    def test_pstate_rule_match_case_sensitive(self):
+        """Test pstate rule match is case-sensitive lowercase."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        rules = controller.generate_event_rules()
+        pstate_rule = next(r for r in rules if r['name'] == 'pstate')
+
+        # Should be lowercase 'pstate', not 'PSTATE' or 'Pstate'
+        self.assertEqual(pstate_rule['pattern']['value'], 'pstate')
+
+    def test_kernel_panic_rule_match(self):
+        """Test kernel-panic rule has correct match pattern."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM1", runner=runner)
+
+        rules = controller.generate_event_rules()
+        panic_rule = next(r for r in rules if r['name'] == 'kernel-panic')
+
+        self.assertEqual(panic_rule['pattern']['value'], 'Kernel panic')
+
+    def test_smc_bootloader_rule_match(self):
+        """Test smc-bootloader rule has correct match pattern."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        rules = controller.generate_event_rules()
+        smc_rule = next(r for r in rules if r['name'] == 'smc-bootloader')
+
+        self.assertEqual(smc_rule['pattern']['value'], 'SMC bootloader')
+
+    def test_register_event_rules(self):
+        """Test registering event rules with serialwrap."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        controller.register_event_rules()
+
+        # Should have called event add for each rule
+        add_commands = [cmd for cmd in runner.commands if 'event' in ' '.join(cmd) and 'add' in ' '.join(cmd)]
+        self.assertEqual(len(add_commands), 5)
+
+    def test_register_event_rules_uses_file_api(self):
+        """Register rules through event add --file for the deployed CLI."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        controller.register_event_rules()
+
+        add_commands = [
+            cmd for cmd in runner.commands
+            if 'event add' in ' '.join(cmd)
+        ]
+        self.assertEqual(len(add_commands), 5)
+        for cmd in add_commands:
+            self.assertIn("--timeout", cmd)
+            self.assertIn("--file", cmd)
+
+    def test_enable_selector(self):
+        """Test enabling event matcher for selected COM."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM1", runner=runner)
+
+        controller.enable_selector()
+
+        # Should have called event enable for COM1
+        enable_found = False
+        for cmd in runner.commands:
+            cmd_str = ' '.join(cmd)
+            if 'event' in cmd_str and 'enable' in cmd_str and 'COM1' in cmd_str:
+                enable_found = True
+                break
+        self.assertTrue(enable_found)
+
+    def test_disable_selector(self):
+        """Test disabling event matcher for selected COM."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        controller.disable_selector()
+
+        # Should have called event disable for COM0
+        disable_found = False
+        for cmd in runner.commands:
+            cmd_str = ' '.join(cmd)
+            if 'event' in cmd_str and 'disable' in cmd_str and 'COM0' in cmd_str:
+                disable_found = True
+                break
+        self.assertTrue(disable_found)
+
+    def test_reset_selector(self):
+        """Test resetting event state for selected COM."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM1", runner=runner)
+
+        controller.reset_selector()
+
+        # Should have called event reset for COM1
+        reset_found = False
+        for cmd in runner.commands:
+            cmd_str = ' '.join(cmd)
+            if 'event' in cmd_str and 'reset' in cmd_str and 'COM1' in cmd_str:
+                reset_found = True
+                break
+        self.assertTrue(reset_found)
+
+    def test_check_other_selectors_enabled(self):
+        """Test checking if other COM selectors are still enabled."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+
+        # Simulate COM1 still enabled
+        status_output = json.dumps({
+            "selectors": {
+                "COM0": {"enabled": False},
+                "COM1": {"enabled": True}
+            }
+        })
+        runner.set_response('event status', 0, status_output)
+
+        controller = RebootController("COM0", runner=runner)
+        result = controller.check_other_selectors_enabled()
+
+        # COM1 is still enabled, so should return True
+        self.assertTrue(result)
+
+    def test_check_other_selectors_none_enabled(self):
+        """Test checking when no other COM selectors are enabled."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+
+        # Simulate all disabled
+        status_output = json.dumps({
+            "selectors": {
+                "COM0": {"enabled": False},
+                "COM1": {"enabled": False}
+            }
+        })
+        runner.set_response('event status', 0, status_output)
+
+        controller = RebootController("COM1", runner=runner)
+        result = controller.check_other_selectors_enabled()
+
+        # No other selectors enabled, so should return False
+        self.assertFalse(result)
+
+    def test_check_other_selectors_enabled_accepts_coms_list(self):
+        """Treat status.coms as the enabled selector list in newer daemons."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        runner.set_response('event status', 0, json.dumps({"coms": ["COM1"]}))
+
+        controller = RebootController("COM0", runner=runner)
+        self.assertTrue(controller.check_other_selectors_enabled())
+
+    def test_remove_event_rules(self):
+        """Test removing shared event rules."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        controller.remove_event_rules()
+
+        # Should have called event rm for each rule
+        rm_commands = [cmd for cmd in runner.commands if 'event' in ' '.join(cmd) and 'rm' in ' '.join(cmd)]
+        self.assertEqual(len(rm_commands), 5)
+        self.assertIn('agent-reboot-controller.brcm-therm', ' '.join(rm_commands[0]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_controller_integration.py
+++ b/tests/test_controller_integration.py
@@ -1,0 +1,738 @@
+#!/usr/bin/env python3
+"""Integration tests for controller main flow and startup sequence."""
+
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import json
+
+
+class FakeCommandRunner:
+    """Fake command runner for testing without invoking real serialwrap."""
+
+    def __init__(self):
+        self.commands = []
+        self.responses = {}
+        self.call_count = {}
+
+    def run(self, cmd, **kwargs):
+        """Record command and return configured response."""
+        self.commands.append(cmd)
+        cmd_str = ' '.join(cmd) if isinstance(cmd, list) else cmd
+
+        # Track call count
+        self.call_count[cmd_str] = self.call_count.get(cmd_str, 0) + 1
+
+        # Check custom responses first
+        for pattern, response in self.responses.items():
+            if pattern in cmd_str:
+                return response
+
+        # Default successful responses
+        if 'event --help' in cmd_str:
+            return (0, "Usage: serialwrap event ...", "")
+        elif 'daemon status' in cmd_str:
+            return (0, "Daemon: RUNNING\nPID: 12345", "")
+        elif 'cmd submit' in cmd_str:
+            return (0, "Command submitted", "")
+        elif 'session list' in cmd_str:
+            return (0, json.dumps({"sessions": [{"selector": "COM0", "state": "READY"}]}), "")
+        elif 'session self-test' in cmd_str:
+            return (0, json.dumps({"classification": "OK", "probe_ok": True}), "")
+        elif 'event add' in cmd_str:
+            return (0, "", "")
+        elif 'event enable' in cmd_str:
+            return (0, "", "")
+        elif 'event disable' in cmd_str:
+            return (0, "", "")
+        elif 'event reset' in cmd_str:
+            return (0, "", "")
+        elif 'event status' in cmd_str:
+            return (0, json.dumps({"selectors": {"COM0": {"enabled": False}, "COM1": {"enabled": False}}}), "")
+        elif 'event rm' in cmd_str:
+            return (0, "", "")
+        elif 'session recover' in cmd_str:
+            return (0, "", "")
+        elif 'session interactive-open' in cmd_str:
+            return (0, json.dumps({"interactive_id": "agent-int"}), "")
+        elif 'session interactive-send' in cmd_str:
+            return (0, "", "")
+        elif 'session interactive-close' in cmd_str:
+            return (0, "", "")
+
+        return (0, "", "")
+
+    def set_response(self, pattern, returncode, stdout, stderr=""):
+        """Configure response for commands matching pattern."""
+        self.responses[pattern] = (returncode, stdout, stderr)
+
+
+class TestControllerIntegration(unittest.TestCase):
+    """Integration tests for main controller flow."""
+
+    def test_startup_sequence_order(self):
+        """Test startup calls methods in correct order."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir, count_limit=1)
+
+            # Track method calls
+            call_order = []
+            marker_captured = []
+
+            original_check_event = controller.check_serialwrap_event_support
+            original_check_daemon = controller.check_daemon_status
+            original_send_marker = controller.send_marker_command
+            original_find_log = controller.find_active_minicom_log
+            original_register = controller.register_event_rules
+            original_enable = controller.enable_selector
+
+            def tracked_check_event():
+                call_order.append('check_event_support')
+                return original_check_event()
+
+            def tracked_check_daemon():
+                call_order.append('check_daemon_status')
+                return original_check_daemon()
+
+            def tracked_send_marker():
+                call_order.append('send_marker')
+                marker = original_send_marker()
+                marker_captured.append(marker)
+                # Create log with actual marker
+                log_file = Path(tmpdir) / "mini_COM0_test.log"
+                log_file.write_text(f"boot log\n{marker}\n")
+                return marker
+
+            def tracked_find_log(marker, **kwargs):
+                call_order.append('find_active_log')
+                return original_find_log(marker, **kwargs)
+
+            def tracked_register():
+                call_order.append('register_rules')
+                return original_register()
+
+            def tracked_enable():
+                call_order.append('enable_selector')
+                return original_enable()
+
+            controller.check_serialwrap_event_support = tracked_check_event
+            controller.check_daemon_status = tracked_check_daemon
+            controller.send_marker_command = tracked_send_marker
+            controller.find_active_minicom_log = tracked_find_log
+            controller.register_event_rules = tracked_register
+            controller.enable_selector = tracked_enable
+
+            # Run startup
+            result = controller.startup()
+
+            # Verify order
+            self.assertTrue(result)
+            self.assertEqual(call_order[0], 'check_event_support')
+            self.assertEqual(call_order[1], 'check_daemon_status')
+            self.assertEqual(call_order[2], 'send_marker')
+            self.assertEqual(call_order[3], 'find_active_log')
+            # register_rules and enable_selector should come after find_log
+            self.assertIn('register_rules', call_order)
+            self.assertIn('enable_selector', call_order)
+
+    def test_startup_failure_event_support(self):
+        """Test startup fails when event support not available."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        runner.set_response('event --help', 1, "", "Unknown command")
+
+        controller = RebootController("COM0", runner=runner)
+
+        result = controller.startup()
+
+        self.assertFalse(result)
+
+    def test_startup_failure_daemon_not_running(self):
+        """Test startup fails when daemon not running."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        runner.set_response('daemon status', 1, "", "Daemon not running")
+
+        controller = RebootController("COM1", runner=runner)
+
+        result = controller.startup()
+
+        self.assertFalse(result)
+
+    def test_startup_failure_no_active_log(self):
+        """Test startup fails when no active log found."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+
+            result = controller.startup()
+
+            self.assertFalse(result)
+
+    def test_startup_sets_active_log_path(self):
+        """Test startup sets active_log_path from find_active_minicom_log."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+
+            # Intercept marker to create log
+            original_send_marker = controller.send_marker_command
+            def tracked_send_marker():
+                marker = original_send_marker()
+                # Create log with actual marker
+                log_file = Path(tmpdir) / "mini_COM0_test.log"
+                log_file.write_text(f"boot log\n{marker}\n")
+                return marker
+            controller.send_marker_command = tracked_send_marker
+
+            self.assertIsNone(controller.active_log_path)
+
+            result = controller.startup()
+
+            self.assertTrue(result)
+            self.assertIsNotNone(controller.active_log_path)
+            self.assertTrue(controller.active_log_path.exists())
+
+    def test_startup_adopts_prompted_active_log_when_marker_session_not_ready(self):
+        """Startup should adopt a recent prompted log when marker submit is blocked."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            runner.set_response(
+                'cmd submit',
+                1,
+                json.dumps({
+                    "ok": False,
+                    "error_code": "SESSION_NOT_READY",
+                    "session": {"state": "ATTACHED"}
+                }),
+                ""
+            )
+            log_file = Path(tmpdir) / "mini_COM0_existing.log"
+            log_file.write_text("U-Boot\n=> \n")
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+
+            result = controller.startup()
+
+            self.assertTrue(result)
+            self.assertEqual(controller.active_log_path, log_file)
+            self.assertIsNotNone(controller.state_dir)
+            self.assertTrue(controller.state_dir.exists())
+
+    def test_startup_still_fails_without_prompted_log_when_marker_session_not_ready(self):
+        """Startup should still fail if no prompted active log can be adopted."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            runner.set_response(
+                'cmd submit',
+                1,
+                json.dumps({
+                    "ok": False,
+                    "error_code": "SESSION_NOT_READY",
+                    "session": {"state": "ATTACHED"}
+                }),
+                ""
+            )
+            log_file = Path(tmpdir) / "mini_COM0_existing.log"
+            log_file.write_text("U-Boot\nno prompt yet\n")
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+
+            result = controller.startup()
+
+            self.assertFalse(result)
+            self.assertIsNone(controller.active_log_path)
+
+    def test_startup_does_not_adopt_older_prompted_log_when_newer_log_lacks_prompt(self):
+        """Fallback should not use an older prompted log over the newest active-looking log."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            runner.set_response(
+                'cmd submit',
+                1,
+                json.dumps({
+                    "ok": False,
+                    "error_code": "SESSION_NOT_READY",
+                    "session": {"state": "ATTACHED"}
+                }),
+                ""
+            )
+
+            older_log = Path(tmpdir) / "mini_COM0_older.log"
+            older_log.write_text("old session\n=> \n")
+            newer_log = Path(tmpdir) / "mini_COM0_newer.log"
+            newer_log.write_text("new session\nstill booting\n")
+            now = time.time()
+            os.utime(older_log, (now - 5, now - 5))
+            os.utime(newer_log, (now, now))
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+
+            result = controller.startup()
+
+            self.assertFalse(result)
+            self.assertIsNone(controller.active_log_path)
+
+    def test_startup_uses_structured_session_not_ready_signal(self):
+        """Fallback should use structured error metadata, not exception text matching."""
+        from serialwrap_reboot_test.controller import RebootController, ControllerError
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            log_file = Path(tmpdir) / "mini_COM0_existing.log"
+            log_file.write_text("login\nroot@prplOS:/# \n")
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+
+            def structured_send_marker_failure():
+                error = ControllerError("marker submission blocked")
+                error.error_code = "SESSION_NOT_READY"
+                raise error
+
+            controller.send_marker_command = structured_send_marker_failure
+
+            result = controller.startup()
+
+            self.assertTrue(result)
+            self.assertEqual(controller.active_log_path, log_file)
+
+    def test_startup_reuses_trusted_previous_active_log_when_marker_blocked(self):
+        """Startup should reuse a trusted prior active log when marker submit is blocked."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            runner.set_response(
+                'cmd submit',
+                1,
+                json.dumps({
+                    "ok": False,
+                    "error_code": "SESSION_NOT_READY",
+                    "session": {"state": "ATTACHED"}
+                }),
+                ""
+            )
+            log_file = Path(tmpdir) / "mini_COM0_latest.log"
+            log_file.write_text("boot continues\nno prompt right now\n")
+
+            previous_state_dir = Path(tmpdir) / "saved-state"
+            previous_state_dir.mkdir()
+            (previous_state_dir / "active_minicom_log.txt").write_text(str(log_file))
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+            run_state_dir = Path(tmpdir) / "new-state"
+            controller.iter_previous_run_state_dirs = lambda: [previous_state_dir]
+            def fake_create_run_state_directory():
+                run_state_dir.mkdir()
+                return run_state_dir
+            controller.create_run_state_directory = fake_create_run_state_directory
+            controller.register_event_rules = lambda: None
+            controller.enable_selector = lambda: None
+            controller.register_signal_handlers = lambda: None
+
+            result = controller.startup()
+
+            self.assertTrue(result)
+            self.assertEqual(controller.active_log_path, log_file)
+
+    def test_startup_reuses_trusted_previous_active_log_when_marker_lookup_misses(self):
+        """Startup should reuse a trusted prior active log when marker discovery misses."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            log_file = Path(tmpdir) / "mini_COM0_latest.log"
+            log_file.write_text("boot continues\nno prompt right now\n")
+
+            previous_state_dir = Path(tmpdir) / "saved-state"
+            previous_state_dir.mkdir()
+            (previous_state_dir / "active_minicom_log.txt").write_text(str(log_file))
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+            run_state_dir = Path(tmpdir) / "new-state-marker-miss"
+            controller.find_active_minicom_log = lambda marker, **kwargs: None
+            controller.iter_previous_run_state_dirs = lambda: [previous_state_dir]
+
+            def fake_create_run_state_directory():
+                run_state_dir.mkdir()
+                return run_state_dir
+
+            controller.create_run_state_directory = fake_create_run_state_directory
+            controller.register_event_rules = lambda: None
+            controller.enable_selector = lambda: None
+            controller.register_signal_handlers = lambda: None
+
+            result = controller.startup()
+
+            self.assertTrue(result)
+            self.assertEqual(controller.active_log_path, log_file)
+
+    def test_startup_prefers_prompted_log_before_trusted_previous_when_marker_lookup_misses(self):
+        """Startup should prefer a prompted current log before trusted prior state."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            prompted_log = Path(tmpdir) / "mini_COM0_latest.log"
+            prompted_log.write_text("login\nroot@prplOS:/# \n")
+            older_trusted_log = Path(tmpdir) / "mini_COM0_older.log"
+            older_trusted_log.write_text("older session\n")
+            now = time.time()
+            os.utime(older_trusted_log, (now - 5, now - 5))
+            os.utime(prompted_log, (now, now))
+
+            previous_state_dir = Path(tmpdir) / "saved-state"
+            previous_state_dir.mkdir()
+            (previous_state_dir / "active_minicom_log.txt").write_text(str(older_trusted_log))
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+            run_state_dir = Path(tmpdir) / "new-state-prompted-first"
+            controller.find_active_minicom_log = lambda marker, **kwargs: None
+            controller.iter_previous_run_state_dirs = lambda: [previous_state_dir]
+
+            def fake_create_run_state_directory():
+                run_state_dir.mkdir()
+                return run_state_dir
+
+            controller.create_run_state_directory = fake_create_run_state_directory
+            controller.register_event_rules = lambda: None
+            controller.enable_selector = lambda: None
+            controller.register_signal_handlers = lambda: None
+
+            result = controller.startup()
+
+            self.assertTrue(result)
+            self.assertEqual(controller.active_log_path, prompted_log)
+
+    def test_startup_rejects_previous_active_log_if_not_newest_selector_log(self):
+        """Startup should not trust prior state when it points to an older selector log."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            runner.set_response(
+                'cmd submit',
+                1,
+                json.dumps({
+                    "ok": False,
+                    "error_code": "SESSION_NOT_READY",
+                    "session": {"state": "ATTACHED"}
+                }),
+                ""
+            )
+            older_log = Path(tmpdir) / "mini_COM0_older.log"
+            older_log.write_text("older session\n")
+            newer_log = Path(tmpdir) / "mini_COM0_newer.log"
+            newer_log.write_text("newer session\nstill booting\n")
+            now = time.time()
+            os.utime(older_log, (now - 5, now - 5))
+            os.utime(newer_log, (now, now))
+
+            previous_state_dir = Path(tmpdir) / "saved-state"
+            previous_state_dir.mkdir()
+            (previous_state_dir / "active_minicom_log.txt").write_text(str(older_log))
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+            controller.iter_previous_run_state_dirs = lambda: [previous_state_dir]
+            controller.register_event_rules = lambda: None
+            controller.enable_selector = lambda: None
+            controller.register_signal_handlers = lambda: None
+
+            result = controller.startup()
+
+            self.assertFalse(result)
+            self.assertIsNone(controller.active_log_path)
+
+    def test_startup_reuses_trusted_previous_active_log_even_when_log_is_older_than_recency_window(self):
+        """Trusted previous-log fallback should ignore the normal recency window."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            runner.set_response(
+                'cmd submit',
+                1,
+                json.dumps({
+                    "ok": False,
+                    "error_code": "SESSION_NOT_READY",
+                    "session": {"state": "ATTACHED"}
+                }),
+                ""
+            )
+            log_file = Path(tmpdir) / "mini_COM0_old_but_current.log"
+            log_file.write_text("quiet active log\n")
+            old_time = time.time() - 1200
+            os.utime(log_file, (old_time, old_time))
+
+            previous_state_dir = Path(tmpdir) / "saved-state"
+            previous_state_dir.mkdir()
+            (previous_state_dir / "active_minicom_log.txt").write_text(str(log_file))
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+            run_state_dir = Path(tmpdir) / "new-state-old-log"
+            controller.iter_previous_run_state_dirs = lambda: [previous_state_dir]
+
+            def fake_create_run_state_directory():
+                run_state_dir.mkdir()
+                return run_state_dir
+
+            controller.create_run_state_directory = fake_create_run_state_directory
+            controller.register_event_rules = lambda: None
+            controller.enable_selector = lambda: None
+            controller.register_signal_handlers = lambda: None
+
+            result = controller.startup()
+
+            self.assertTrue(result)
+            self.assertEqual(controller.active_log_path, log_file)
+
+    def test_startup_sets_state_dir(self):
+        """Test startup sets state_dir for cleanup."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            controller = RebootController("COM1", runner=runner, log_dir=tmpdir)
+
+            # Intercept marker to create log
+            original_send_marker = controller.send_marker_command
+            def tracked_send_marker():
+                marker = original_send_marker()
+                # Create log with actual marker
+                log_file = Path(tmpdir) / "mini_COM1_test.log"
+                log_file.write_text(f"boot log\n{marker}\n")
+                return marker
+            controller.send_marker_command = tracked_send_marker
+
+            self.assertIsNone(controller.state_dir)
+
+            result = controller.startup()
+
+            self.assertTrue(result)
+            self.assertIsNotNone(controller.state_dir)
+            self.assertTrue(controller.state_dir.exists())
+
+    def test_run_loop_executes_normal_reboot(self):
+        """Test run loop executes normal reboot action."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = Path(tmpdir) / "mini_COM0_test.log"
+            log_file.write_text("boot log\n__SW_REBOOT_TEST_COM0_test__\n")
+
+            runner = FakeCommandRunner()
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir, count_limit=1)
+            controller.startup()
+
+            # Run one loop iteration
+            controller.run_loop()
+
+            # Should have submitted reboot
+            reboot_submitted = any('cmd submit' in ' '.join(cmd) and 'reboot' in ' '.join(cmd)
+                                  for cmd in runner.commands)
+            self.assertTrue(reboot_submitted)
+            self.assertEqual(controller.reboot_count, 1)
+
+    def test_run_loop_executes_raw_reset(self):
+        """Test run loop executes raw reset fallback."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = Path(tmpdir) / "mini_COM0_test.log"
+            log_file.write_text("boot log\n=>\n")
+
+            runner = FakeCommandRunner()
+            # Simulate NOT READY
+            runner.set_response('session list', 0,
+                json.dumps({"sessions": [{"selector": "COM0", "state": "RECOVERY"}]}))
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir, count_limit=1)
+
+            # Intercept marker to create log
+            original_send_marker = controller.send_marker_command
+            def tracked_send_marker():
+                marker = original_send_marker()
+                log_file.write_text(f"boot log\n{marker}\n=>\n")
+                return marker
+            controller.send_marker_command = tracked_send_marker
+
+            controller.startup()
+            # Set last action time to allow recovery
+            controller.last_action_time = time.time() - 400
+
+            # Run one loop iteration
+            controller.run_loop()
+
+            # Should have sent raw reset through interactive console API
+            raw_reset = any('interactive-send' in ' '.join(cmd) and 'reset' in ' '.join(cmd)
+                           for cmd in runner.commands)
+            self.assertTrue(raw_reset)
+
+    def test_run_loop_sleeps_on_wait(self):
+        """Test run loop sleeps when action is wait."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = Path(tmpdir) / "mini_COM1_test.log"
+            log_file.write_text("boot log\nno prompt\n")
+
+            runner = FakeCommandRunner()
+            # Simulate NOT READY
+            runner.set_response('session list', 0,
+                json.dumps({"sessions": [{"selector": "COM1", "state": "RECOVERY"}]}))
+
+            controller = RebootController("COM1", runner=runner, log_dir=tmpdir, count_limit=1)
+            controller.startup()
+            # Set last action time to trigger throttle
+            controller.last_action_time = time.time() - 10
+
+            # Mock sleep
+            sleep_called = []
+            def mock_sleep(seconds):
+                sleep_called.append(seconds)
+
+            controller.sleep_fn = mock_sleep
+
+            # Run one loop iteration
+            controller.run_loop()
+
+            # Should have slept
+            self.assertTrue(len(sleep_called) > 0)
+
+    def test_main_integration_with_count_limit(self):
+        """Test main() runs full startup -> loop -> cleanup flow."""
+        from serialwrap_reboot_test.controller import main_with_runner
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+
+            # Intercept the first marker command to create the log
+            marker_created = []
+            original_run = runner.run
+            def intercepting_run(cmd, **kwargs):
+                result = original_run(cmd, **kwargs)
+                # Check if this is a marker submission
+                cmd_str = ' '.join(cmd)
+                if 'cmd submit' in cmd_str and '__SW_REBOOT_TEST_' in cmd_str:
+                    # Extract marker from command
+                    for part in cmd:
+                        if '__SW_REBOOT_TEST_' in part:
+                            marker = part.replace('echo ', '').strip()
+                            if marker not in marker_created:
+                                marker_created.append(marker)
+                                # Create log with marker
+                                log_file = Path(tmpdir) / "mini_COM0_test.log"
+                                log_file.write_text(f"boot log\n{marker}\n")
+                            break
+                return result
+            runner.run = intercepting_run
+
+            # Run main with test runner
+            exit_code = main_with_runner(
+                ["--selector", "COM0", "--count", "1"],
+                runner=runner,
+                log_dir=tmpdir
+            )
+
+            self.assertEqual(exit_code, 0)
+
+            # Verify startup happened
+            event_check = any('event --help' in ' '.join(cmd) for cmd in runner.commands)
+            daemon_check = any('daemon status' in ' '.join(cmd) for cmd in runner.commands)
+            self.assertTrue(event_check)
+            self.assertTrue(daemon_check)
+
+            # Verify rules registered
+            rule_adds = [cmd for cmd in runner.commands if 'event' in ' '.join(cmd) and 'add' in ' '.join(cmd)]
+            self.assertEqual(len(rule_adds), 5)
+
+            # Verify reboot submitted
+            reboot_cmd = any('cmd submit' in ' '.join(cmd) and 'reboot' in ' '.join(cmd)
+                            for cmd in runner.commands)
+            self.assertTrue(reboot_cmd)
+
+            # Verify cleanup happened
+            disable_cmd = any('event' in ' '.join(cmd) and 'disable' in ' '.join(cmd)
+                             for cmd in runner.commands)
+            self.assertTrue(disable_cmd)
+
+    def test_main_returns_nonzero_on_startup_failure(self):
+        """Test main() returns non-zero exit code on startup failure."""
+        from serialwrap_reboot_test.controller import main_with_runner
+
+        runner = FakeCommandRunner()
+        runner.set_response('event --help', 1, "", "Unknown command")
+
+        exit_code = main_with_runner(
+            ["--selector", "COM0"],
+            runner=runner
+        )
+
+        self.assertNotEqual(exit_code, 0)
+
+    def test_marker_submission_failure(self):
+        """Test controller handles marker submission failure."""
+        from serialwrap_reboot_test.controller import RebootController, ControllerError
+
+        runner = FakeCommandRunner()
+        runner.set_response('cmd submit', 1, "", "Failed to submit")
+
+        controller = RebootController("COM0", runner=runner)
+
+        with self.assertRaises(ControllerError):
+            controller.send_marker_command()
+
+    def test_reboot_submission_failure(self):
+        """Test controller handles reboot submission failure."""
+        from serialwrap_reboot_test.controller import RebootController, ControllerError
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = Path(tmpdir) / "mini_COM0_test.log"
+            log_file.write_text("boot log\n")
+
+            runner = FakeCommandRunner()
+            runner.set_response('cmd submit', 1, "", "Failed to submit reboot")
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+            controller.active_log_path = log_file
+
+            with self.assertRaises(ControllerError):
+                controller.submit_normal_reboot()
+
+            # Reboot count should not increment on failure
+            self.assertEqual(controller.reboot_count, 0)
+
+    def test_event_add_failure(self):
+        """Test controller handles event rule add failure."""
+        from serialwrap_reboot_test.controller import RebootController, ControllerError
+
+        runner = FakeCommandRunner()
+        runner.set_response('event add', 1, "", "Failed to add rule")
+
+        controller = RebootController("COM0", runner=runner)
+
+        with self.assertRaises(ControllerError):
+            controller.register_event_rules()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_controller_readiness.py
+++ b/tests/test_controller_readiness.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Test controller readiness checks and setup (Task 2.2)."""
+
+import os
+import sys
+import unittest
+from unittest.mock import Mock, patch, MagicMock
+from pathlib import Path
+import tempfile
+import time
+
+
+class FakeCommandRunner:
+    """Fake command runner for testing without invoking real serialwrap."""
+
+    def __init__(self):
+        self.commands = []
+        self.responses = {}
+        self.call_count = {}
+
+    def run(self, cmd, **kwargs):
+        """Record command and return configured response."""
+        self.commands.append(cmd)
+        cmd_str = ' '.join(cmd) if isinstance(cmd, list) else cmd
+
+        # Track call count for this command
+        self.call_count[cmd_str] = self.call_count.get(cmd_str, 0) + 1
+
+        # Check custom responses first
+        for pattern, response in self.responses.items():
+            if pattern in cmd_str:
+                return response
+
+        # Default responses
+        if 'event --help' in cmd_str:
+            return (0, "Usage: serialwrap event ...", "")
+        elif 'daemon status' in cmd_str:
+            return (0, "Daemon: RUNNING\nPID: 12345", "")
+        elif 'cmd submit' in cmd_str:
+            return (0, "Command submitted", "")
+
+        return (0, "", "")
+
+    def set_response(self, pattern, returncode, stdout, stderr=""):
+        """Configure response for commands matching pattern."""
+        self.responses[pattern] = (returncode, stdout, stderr)
+
+
+class TestControllerReadiness(unittest.TestCase):
+    """Test controller readiness checks and initialization."""
+
+    def test_check_serialwrap_event_support(self):
+        """Test validation of serialwrap event subcommand support."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        # Should succeed with event --help available
+        result = controller.check_serialwrap_event_support()
+        self.assertTrue(result)
+
+        # Should fail if event command not supported
+        runner.set_response('event --help', 1, "", "Unknown command")
+        result = controller.check_serialwrap_event_support()
+        self.assertFalse(result)
+
+    def test_check_daemon_status(self):
+        """Test serialwrap daemon health check."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM1", runner=runner)
+
+        # Should succeed with daemon running
+        result = controller.check_daemon_status()
+        self.assertTrue(result)
+
+        # Should fail if daemon not running
+        runner.set_response('daemon status', 1, "", "Daemon not running")
+        result = controller.check_daemon_status()
+        self.assertFalse(result)
+
+    def test_send_marker_command(self):
+        """Test sending marker command through serialwrap."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        marker = controller.send_marker_command()
+
+        # Should return a marker string
+        self.assertIn("__SW_REBOOT_TEST_", marker)
+        self.assertIn("COM0", marker)
+
+        # Should have submitted command with agent source
+        cmd_found = False
+        for cmd in runner.commands:
+            cmd_str = ' '.join(cmd) if isinstance(cmd, list) else cmd
+            if 'cmd submit' in cmd_str and 'agent:reboot-controller' in cmd_str:
+                cmd_found = True
+                self.assertIn('--timeout', cmd)
+                break
+        self.assertTrue(cmd_found)
+
+    def test_find_active_minicom_log(self):
+        """Test finding active minicom log with marker."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        # Create temp directory with test logs
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create an old log (should be ignored)
+            old_log = Path(tmpdir) / "mini_COM0_260501-120000.log"
+            old_log.write_text("some old content\n")
+            # Set old timestamp
+            old_time = time.time() - 3600  # 1 hour ago
+            os.utime(old_log, (old_time, old_time))
+
+            # Create a recent log without marker (should be ignored)
+            recent_no_marker = Path(tmpdir) / "mini_COM0_260506-140000.log"
+            recent_no_marker.write_text("recent but no marker\n")
+
+            # Create a recent log with marker (should be found)
+            marker = "__SW_REBOOT_TEST_COM0_12345__"
+            active_log = Path(tmpdir) / "mini_COM0_260506-152744.log"
+            active_log.write_text(f"log content\n{marker}\nmore content\n")
+
+            runner = FakeCommandRunner()
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+
+            found_log = controller.find_active_minicom_log(marker, max_age_seconds=600)
+
+            self.assertIsNotNone(found_log)
+            self.assertEqual(found_log.name, "mini_COM0_260506-152744.log")
+
+    def test_find_active_minicom_log_no_match(self):
+        """Test finding active minicom log when none match."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            controller = RebootController("COM1", runner=runner, log_dir=tmpdir)
+
+            found_log = controller.find_active_minicom_log("nonexistent_marker")
+
+            self.assertIsNone(found_log)
+
+    def test_find_active_minicom_log_waits_for_delayed_marker(self):
+        """Retry briefly when marker appears after command acceptance."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            marker = "__SW_REBOOT_TEST_COM0_DELAYED__"
+            active_log = Path(tmpdir) / "mini_COM0_260507-101108.log"
+            active_log.write_text("boot log\n")
+
+            runner = FakeCommandRunner()
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+            controller.marker_wait_seconds = 2
+            controller.marker_poll_interval = 1
+
+            sleep_calls = []
+            def fake_sleep(seconds):
+                sleep_calls.append(seconds)
+                if len(sleep_calls) == 1:
+                    with active_log.open("a") as f:
+                        f.write(f"{marker}\n")
+
+            controller.sleep_fn = fake_sleep
+
+            found_log = controller.find_active_minicom_log(marker, max_age_seconds=600)
+
+            self.assertEqual(found_log, active_log)
+            self.assertGreaterEqual(len(sleep_calls), 1)
+
+    def test_derive_report_path(self):
+        """Test deriving report path from minicom log name."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM1", runner=runner)
+
+        minicom_log = Path("/home/user/b-log/mini_COM1_260506-152744.log")
+        report_path = controller.derive_report_path(minicom_log)
+
+        self.assertEqual(report_path.name, "event-triggered_COM1_260506-152744.md")
+        self.assertEqual(report_path.parent, minicom_log.parent)
+
+    def test_create_run_state_directory(self):
+        """Test creating /tmp run-state directory."""
+        from serialwrap_reboot_test.controller import RebootController
+        import shutil
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        state_dir = controller.create_run_state_directory()
+
+        # Should be under /tmp with selector and PID
+        self.assertTrue(str(state_dir).startswith("/tmp/serialwrap-reboot-test.COM0."))
+        self.assertTrue(state_dir.exists())
+
+        # Clean up
+        shutil.rmtree(state_dir)
+
+    def test_store_run_state(self):
+        """Test storing run state files."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_dir = Path(tmpdir) / "state"
+            state_dir.mkdir()
+
+            runner = FakeCommandRunner()
+            controller = RebootController("COM1", runner=runner)
+
+            minicom_log = Path("/home/user/b-log/mini_COM1_260506-152744.log")
+            report_path = Path("/home/user/b-log/event-triggered_COM1_260506-152744.md")
+
+            controller.store_run_state(state_dir, minicom_log, report_path)
+
+            # Should have stored the paths
+            minicom_file = state_dir / "active_minicom_log.txt"
+            report_file = state_dir / "report_path.txt"
+
+            self.assertTrue(minicom_file.exists())
+            self.assertTrue(report_file.exists())
+
+            self.assertEqual(minicom_file.read_text().strip(), str(minicom_log))
+            self.assertEqual(report_file.read_text().strip(), str(report_path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_controller_reboot_loop.py
+++ b/tests/test_controller_reboot_loop.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+"""Test controller reboot loop logic (Task 2.4)."""
+
+import json
+import os
+import time
+import unittest
+from unittest.mock import Mock, patch
+
+
+class FakeCommandRunner:
+    """Fake command runner for testing without invoking real serialwrap."""
+
+    def __init__(self):
+        self.commands = []
+        self.responses = {}
+        self.call_count = {}
+
+    def run(self, cmd, **kwargs):
+        """Record command and return configured response."""
+        self.commands.append(cmd)
+        cmd_str = ' '.join(cmd) if isinstance(cmd, list) else cmd
+
+        # Track call count
+        self.call_count[cmd_str] = self.call_count.get(cmd_str, 0) + 1
+
+        # Check custom responses first
+        for pattern, response in self.responses.items():
+            if pattern in cmd_str:
+                return response
+
+        # Default responses
+        return (0, "", "")
+
+    def set_response(self, pattern, returncode, stdout, stderr=""):
+        """Configure response for commands matching pattern."""
+        self.responses[pattern] = (returncode, stdout, stderr)
+
+
+class TestControllerRebootLoop(unittest.TestCase):
+    """Test controller reboot loop decision logic."""
+
+    def test_check_ready_state_when_ready(self):
+        """Test checking READY state when session is READY."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+
+        # Simulate READY state
+        session_output = json.dumps({
+            "sessions": [{
+                "selector": "COM0",
+                "state": "READY"
+            }]
+        })
+        runner.set_response('session list', 0, session_output)
+
+        controller = RebootController("COM0", runner=runner)
+        result = controller.check_ready_state()
+
+        self.assertTrue(result)
+
+    def test_check_ready_state_accepts_com_field(self):
+        """Treat session.com as the selector field in newer session list output."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        session_output = json.dumps({
+            "sessions": [{
+                "com": "COM0",
+                "state": "READY"
+            }]
+        })
+        runner.set_response('session list', 0, session_output)
+
+        controller = RebootController("COM0", runner=runner)
+        self.assertTrue(controller.check_ready_state())
+
+    def test_check_ready_state_when_not_ready(self):
+        """Test checking READY state when session is not READY."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+
+        # Simulate NOT_READY state
+        session_output = json.dumps({
+            "sessions": [{
+                "selector": "COM1",
+                "state": "RECOVERY"
+            }]
+        })
+        runner.set_response('session list', 0, session_output)
+
+        controller = RebootController("COM1", runner=runner)
+        result = controller.check_ready_state()
+
+        self.assertFalse(result)
+
+    def test_check_self_test_ok(self):
+        """Test self-test check when classification is OK."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+
+        # Simulate self-test OK
+        selftest_output = json.dumps({
+            "classification": "OK",
+            "probe_ok": True
+        })
+        runner.set_response('session self-test', 0, selftest_output)
+
+        controller = RebootController("COM0", runner=runner)
+        result = controller.check_self_test()
+
+        self.assertTrue(result)
+
+    def test_check_self_test_not_ok(self):
+        """Test self-test check when classification is not OK."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+
+        # Simulate self-test failure
+        selftest_output = json.dumps({
+            "classification": "DEGRADED",
+            "probe_ok": False
+        })
+        runner.set_response('session self-test', 0, selftest_output)
+
+        controller = RebootController("COM1", runner=runner)
+        result = controller.check_self_test()
+
+        self.assertFalse(result)
+
+    def test_submit_normal_reboot(self):
+        """Test submitting normal reboot command."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        timestamp = controller.submit_normal_reboot()
+
+        # Should return a timestamp
+        self.assertIsNotNone(timestamp)
+        self.assertIsInstance(timestamp, float)
+
+        # Should have submitted reboot command with agent source
+        cmd_found = False
+        for cmd in runner.commands:
+            cmd_str = ' '.join(cmd)
+            if 'cmd submit' in cmd_str and 'agent:reboot-controller' in cmd_str and 'reboot' in cmd_str:
+                cmd_found = True
+                self.assertIn('--timeout', cmd)
+                self.assertIn('--cmd-timeout', cmd)
+                break
+        self.assertTrue(cmd_found)
+
+    def test_should_throttle_recovery_within_five_minutes(self):
+        """Test recovery throttling within 5 minutes."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM1", runner=runner)
+
+        # Set last action to 2 minutes ago
+        last_action = time.time() - 120
+
+        result = controller.should_throttle_recovery(last_action, throttle_seconds=300)
+
+        self.assertTrue(result)
+
+    def test_should_throttle_recovery_after_five_minutes(self):
+        """Test recovery throttling after 5 minutes."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+
+        # Set last action to 6 minutes ago
+        last_action = time.time() - 360
+
+        result = controller.should_throttle_recovery(last_action, throttle_seconds=300)
+
+        self.assertFalse(result)
+
+    def test_run_session_recover(self):
+        """Test running session recover command."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM1", runner=runner)
+
+        controller.run_session_recover()
+
+        # Should have called session recover
+        cmd_found = False
+        for cmd in runner.commands:
+            cmd_str = ' '.join(cmd)
+            if 'session recover' in cmd_str:
+                cmd_found = True
+                self.assertIn('--timeout', cmd)
+                break
+        self.assertTrue(cmd_found)
+
+    def test_check_log_tail_for_uboot_prompt(self):
+        """Test checking log tail for U-Boot prompt."""
+        from serialwrap_reboot_test.controller import RebootController
+        from pathlib import Path
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = Path(tmpdir) / "mini_COM0_test.log"
+            log_file.write_text("boot log\nsome output\n=>\nmore output\n")
+
+            runner = FakeCommandRunner()
+            controller = RebootController("COM0", runner=runner)
+
+            result = controller.check_log_tail_for_prompt(log_file, "=>", tail_lines=50)
+
+            self.assertTrue(result)
+
+    def test_check_log_tail_for_prplos_prompt(self):
+        """Test checking log tail for prplOS prompt."""
+        from serialwrap_reboot_test.controller import RebootController
+        from pathlib import Path
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = Path(tmpdir) / "mini_COM1_test.log"
+            log_file.write_text("boot log\nlogin successful\nroot@prplOS:/# \n")
+
+            runner = FakeCommandRunner()
+            controller = RebootController("COM1", runner=runner)
+
+            result = controller.check_log_tail_for_prompt(log_file, "root@prplOS:/#", tail_lines=50)
+
+            self.assertTrue(result)
+
+    def test_check_log_tail_no_prompt(self):
+        """Test checking log tail when no prompt is found."""
+        from serialwrap_reboot_test.controller import RebootController
+        from pathlib import Path
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = Path(tmpdir) / "mini_COM0_test.log"
+            log_file.write_text("boot log\nsome output\nno prompt here\n")
+
+            runner = FakeCommandRunner()
+            controller = RebootController("COM0", runner=runner)
+
+            result = controller.check_log_tail_for_prompt(log_file, "=>", tail_lines=50)
+
+            self.assertFalse(result)
+
+    def test_send_raw_broker_command_reset(self):
+        """Test sending raw broker command for reset."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        runner.set_response('session interactive-open', 0, json.dumps({"interactive_id": "agent-int"}))
+        controller = RebootController("COM0", runner=runner)
+
+        timestamp = controller.send_raw_broker_command("reset")
+
+        # Should return a timestamp
+        self.assertIsNotNone(timestamp)
+        self.assertIsInstance(timestamp, float)
+
+        # Should have sent via interactive console API
+        cmd_found = False
+        for cmd in runner.commands:
+            cmd_str = ' '.join(cmd)
+            if 'interactive-send' in cmd_str and 'reset' in cmd_str:
+                cmd_found = True
+                break
+        self.assertTrue(cmd_found)
+
+    def test_send_raw_broker_command_reboot_force(self):
+        """Test sending raw broker command for reboot -f."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        runner.set_response('session interactive-open', 0, json.dumps({"interactive_id": "agent-int"}))
+        controller = RebootController("COM1", runner=runner)
+
+        timestamp = controller.send_raw_broker_command("reboot -f")
+
+        # Should return a timestamp
+        self.assertIsNotNone(timestamp)
+
+        # Should have sent via interactive console API
+        cmd_found = False
+        for cmd in runner.commands:
+            cmd_str = ' '.join(cmd)
+            if 'interactive-send' in cmd_str and 'reboot -f' in cmd_str:
+                cmd_found = True
+                break
+        self.assertTrue(cmd_found)
+
+    @patch('serialwrap_reboot_test.controller.os.close')
+    @patch('serialwrap_reboot_test.controller.os.write')
+    @patch('serialwrap_reboot_test.controller.os.open')
+    def test_send_raw_broker_command_falls_back_to_console_attach_when_session_not_ready(
+        self,
+        mock_open,
+        mock_write,
+        mock_close,
+    ):
+        """Use console attach fallback when interactive-open reports SESSION_NOT_READY."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        runner.set_response(
+            'session interactive-open',
+            1,
+            json.dumps({"ok": False, "error_code": "SESSION_NOT_READY"}),
+            "",
+        )
+        runner.set_response(
+            'session console-attach',
+            0,
+            json.dumps({
+                "client_id": "client-123",
+                "interactive_owner": True,
+                "vtty": "/dev/pts/42",
+            }),
+            "",
+        )
+        runner.set_response('session console-detach', 0, json.dumps({"ok": True}), "")
+        mock_open.return_value = 99
+        mock_write.return_value = len(b"reset\n")
+
+        controller = RebootController("COM0", runner=runner)
+
+        timestamp = controller.send_raw_broker_command("reset")
+
+        self.assertIsInstance(timestamp, float)
+        mock_open.assert_called_once_with("/dev/pts/42", os.O_WRONLY)
+        mock_write.assert_called_once_with(99, b"reset\n")
+        mock_close.assert_called_once_with(99)
+        self.assertTrue(any('session console-attach' in ' '.join(cmd) for cmd in runner.commands))
+        detach_cmd = next(
+            cmd for cmd in runner.commands
+            if 'session console-detach' in ' '.join(cmd)
+        )
+        self.assertIn('--selector', detach_cmd)
+        self.assertIn('COM0', detach_cmd)
+        self.assertIn('--client-id', detach_cmd)
+
+    @patch('serialwrap_reboot_test.controller.os.open')
+    def test_send_raw_broker_command_fails_when_console_attach_does_not_grant_ownership(
+        self,
+        mock_open,
+    ):
+        """Fallback must fail clearly when console attach does not grant ownership."""
+        from serialwrap_reboot_test.controller import RebootController, ControllerError
+
+        runner = FakeCommandRunner()
+        runner.set_response(
+            'session interactive-open',
+            1,
+            json.dumps({"ok": False, "error_code": "SESSION_NOT_READY"}),
+            "",
+        )
+        runner.set_response(
+            'session console-attach',
+            0,
+            json.dumps({
+                "client_id": "client-456",
+                "interactive_owner": False,
+                "vtty": "/dev/pts/77",
+            }),
+            "",
+        )
+
+        controller = RebootController("COM1", runner=runner)
+
+        with self.assertRaises(ControllerError) as cm:
+            controller.send_raw_broker_command("reboot -f")
+
+        self.assertIn("ownership", str(cm.exception).lower())
+        mock_open.assert_not_called()
+        self.assertTrue(any('session console-detach' in ' '.join(cmd) for cmd in runner.commands))
+
+    @patch('serialwrap_reboot_test.controller.os.close')
+    @patch('serialwrap_reboot_test.controller.os.write')
+    @patch('serialwrap_reboot_test.controller.os.open')
+    def test_send_raw_broker_command_ignores_console_not_found_on_detach(
+        self,
+        mock_open,
+        mock_write,
+        mock_close,
+    ):
+        """Console detach should be best-effort when console is already gone."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        runner.set_response(
+            'session interactive-open',
+            1,
+            json.dumps({"ok": False, "error_code": "SESSION_NOT_READY"}),
+            "",
+        )
+        runner.set_response(
+            'session console-attach',
+            0,
+            json.dumps({
+                "client_id": "client-789",
+                "interactive_owner": True,
+                "vtty": "/dev/pts/88",
+            }),
+            "",
+        )
+        runner.set_response(
+            'session console-detach',
+            1,
+            json.dumps({"ok": False, "error_code": "CONSOLE_NOT_FOUND"}),
+            "",
+        )
+        mock_open.return_value = 101
+        mock_write.return_value = len(b"reset\n")
+
+        controller = RebootController("COM0", runner=runner)
+
+        timestamp = controller.send_raw_broker_command("reset")
+
+        self.assertIsInstance(timestamp, float)
+        mock_open.assert_called_once_with("/dev/pts/88", os.O_WRONLY)
+        mock_write.assert_called_once_with(101, b"reset\n")
+        mock_close.assert_called_once_with(101)
+
+    @patch('serialwrap_reboot_test.controller.os.close')
+    @patch('serialwrap_reboot_test.controller.os.write')
+    @patch('serialwrap_reboot_test.controller.os.open')
+    def test_send_raw_broker_command_fails_on_short_write_and_detaches(
+        self,
+        mock_open,
+        mock_write,
+        mock_close,
+    ):
+        """Short writes must fail and still release the attached console."""
+        from serialwrap_reboot_test.controller import RebootController, ControllerError
+
+        runner = FakeCommandRunner()
+        runner.set_response(
+            'session interactive-open',
+            1,
+            json.dumps({"ok": False, "error_code": "SESSION_NOT_READY"}),
+            "",
+        )
+        runner.set_response(
+            'session console-attach',
+            0,
+            json.dumps({
+                "client_id": "client-short",
+                "interactive_owner": True,
+                "vtty": "/dev/pts/66",
+            }),
+            "",
+        )
+        runner.set_response('session console-detach', 0, json.dumps({"ok": True}), "")
+        mock_open.return_value = 55
+        mock_write.return_value = len(b"reset\n") - 1
+
+        controller = RebootController("COM0", runner=runner)
+
+        with self.assertRaises(ControllerError) as cm:
+            controller.send_raw_broker_command("reset")
+
+        self.assertIn("short write", str(cm.exception).lower())
+        mock_open.assert_called_once_with("/dev/pts/66", os.O_WRONLY)
+        mock_write.assert_called_once_with(55, b"reset\n")
+        mock_close.assert_called_once_with(55)
+        self.assertTrue(any('session console-detach' in ' '.join(cmd) for cmd in runner.commands))
+
+    def test_reboot_decision_ready_and_self_test_ok(self):
+        """Test reboot decision when READY and self-test OK."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+
+        # Simulate READY and self-test OK
+        session_output = json.dumps({"sessions": [{"selector": "COM0", "state": "READY"}]})
+        selftest_output = json.dumps({"classification": "OK", "probe_ok": True})
+        runner.set_response('session list', 0, session_output)
+        runner.set_response('session self-test', 0, selftest_output)
+
+        controller = RebootController("COM0", runner=runner)
+
+        action = controller.decide_reboot_action(None)
+
+        self.assertEqual(action['type'], 'normal_reboot')
+
+    def test_reboot_decision_not_ready_within_throttle(self):
+        """Test reboot decision when not READY and within throttle period."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+
+        # Simulate NOT READY
+        session_output = json.dumps({"sessions": [{"selector": "COM1", "state": "RECOVERY"}]})
+        runner.set_response('session list', 0, session_output)
+
+        controller = RebootController("COM1", runner=runner)
+
+        # Last action 2 minutes ago (within 5 minute throttle)
+        last_action = time.time() - 120
+
+        action = controller.decide_reboot_action(last_action)
+
+        self.assertEqual(action['type'], 'wait')
+
+    def test_reboot_decision_not_ready_after_throttle_no_prompt(self):
+        """Test reboot decision when not READY, after throttle, no prompt found."""
+        from serialwrap_reboot_test.controller import RebootController
+        from pathlib import Path
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = Path(tmpdir) / "mini_COM0_test.log"
+            log_file.write_text("boot log\nno prompt\n")
+
+            runner = FakeCommandRunner()
+
+            # Simulate NOT READY
+            session_output = json.dumps({"sessions": [{"selector": "COM0", "state": "RECOVERY"}]})
+            runner.set_response('session list', 0, session_output)
+
+            controller = RebootController("COM0", runner=runner, active_log=log_file)
+
+            # Last action 6 minutes ago (after 5 minute throttle)
+            last_action = time.time() - 360
+
+            action = controller.decide_reboot_action(last_action)
+
+            # Should have run recover, then wait since no prompt
+            self.assertEqual(action['type'], 'wait')
+
+    def test_reboot_decision_uses_prompt_fallback_after_recover_failure(self):
+        """Test prompt fallback still works when recover returns a JSON error."""
+        from serialwrap_reboot_test.controller import RebootController
+        from pathlib import Path
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = Path(tmpdir) / "mini_COM1_test.log"
+            log_file.write_text("boot log\nroot@prplOS:/# \n")
+
+            runner = FakeCommandRunner()
+            session_output = json.dumps({"sessions": [{"selector": "COM1", "state": "ATTACHED"}]})
+            runner.set_response('session list', 0, session_output)
+            runner.set_response(
+                'session recover',
+                2,
+                json.dumps({"ok": False, "error_code": "PROMPT_TIMEOUT", "partial": True}),
+                "",
+            )
+
+            controller = RebootController("COM1", runner=runner, active_log=log_file)
+
+            last_action = time.time() - 360
+            action = controller.decide_reboot_action(last_action)
+
+            self.assertEqual(action['type'], 'raw_reboot')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cursor_load_race.py
+++ b/tests/test_cursor_load_race.py
@@ -1,0 +1,194 @@
+"""Test for cursor-load-before-lock race condition."""
+
+import tempfile
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from serialwrap_reboot_test.event_handler import handle_event, load_scan_cursors
+
+
+class TestCursorLoadRace:
+    """Test that cursor load happens inside the lock to prevent races."""
+
+    def test_concurrent_same_event_handlers_with_delay_expose_race(self):
+        """Use timing delays to expose the cursor-load-before-lock race."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+
+            # Create log with multiple matching lines
+            log_path = tmpdir / "mini_COM0_260506-152744.log"
+            log_path.write_text(
+                "line 1 brcm-therm\n"
+                "line 2 brcm-therm\n"
+                "line 3 brcm-therm\n"
+            )
+
+            # Set up state
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+
+            payload = {
+                "selector": "COM0",
+                "event": "brcm-therm",
+                "timestamp": "2026-05-06T16:10:23+08:00"
+            }
+
+            # Track which lines are being scanned
+            scan_calls = []
+            original_open = Path.open
+
+            def delayed_open(self, *args, **kwargs):
+                # Add delay to expose race window
+                scan_calls.append(("open", self))
+                time.sleep(0.01)  # Small delay
+                return original_open(self, *args, **kwargs)
+
+            results = []
+            errors = []
+
+            def run_handler():
+                try:
+                    with patch.object(Path, 'open', delayed_open):
+                        result = handle_event(payload, state_root=tmpdir, log_dir=tmpdir)
+                        results.append(result)
+                except Exception as e:
+                    errors.append(e)
+
+            # Launch two threads concurrently
+            thread1 = threading.Thread(target=run_handler)
+            thread2 = threading.Thread(target=run_handler)
+
+            thread1.start()
+            thread2.start()
+            thread1.join()
+            thread2.join()
+
+            # Both should succeed
+            assert len(errors) == 0, f"Errors: {errors}"
+            assert all(r == 0 for r in results), f"Results: {results}"
+
+            # Check report - should have TWO events, not one duplicated
+            report_path = tmpdir / "event-triggered_COM0_260506-152744.md"
+            content = report_path.read_text()
+
+            # Count event rows in report
+            event_rows = [line for line in content.split('\n') if line.startswith('| mini_COM0')]
+
+            # This test exposes the race - if both threads read cursor before lock,
+            # they both see line 1. After fix, this should pass.
+            assert len(event_rows) == 2, f"Expected 2 event rows, got {len(event_rows)}: {event_rows}"
+
+            # Should have different lines (line 1 and line 2), not duplicates
+            # Before fix: might have "| 1 |" twice
+            # After fix: should have "| 1 |" and "| 2 |"
+            has_line_1 = "| 1 |" in content
+            has_line_2 = "| 2 |" in content
+
+            # At minimum, should have 2 distinct entries
+            assert has_line_1, "Should have line 1"
+            # This assertion documents the expected behavior after fix
+            assert has_line_2, "Should have line 2 (cursor should advance under lock)"
+
+    def test_cursor_load_happens_inside_lock(self):
+        """Verify cursor is loaded inside the report lock, not before."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+
+            log_path = tmpdir / "mini_COM0_260506-152744.log"
+            log_path.write_text("line 1 brcm-therm\n")
+
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+
+            payload = {
+                "selector": "COM0",
+                "event": "brcm-therm",
+                "timestamp": "2026-05-06T16:10:23+08:00"
+            }
+
+            # Track when cursor is loaded vs when lock is acquired
+            events = []
+
+            original_load = load_scan_cursors
+            original_locked_file = None
+
+            def tracked_load(cursor_file):
+                events.append("cursor_load")
+                return original_load(cursor_file)
+
+            import serialwrap_reboot_test.event_handler as handler_module
+
+            class TrackedLock:
+                def __init__(self, orig_context):
+                    self.orig_context = orig_context
+
+                def __enter__(self):
+                    events.append("lock_acquired")
+                    return self.orig_context.__enter__()
+
+                def __exit__(self, *args):
+                    events.append("lock_released")
+                    return self.orig_context.__exit__(*args)
+
+            original_locked_file = handler_module._locked_file
+
+            def tracked_locked_file(lock_path):
+                orig_context = original_locked_file(lock_path)
+                return TrackedLock(orig_context)
+
+            with patch.object(handler_module, 'load_scan_cursors', tracked_load):
+                with patch.object(handler_module, '_locked_file', tracked_locked_file):
+                    result = handle_event(payload, state_root=tmpdir, log_dir=tmpdir)
+
+            assert result == 0
+
+            # Verify cursor_load happens AFTER lock_acquired
+            if "cursor_load" in events and "lock_acquired" in events:
+                cursor_idx = events.index("cursor_load")
+                lock_idx = events.index("lock_acquired")
+                assert lock_idx < cursor_idx, \
+                    f"Cursor should be loaded INSIDE lock. Events: {events}"
+
+    def test_sequential_same_event_handlers_advance_cursor(self):
+        """Sequential handlers for same event should advance cursor properly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+
+            log_path = tmpdir / "mini_COM0_260506-152744.log"
+            log_path.write_text(
+                "line 1 brcm-therm\n"
+                "line 2 brcm-therm\n"
+                "line 3 brcm-therm\n"
+            )
+
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+
+            payload = {
+                "selector": "COM0",
+                "event": "brcm-therm",
+                "timestamp": "2026-05-06T16:10:23+08:00"
+            }
+
+            # First call
+            result1 = handle_event(payload, state_root=tmpdir, log_dir=tmpdir)
+            assert result1 == 0
+
+            # Second call
+            result2 = handle_event(payload, state_root=tmpdir, log_dir=tmpdir)
+            assert result2 == 0
+
+            # Check report has both lines
+            report_path = tmpdir / "event-triggered_COM0_260506-152744.md"
+            content = report_path.read_text()
+
+            assert "| 1 |" in content
+            assert "| 2 |" in content
+            assert "| brcm-therm | 2 |" in content

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -1,0 +1,408 @@
+"""Tests for event handler."""
+
+import json
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from serialwrap_reboot_test.event_handler import (
+    parse_event_payload,
+    resolve_active_log,
+    scan_log_for_events,
+    load_report_data,
+    generate_report_content,
+    load_scan_cursors,
+    save_scan_cursors,
+    handle_event,
+)
+
+
+class TestPayloadParsing:
+    """Test event payload parsing."""
+
+    def test_parse_valid_payload_with_selector_and_event(self):
+        """Parse a valid payload with selector and event."""
+        payload = json.dumps({
+            "selector": "COM0",
+            "event": "brcm-therm",
+            "matched_text": "brcm-therm error",
+            "timestamp": "2026-05-06T16:10:23+08:00"
+        })
+        result = parse_event_payload(payload)
+        assert result["selector"] == "COM0"
+        assert result["event"] == "brcm-therm"
+
+    def test_parse_payload_normalizes_rule_name_to_match_text(self):
+        """Normalize serialwrap rule names to report/log match text."""
+        payload = json.dumps({
+            "selector": "COM1",
+            "event": "kernel-panic",
+            "timestamp": "2026-05-06T16:10:23+08:00"
+        })
+        result = parse_event_payload(payload)
+        assert result["selector"] == "COM1"
+        assert result["event"] == "Kernel panic"
+
+    def test_parse_current_serialwrap_dispatch_payload(self):
+        """Parse payload emitted by current EventEngine dispatcher."""
+        payload = json.dumps({
+            "selector": "COM1",
+            "rule_id": "agent-reboot-controller.smc-bootloader",
+            "rule_name": "smc-bootloader",
+            "matched_text": "SMC bootloader",
+            "matched_at": 1778121867975,
+        })
+        result = parse_event_payload(payload)
+        assert result["selector"] == "COM1"
+        assert result["event"] == "SMC bootloader"
+        assert result["timestamp"].startswith("2026-")
+
+    def test_parse_payload_rejects_invalid_selector(self):
+        """Reject selectors that could escape current-run state matching."""
+        payload = json.dumps({"selector": "../COM0", "event": "brcm-therm"})
+        result = parse_event_payload(payload)
+        assert result is None
+
+    def test_parse_payload_rejects_unknown_event(self):
+        """Reject event names outside the reboot-test rule set."""
+        payload = json.dumps({"selector": "COM0", "event": "unexpected"})
+        result = parse_event_payload(payload)
+        assert result is None
+
+    def test_parse_payload_rejects_non_string_event(self):
+        """Reject non-string event values before log scanning."""
+        payload = json.dumps({"selector": "COM0", "event": ["brcm-therm"]})
+        result = parse_event_payload(payload)
+        assert result is None
+
+    def test_parse_payload_missing_selector_returns_none(self):
+        """Return None if selector is missing."""
+        payload = json.dumps({"event": "brcm-therm"})
+        result = parse_event_payload(payload)
+        assert result is None
+
+    def test_parse_payload_missing_event_returns_none(self):
+        """Return None if event is missing."""
+        payload = json.dumps({"selector": "COM0"})
+        result = parse_event_payload(payload)
+        assert result is None
+
+    def test_parse_invalid_json_returns_none(self):
+        """Return None for invalid JSON."""
+        result = parse_event_payload("not json")
+        assert result is None
+
+    def test_parse_empty_payload_returns_none(self):
+        """Return None for empty payload."""
+        result = parse_event_payload("")
+        assert result is None
+
+
+class TestActiveLogResolution:
+    """Test active log resolution."""
+
+    def test_resolve_from_current_run_state(self):
+        """Resolve active log from current-run state."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+
+            log_path = tmpdir / "mini_COM0_260506-152744.log"
+            log_path.touch()
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+
+            result = resolve_active_log("COM0", state_root=tmpdir, log_dir=tmpdir)
+            assert result == log_path
+
+    def test_resolve_fallback_to_recent_log(self):
+        """Fall back to recent minicom log in log_dir."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+
+            # Create a recent log
+            recent_log = tmpdir / "mini_COM1_260506-152744.log"
+            recent_log.touch()
+
+            result = resolve_active_log("COM1", state_root=tmpdir, log_dir=tmpdir)
+            assert result == recent_log
+
+    def test_resolve_returns_none_if_no_recent_log(self):
+        """Return None if no recent log within 10 minutes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+
+            # Create an old log
+            old_log = tmpdir / "mini_COM0_260506-000000.log"
+            old_log.touch()
+            # Make it old by setting mtime to 20 minutes ago
+            import time
+            old_time = time.time() - 20 * 60
+            import os
+            os.utime(old_log, (old_time, old_time))
+
+            result = resolve_active_log("COM0", state_root=tmpdir, log_dir=tmpdir)
+            assert result is None
+
+    def test_resolve_returns_none_if_log_does_not_exist(self):
+        """Return None if the state file points to non-existent log."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+
+            nonexistent = tmpdir / "nonexistent.log"
+            (state_dir / "active_minicom_log.txt").write_text(str(nonexistent))
+
+            result = resolve_active_log("COM0", state_root=tmpdir, log_dir=tmpdir)
+            assert result is None
+
+
+class TestLogScanning:
+    """Test log scanning with cursors."""
+
+    def test_scan_log_for_single_event(self):
+        """Scan log and find event matches."""
+        with tempfile.TemporaryFile(mode="w+") as f:
+            f.write("line 1\n")
+            f.write("line 2 brcm-therm error\n")
+            f.write("line 3\n")
+            f.write("line 4 brcm-therm again\n")
+            f.seek(0)
+
+            matches = list(scan_log_for_events(f, "brcm-therm", start_line=0))
+            assert len(matches) == 2
+            assert matches[0] == (2, "line 2 brcm-therm error")
+            assert matches[1] == (4, "line 4 brcm-therm again")
+
+    def test_scan_log_with_start_cursor(self):
+        """Scan log starting from a cursor position."""
+        with tempfile.TemporaryFile(mode="w+") as f:
+            f.write("line 1 brcm-therm\n")
+            f.write("line 2\n")
+            f.write("line 3 brcm-therm again\n")
+            f.seek(0)
+
+            matches = list(scan_log_for_events(f, "brcm-therm", start_line=1))
+            assert len(matches) == 1
+            assert matches[0] == (3, "line 3 brcm-therm again")
+
+    def test_scan_log_no_matches(self):
+        """Return empty list if no matches."""
+        with tempfile.TemporaryFile(mode="w+") as f:
+            f.write("line 1\n")
+            f.write("line 2\n")
+            f.seek(0)
+
+            matches = list(scan_log_for_events(f, "brcm-therm", start_line=0))
+            assert len(matches) == 0
+
+
+class TestScanCursors:
+    """Test cursor persistence."""
+
+    def test_load_nonexistent_cursors_returns_empty(self):
+        """Load cursors from nonexistent file returns empty dict."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cursor_file = Path(tmpdir) / "cursors.json"
+            cursors = load_scan_cursors(cursor_file)
+            assert cursors == {}
+
+    def test_save_and_load_cursors(self):
+        """Save and load cursor state."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cursor_file = Path(tmpdir) / "cursors.json"
+            data = {"brcm-therm": 5, "pstate": 10}
+
+            save_scan_cursors(cursor_file, data)
+            loaded = load_scan_cursors(cursor_file)
+
+            assert loaded == data
+
+
+class TestReportData:
+    """Test report data loading and generation."""
+
+    def test_load_report_data_new_report(self):
+        """Load report data for a new report."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = Path(tmpdir) / "event-triggered_COM0_260506-152744.md"
+
+            data = load_report_data(report_path)
+
+            assert data["events"] == []
+            assert data["summary"] == {}
+
+    def test_load_report_data_existing_report(self):
+        """Load report data from existing report."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = Path(tmpdir) / "event-triggered_COM0_260506-152744.md"
+            report_path.write_text("""# Event Triggered Report
+
+Log: mini_COM0_260506-152744.log
+Generated: 2026-05-06T16:10:23+08:00
+
+## Summary
+
+Denominator: SMC bootloader = 2
+
+| Event | Count | Probability vs SMC bootloader |
+| --- | ---: | ---: |
+| brcm-therm | 1 | 50.00% |
+| SMC bootloader | 2 | 100.00% |
+
+## Events
+
+| Log name | Log line number | Event trigger time | Event |
+| --- | ---: | --- | --- |
+| mini_COM0_260506-152744.log | 10 | 2026-05-06T16:10:20+08:00 | brcm-therm |
+| mini_COM0_260506-152744.log | 20 | 2026-05-06T16:10:23+08:00 | SMC bootloader |
+""")
+
+            data = load_report_data(report_path)
+
+            assert len(data["events"]) == 2
+            assert data["summary"]["brcm-therm"] == 1
+            assert data["summary"]["SMC bootloader"] == 2
+
+    def test_generate_report_with_zero_denominator(self):
+        """Generate report with zero SMC bootloader count shows N/A."""
+        log_name = "mini_COM0_260506-152744.log"
+        events = [
+            {
+                "log_name": log_name,
+                "line_number": 10,
+                "timestamp": "2026-05-06T16:10:20+08:00",
+                "event": "brcm-therm"
+            }
+        ]
+        summary = {"brcm-therm": 1}
+
+        content = generate_report_content(log_name, events, summary)
+
+        assert "N/A" in content
+        assert "Denominator: SMC bootloader = 0" in content
+
+    def test_generate_report_with_nonzero_denominator(self):
+        """Generate report with probabilities."""
+        log_name = "mini_COM0_260506-152744.log"
+        events = [
+            {
+                "log_name": log_name,
+                "line_number": 10,
+                "timestamp": "2026-05-06T16:10:20+08:00",
+                "event": "brcm-therm"
+            },
+            {
+                "log_name": log_name,
+                "line_number": 20,
+                "timestamp": "2026-05-06T16:10:23+08:00",
+                "event": "SMC bootloader"
+            },
+            {
+                "log_name": log_name,
+                "line_number": 30,
+                "timestamp": "2026-05-06T16:10:26+08:00",
+                "event": "SMC bootloader"
+            }
+        ]
+        summary = {"brcm-therm": 1, "SMC bootloader": 2}
+
+        content = generate_report_content(log_name, events, summary)
+
+        assert "Denominator: SMC bootloader = 2" in content
+        assert "50.00%" in content
+        assert "100.00%" in content
+
+
+class TestEventHandlerIntegration:
+    """Test the full event handler flow."""
+
+    def test_handle_event_with_valid_payload(self):
+        """Handle a complete event with valid payload."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+
+            # Set up log
+            log_path = tmpdir / "mini_COM0_260506-152744.log"
+            log_path.write_text("line 1\nline 2 brcm-therm error\nline 3\n")
+
+            # Set up state
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+
+            # Prepare payload
+            payload = {
+                "selector": "COM0",
+                "event": "brcm-therm",
+                "timestamp": "2026-05-06T16:10:23+08:00"
+            }
+
+            result = handle_event(
+                payload,
+                state_root=tmpdir,
+                log_dir=tmpdir
+            )
+
+            assert result == 0
+
+            # Check that report was created
+            report_path = tmpdir / f"event-triggered_COM0_{log_path.stem.split('_', 2)[2]}.md"
+            assert report_path.exists()
+
+    def test_handle_event_missing_log_returns_nonzero(self):
+        """Return non-zero if log cannot be resolved."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+
+            payload = {
+                "selector": "COM0",
+                "event": "brcm-therm",
+                "timestamp": "2026-05-06T16:10:23+08:00"
+            }
+
+            result = handle_event(
+                payload,
+                state_root=tmpdir,
+                log_dir=tmpdir
+            )
+
+            assert result != 0
+
+    def test_handle_event_is_idempotent(self):
+        """Handler can be called multiple times with same event."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+
+            # Set up log
+            log_path = tmpdir / "mini_COM0_260506-152744.log"
+            log_path.write_text("line 1\nline 2 brcm-therm\nline 3 brcm-therm\nline 4\n")
+
+            # Set up state
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+
+            payload = {
+                "selector": "COM0",
+                "event": "brcm-therm",
+                "timestamp": "2026-05-06T16:10:23+08:00"
+            }
+
+            # First call
+            result1 = handle_event(payload, state_root=tmpdir, log_dir=tmpdir)
+            assert result1 == 0
+
+            # Second call should advance cursor
+            result2 = handle_event(payload, state_root=tmpdir, log_dir=tmpdir)
+            assert result2 == 0
+
+            # Check that both events are in report
+            report_path = tmpdir / f"event-triggered_COM0_{log_path.stem.split('_', 2)[2]}.md"
+            content = report_path.read_text()
+            assert "| 2 |" in content  # Line 2
+            assert "| 3 |" in content  # Line 3

--- a/tests/test_event_handler_fixes.py
+++ b/tests/test_event_handler_fixes.py
@@ -1,0 +1,368 @@
+"""Tests for event handler fixes (issues 1-6)."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
+from io import StringIO
+
+import pytest
+
+from serialwrap_reboot_test.event_handler import (
+    resolve_active_state,
+    derive_report_path_from_log,
+    scan_log_for_events,
+    generate_report_content,
+    save_scan_cursors,
+    load_scan_cursors,
+    handle_event,
+)
+
+
+class TestIssue1ReportPathFromState:
+    """Issue 1: report_path.txt from current-run state must be used."""
+
+    def test_resolve_state_uses_report_path_from_state(self):
+        """Use report_path.txt from state when available."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+
+            log_path = tmpdir / "mini_COM0_260506-152744.log"
+            log_path.touch()
+            report_path = tmpdir / "event-triggered_COM0_260506-152744.md"
+
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+            (state_dir / "report_path.txt").write_text(str(report_path))
+
+            active_log, active_report = resolve_active_state(
+                "COM0", state_root=tmpdir, log_dir=tmpdir
+            )
+
+            assert active_log == log_path
+            assert active_report == report_path
+
+    def test_resolve_state_derives_report_when_state_has_no_report_path(self):
+        """Derive report path when state has no report_path.txt."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+
+            log_path = tmpdir / "mini_COM0_260506-152744.log"
+            log_path.touch()
+
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+            # No report_path.txt
+
+            active_log, active_report = resolve_active_state(
+                "COM0", state_root=tmpdir, log_dir=tmpdir
+            )
+
+            assert active_log == log_path
+            assert active_report is not None
+            assert "event-triggered_COM0_260506-152744.md" in str(active_report)
+
+    def test_handle_event_rejects_invalid_report_path_from_state(self):
+        """handle_event should reject report_path.txt that does not match the log."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+
+            log_path = tmpdir / "mini_COM0_260506-152744.log"
+            log_path.write_text("line 1 brcm-therm\n")
+
+            # Forged/stale state specifies a custom report path
+            custom_report = tmpdir / "custom-report.md"
+            derived_report = tmpdir / "event-triggered_COM0_260506-152744.md"
+
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+            (state_dir / "report_path.txt").write_text(str(custom_report))
+
+            payload = {
+                "selector": "COM0",
+                "event": "brcm-therm",
+                "timestamp": "2026-05-06T16:10:23+08:00"
+            }
+
+            result = handle_event(payload, state_root=tmpdir, log_dir=tmpdir)
+
+            assert result == 0
+            assert not custom_report.exists()
+            assert derived_report.exists()
+            assert "brcm-therm" in derived_report.read_text()
+
+    def test_resolve_state_rejects_report_path_outside_log_dir(self):
+        """Reject report_path.txt pointing outside the minicom log directory."""
+        with tempfile.TemporaryDirectory() as tmpdir, tempfile.TemporaryDirectory() as outside:
+            tmpdir = Path(tmpdir)
+            outside = Path(outside)
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+
+            log_path = tmpdir / "mini_COM0_260506-152744.log"
+            log_path.touch()
+            forged_report = outside / "event-triggered_COM0_260506-152744.md"
+            derived_report = tmpdir / "event-triggered_COM0_260506-152744.md"
+
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+            (state_dir / "report_path.txt").write_text(str(forged_report))
+
+            active_log, active_report = resolve_active_state(
+                "COM0", state_root=tmpdir, log_dir=tmpdir
+            )
+
+            assert active_log == log_path
+            assert active_report == derived_report
+
+
+class TestIssue2RobustReportPathDerivation:
+    """Issue 2: Report path derivation must not crash on unexpected log names."""
+
+    def test_derive_report_path_from_standard_log(self):
+        """Derive report path from standard minicom log name."""
+        log_path = Path("/home/user/b-log/mini_COM0_260506-152744.log")
+        result = derive_report_path_from_log("COM0", log_path)
+
+        assert result is not None
+        assert result.name == "event-triggered_COM0_260506-152744.md"
+        assert result.parent == log_path.parent
+
+    def test_derive_report_path_from_nonstandard_log_returns_none(self):
+        """Return None for non-standard log names."""
+        log_path = Path("/home/user/b-log/weird-log.log")
+        result = derive_report_path_from_log("COM0", log_path)
+
+        assert result is None
+
+    def test_derive_report_path_from_log_without_underscore_returns_none(self):
+        """Return None for log names without expected format."""
+        log_path = Path("/home/user/b-log/mini.log")
+        result = derive_report_path_from_log("COM0", log_path)
+
+        assert result is None
+
+    def test_handle_event_returns_nonzero_for_nonstandard_log_name(self):
+        """Handler returns non-zero and stderr if cannot derive report path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+
+            # Non-standard log name
+            log_path = tmpdir / "weird-log.log"
+            log_path.write_text("line 1 brcm-therm\n")
+
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+            # No report_path.txt
+
+            payload = {
+                "selector": "COM0",
+                "event": "brcm-therm",
+                "timestamp": "2026-05-06T16:10:23+08:00"
+            }
+
+            import sys
+            from io import StringIO
+            old_stderr = sys.stderr
+            sys.stderr = StringIO()
+
+            try:
+                result = handle_event(payload, state_root=tmpdir, log_dir=tmpdir)
+                stderr_output = sys.stderr.getvalue()
+            finally:
+                sys.stderr = old_stderr
+
+            assert result != 0
+            assert "report path" in stderr_output.lower() or "derive" in stderr_output.lower()
+
+
+class TestIssue3PathTraversalSecurity:
+    """Issue 3: Validate resolved log paths are within expected log directory."""
+
+    def test_resolve_active_state_rejects_path_traversal_in_state(self):
+        """Reject path traversal attempts in active_minicom_log.txt."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+
+            # Attacker tries to point to /etc/passwd
+            (state_dir / "active_minicom_log.txt").write_text("/etc/passwd")
+
+            active_log, active_report = resolve_active_state(
+                "COM0", state_root=tmpdir, log_dir=tmpdir
+            )
+
+            # Should reject and return None
+            assert active_log is None
+            assert active_report is None
+
+    def test_resolve_active_state_rejects_relative_path_traversal(self):
+        """Reject relative path traversal like ../../etc/passwd."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            log_dir = tmpdir / "b-log"
+            log_dir.mkdir()
+
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+
+            # Attacker tries relative path traversal
+            (state_dir / "active_minicom_log.txt").write_text("../../etc/passwd")
+
+            active_log, active_report = resolve_active_state(
+                "COM0", state_root=tmpdir, log_dir=log_dir
+            )
+
+            assert active_log is None
+            assert active_report is None
+
+    def test_resolve_active_state_accepts_valid_log_in_log_dir(self):
+        """Accept valid logs within log_dir."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            log_dir = tmpdir / "b-log"
+            log_dir.mkdir()
+
+            state_dir = tmpdir / "serialwarp-reboot-test.COM0.12345"
+            state_dir.mkdir()
+
+            log_path = log_dir / "mini_COM0_260506-152744.log"
+            log_path.touch()
+
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+
+            active_log, active_report = resolve_active_state(
+                "COM0", state_root=tmpdir, log_dir=log_dir
+            )
+
+            assert active_log == log_path
+
+
+class TestIssue4StreamingFirstMatchConsumption:
+    """Issue 4: Only consume first match, not materialize all matches."""
+
+    def test_scan_log_for_events_returns_generator(self):
+        """scan_log_for_events should return a generator, not a list."""
+        with tempfile.TemporaryFile(mode="w+") as f:
+            f.write("line 1 brcm-therm\n")
+            f.write("line 2\n")
+            f.seek(0)
+
+            result = scan_log_for_events(f, "brcm-therm", start_line=0)
+
+            # Should be a generator or iterator, not a list
+            import types
+            assert isinstance(result, types.GeneratorType) or hasattr(result, '__next__')
+
+    def test_handle_event_consumes_only_first_match(self):
+        """Verify handle_event only consumes first match from scan."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+
+            # Log with many matches
+            log_path = tmpdir / "mini_COM0_260506-152744.log"
+            lines = ["line 1 brcm-therm\n"] + ["line X brcm-therm\n" for _ in range(10000)]
+            log_path.write_text("".join(lines))
+
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+
+            payload = {
+                "selector": "COM0",
+                "event": "brcm-therm",
+                "timestamp": "2026-05-06T16:10:23+08:00"
+            }
+
+            # This should complete quickly without materializing all 10001 matches
+            result = handle_event(payload, state_root=tmpdir, log_dir=tmpdir)
+
+            assert result == 0
+
+            # Verify only first match was used
+            report_path = tmpdir / "event-triggered_COM0_260506-152744.md"
+            content = report_path.read_text()
+            # Should only have one event
+            assert content.count("| mini_COM0") == 1
+
+
+class TestIssue5DenominatorZeroAllNA:
+    """Issue 5: When denominator is 0, SMC bootloader should also show N/A."""
+
+    def test_generate_report_zero_denominator_all_na(self):
+        """All events including SMC bootloader show N/A when denominator is 0."""
+        log_name = "mini_COM0_260506-152744.log"
+        events = [
+            {
+                "log_name": log_name,
+                "line_number": 10,
+                "timestamp": "2026-05-06T16:10:20+08:00",
+                "event": "brcm-therm"
+            }
+        ]
+        summary = {"brcm-therm": 1}
+
+        content = generate_report_content(log_name, events, summary)
+
+        # Check that SMC bootloader also shows N/A
+        assert "| SMC bootloader | 0 | N/A |" in content
+        assert "100.00%" not in content
+
+
+class TestIssue6AtomicCursorSaves:
+    """Issue 6: Cursor saves should be atomic and merge with existing."""
+
+    def test_save_cursors_merges_with_existing(self):
+        """Saving cursors for one event preserves cursors for other events."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cursor_file = Path(tmpdir) / "cursors.json"
+
+            # Save initial cursors
+            save_scan_cursors(cursor_file, {"brcm-therm": 10})
+
+            # Load and verify
+            assert load_scan_cursors(cursor_file) == {"brcm-therm": 10}
+
+            # Save different event (should merge, not overwrite)
+            save_scan_cursors(cursor_file, {"pstate": 20})
+
+            # Both should be present
+            cursors = load_scan_cursors(cursor_file)
+            assert cursors["brcm-therm"] == 10
+            assert cursors["pstate"] == 20
+
+    def test_save_cursors_updates_existing_event(self):
+        """Saving cursors for an existing event updates its value."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cursor_file = Path(tmpdir) / "cursors.json"
+
+            # Save initial
+            save_scan_cursors(cursor_file, {"brcm-therm": 10, "pstate": 15})
+
+            # Update brcm-therm
+            save_scan_cursors(cursor_file, {"brcm-therm": 25})
+
+            cursors = load_scan_cursors(cursor_file)
+            assert cursors["brcm-therm"] == 25
+            assert cursors["pstate"] == 15
+
+    def test_save_cursors_is_atomic(self):
+        """Cursor saves use atomic write (temp + rename)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cursor_file = Path(tmpdir) / "cursors.json"
+
+            # Save some data
+            save_scan_cursors(cursor_file, {"brcm-therm": 10})
+
+            # File should exist and be readable
+            assert cursor_file.exists()
+            cursors = load_scan_cursors(cursor_file)
+            assert cursors == {"brcm-therm": 10}
+
+            # No temp files should remain
+            temp_files = list(cursor_file.parent.glob("*.tmp*"))
+            assert len(temp_files) == 0

--- a/tests/test_event_handler_race_fixes.py
+++ b/tests/test_event_handler_race_fixes.py
@@ -1,0 +1,267 @@
+"""Tests for event handler race condition and error handling fixes."""
+
+import json
+import tempfile
+import threading
+import time
+from pathlib import Path
+from unittest.mock import Mock, patch, mock_open
+
+import pytest
+
+from serialwrap_reboot_test.event_handler import (
+    save_scan_cursors,
+    load_scan_cursors,
+    handle_event,
+    write_text_atomic,
+)
+
+
+class TestCursorSaveLocking:
+    """Test cursor save operations with locking."""
+
+    def test_cursor_save_preserves_concurrent_updates_sequential(self):
+        """Sequential saves to different events preserve both (lock testing)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cursor_file = Path(tmpdir) / "cursors.json"
+
+            # Save first event
+            save_scan_cursors(cursor_file, {"brcm-therm": 10})
+
+            # Save second event (should merge with first)
+            save_scan_cursors(cursor_file, {"pstate": 20})
+
+            # Load and verify both are present
+            cursors = load_scan_cursors(cursor_file)
+            assert cursors["brcm-therm"] == 10
+            assert cursors["pstate"] == 20
+
+    def test_cursor_save_concurrent_writes_with_threads(self):
+        """Concurrent writes from threads preserve all updates."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cursor_file = Path(tmpdir) / "cursors.json"
+            errors = []
+
+            def save_event(event_name, line_num):
+                try:
+                    save_scan_cursors(cursor_file, {event_name: line_num})
+                except Exception as e:
+                    errors.append(e)
+
+            # Launch concurrent saves
+            threads = [
+                threading.Thread(target=save_event, args=("brcm-therm", 10)),
+                threading.Thread(target=save_event, args=("pstate", 20)),
+                threading.Thread(target=save_event, args=("Link is Down", 30)),
+            ]
+
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            assert len(errors) == 0, f"Errors during concurrent saves: {errors}"
+
+            # All events should be present
+            cursors = load_scan_cursors(cursor_file)
+            assert len(cursors) >= 3, f"Expected 3 events, got {len(cursors)}"
+            assert "brcm-therm" in cursors
+            assert "pstate" in cursors
+            assert "Link is Down" in cursors
+
+
+class TestReportWriteLocking:
+    """Test report write operations with locking."""
+
+    def test_sequential_event_updates_preserve_all_events(self):
+        """Sequential updates to same report preserve all events."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+
+            # Create log and state
+            log_path = tmpdir / "mini_COM0_260506-152744.log"
+            log_path.write_text(
+                "line 1 brcm-therm\n"
+                "line 2 pstate\n"
+                "line 3 Link is Down\n"
+            )
+
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+
+            # First event
+            payload1 = {
+                "selector": "COM0",
+                "event": "brcm-therm",
+                "timestamp": "2026-05-06T16:10:20+08:00"
+            }
+            result1 = handle_event(payload1, state_root=tmpdir, log_dir=tmpdir)
+            assert result1 == 0
+
+            # Second event (different event type)
+            payload2 = {
+                "selector": "COM0",
+                "event": "pstate",
+                "timestamp": "2026-05-06T16:10:21+08:00"
+            }
+            result2 = handle_event(payload2, state_root=tmpdir, log_dir=tmpdir)
+            assert result2 == 0
+
+            # Check report has both events
+            report_path = tmpdir / "event-triggered_COM0_260506-152744.md"
+            content = report_path.read_text()
+            assert "brcm-therm" in content
+            assert "pstate" in content
+            assert content.count("| mini_COM0") == 2
+
+
+class TestAtomicReportWrite:
+    """Test atomic report writing."""
+
+    def test_write_text_atomic_creates_file(self):
+        """write_text_atomic creates file atomically."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "test.md"
+            content = "# Test Report\n\nContent here"
+
+            write_text_atomic(file_path, content)
+
+            assert file_path.exists()
+            assert file_path.read_text() == content
+
+    def test_write_text_atomic_replaces_existing(self):
+        """write_text_atomic replaces existing file atomically."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "test.md"
+
+            # Create initial file
+            file_path.write_text("old content")
+
+            # Atomic replace
+            write_text_atomic(file_path, "new content")
+
+            assert file_path.read_text() == "new content"
+
+    def test_write_text_atomic_no_temp_files_remain(self):
+        """No temporary files remain after atomic write."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "test.md"
+
+            write_text_atomic(file_path, "content")
+
+            # Check no temp files
+            temp_files = list(Path(tmpdir).glob("*.tmp*"))
+            assert len(temp_files) == 0
+
+
+class TestErrorHandling:
+    """Test error handling with narrow exceptions."""
+
+    def test_handle_event_returns_nonzero_on_log_open_failure(self):
+        """Handler returns non-zero on log open failure without traceback."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+
+            # Point to non-existent log
+            log_path = tmpdir / "mini_COM0_260506-152744.log"
+            # Don't create the file
+
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+
+            payload = {
+                "selector": "COM0",
+                "event": "brcm-therm",
+                "timestamp": "2026-05-06T16:10:23+08:00"
+            }
+
+            import sys
+            from io import StringIO
+            old_stderr = sys.stderr
+            sys.stderr = StringIO()
+
+            try:
+                result = handle_event(payload, state_root=tmpdir, log_dir=tmpdir)
+                stderr_output = sys.stderr.getvalue()
+            finally:
+                sys.stderr = old_stderr
+
+            assert result != 0
+            assert "error" in stderr_output.lower() or "failed" in stderr_output.lower()
+
+    def test_handle_event_returns_nonzero_on_report_write_failure(self):
+        """Handler returns non-zero on report write failure without traceback."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+
+            # Create log
+            log_path = tmpdir / "mini_COM0_260506-152744.log"
+            log_path.write_text("line 1 brcm-therm\n")
+
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+
+            # Make report directory read-only to cause write failure
+            report_path = tmpdir / "event-triggered_COM0_260506-152744.md"
+            # Create a directory with the report name to prevent writing
+            report_path.mkdir()
+
+            payload = {
+                "selector": "COM0",
+                "event": "brcm-therm",
+                "timestamp": "2026-05-06T16:10:23+08:00"
+            }
+
+            import sys
+            from io import StringIO
+            old_stderr = sys.stderr
+            sys.stderr = StringIO()
+
+            try:
+                result = handle_event(payload, state_root=tmpdir, log_dir=tmpdir)
+                stderr_output = sys.stderr.getvalue()
+            finally:
+                sys.stderr = old_stderr
+
+            assert result != 0
+            assert "error" in stderr_output.lower() or "failed" in stderr_output.lower()
+
+    def test_handle_event_handles_permission_error_gracefully(self):
+        """Handler handles permission errors gracefully."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+
+            log_path = tmpdir / "mini_COM0_260506-152744.log"
+            log_path.write_text("line 1 brcm-therm\n")
+
+            state_dir = tmpdir / "serialwrap-reboot-test.COM0.12345"
+            state_dir.mkdir()
+            (state_dir / "active_minicom_log.txt").write_text(str(log_path))
+
+            payload = {
+                "selector": "COM0",
+                "event": "brcm-therm",
+                "timestamp": "2026-05-06T16:10:23+08:00"
+            }
+
+            # Mock write_text_atomic to raise PermissionError
+            with patch('serialwrap_reboot_test.event_handler.write_text_atomic') as mock_write:
+                mock_write.side_effect = PermissionError("Permission denied")
+
+                import sys
+                from io import StringIO
+                old_stderr = sys.stderr
+                sys.stderr = StringIO()
+
+                try:
+                    result = handle_event(payload, state_root=tmpdir, log_dir=tmpdir)
+                    stderr_output = sys.stderr.getvalue()
+                finally:
+                    sys.stderr = old_stderr
+
+                assert result != 0
+                # Should print error message, not traceback
+                assert "error" in stderr_output.lower() or "permission" in stderr_output.lower()

--- a/tests/test_fault_installer.py
+++ b/tests/test_fault_installer.py
@@ -1,0 +1,1209 @@
+#!/usr/bin/env python3
+"""Test fault installer for serialwrap-fault-install."""
+
+import unittest
+import re
+
+
+class TestFaultInjectorScript(unittest.TestCase):
+    """Test target fault injector script generation (Task 4.1)."""
+
+    def test_build_fault_injector_script_returns_string(self):
+        """Test that build_fault_injector_script returns a shell script string."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        self.assertIsInstance(script, str)
+        self.assertTrue(len(script) > 0)
+
+    def test_fault_injector_has_shebang(self):
+        """Test that the fault injector script has a shell shebang."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        self.assertTrue(script.startswith('#!/bin/sh'))
+
+    def test_fault_injector_has_10_percent_probability(self):
+        """Test that the fault injector has a 10% probability gate."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Should have a random check, likely with RANDOM % 10 == 0 or similar
+        # Looking for 10% probability: 1 in 10 chance
+        self.assertTrue(
+            'RANDOM' in script or '$RANDOM' in script,
+            "Script should use RANDOM for probability"
+        )
+        # Should have modulo 10 for 10% probability
+        self.assertTrue('% 10' in script or '% 100' in script)
+
+    def test_fault_injector_has_four_fault_types(self):
+        """Test that the fault injector has four fault event types."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        script_lower = script.lower()
+        # Four faults: thermal, 5G ethernet, process coredump, system crash
+        # Should have case/if statements or similar for 4 choices
+        # Looking for thermal notification text
+        self.assertIn('brcm-therm', script_lower)
+        self.assertIn('trip 0', script_lower)
+        self.assertIn('threshold=105000', script_lower)
+
+        # Looking for ethernet AN (ethctl phy-reset)
+        self.assertIn('ethctl', script_lower)
+        self.assertIn('phy-reset', script_lower)
+
+        # Looking for coredump references
+        self.assertIn('kill', script_lower)
+
+        # Looking for panic or crash
+        self.assertTrue('panic' in script_lower or 'crash' in script_lower or 'sysrq' in script_lower)
+
+    def test_fault_injector_thermal_writes_to_dev_console(self):
+        """Test that thermal fault writes to /dev/console."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Thermal notification must write to /dev/console
+        self.assertIn('/dev/console', script)
+        # Should have the exact thermal message
+        self.assertIn('bcm_thermal_drv brcm-therm: Trip 0: threshold=105000 mC hysteresis=2000 mC', script)
+
+    def test_fault_injector_process_coredump_checks_pid_4000(self):
+        """Test that process coredump checks for PID > 4000."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Process coredump should check ps aux for PID > 4000
+        self.assertIn('ps aux', script)
+        self.assertIn('4000', script)
+
+    def test_fault_injector_silent_normal_execution(self):
+        """Test that the fault injector runs silently in normal cases."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Should redirect stdout/stderr to /dev/null for normal output
+        # OR should not have any echo/print statements except for faults
+        # Silent means no debug output - check for /dev/null redirects
+        self.assertIn('/dev/null', script)
+
+    def test_fault_injector_exits_zero(self):
+        """Test that the fault injector exits with 0 on success."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Should have exit 0 or implicit success
+        self.assertIn('exit 0', script)
+
+    def test_fault_injector_equal_probability_four_faults(self):
+        """Test that when triggered, four faults are equally probable (25% each)."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Equal probability among 4 choices when triggered
+        # Likely uses % 4 or case 0|1|2|3)
+        # Should have 4-way branching
+        fault_branches = script.count('0)') + script.count('1)') + script.count('2)') + script.count('3)')
+        self.assertGreaterEqual(fault_branches, 4, "Should have at least 4 case branches for equal probability")
+
+
+class TestInitScript(unittest.TestCase):
+    """Test init script generation (Task 4.2)."""
+
+    def test_build_init_script_returns_string(self):
+        """Test that build_init_script returns a shell script string."""
+        from serialwrap_reboot_test.fault_installer import build_init_script
+
+        script = build_init_script()
+        self.assertIsInstance(script, str)
+        self.assertTrue(len(script) > 0)
+
+    def test_init_script_has_shebang(self):
+        """Test that the init script has a shell shebang."""
+        from serialwrap_reboot_test.fault_installer import build_init_script
+
+        script = build_init_script()
+        self.assertTrue(script.startswith('#!/bin/sh'))
+
+    def test_init_script_calls_fault_injector(self):
+        """Test that the init script calls the fault injector."""
+        from serialwrap_reboot_test.fault_installer import build_init_script
+
+        script = build_init_script()
+        self.assertIn('/usr/sbin/serialwrap-fault-injector', script)
+
+    def test_init_script_handles_start(self):
+        """Test that the init script handles start command."""
+        from serialwrap_reboot_test.fault_installer import build_init_script
+
+        script = build_init_script()
+        self.assertIn('start', script)
+
+
+class TestFaultInstallerFallback(unittest.TestCase):
+    """Test short-write fallback commands (Task 4.2)."""
+
+    def test_short_write_commands_returns_list(self):
+        """Test that short_write_commands returns a list of command strings."""
+        from serialwrap_reboot_test.fault_installer import short_write_commands
+
+        content = "#!/bin/sh\necho test\n"
+        commands = short_write_commands("/usr/sbin/test", content, "0755")
+        self.assertIsInstance(commands, list)
+        self.assertTrue(len(commands) > 0)
+
+    def test_short_write_commands_no_heredoc(self):
+        """Test that fallback commands do not use heredoc."""
+        from serialwrap_reboot_test.fault_installer import short_write_commands
+
+        content = "#!/bin/sh\necho test\n" * 50  # Make it longer
+        commands = short_write_commands("/usr/sbin/test", content, "0755")
+
+        for cmd in commands:
+            # Should not contain heredoc markers
+            self.assertNotIn('<<', cmd)
+            self.assertNotIn('EOF', cmd)
+
+    def test_short_write_commands_bounded_length(self):
+        """Test that each fallback command is reasonably bounded in length."""
+        from serialwrap_reboot_test.fault_installer import short_write_commands
+
+        content = "#!/bin/sh\necho test\n" * 100
+        commands = short_write_commands("/usr/sbin/test", content, "0755")
+
+        # Each command should be reasonably short for UART safety
+        # Allow some overhead for command structure, but keep under 500 chars
+        for cmd in commands:
+            self.assertLess(len(cmd), 500, f"Command too long: {len(cmd)} chars")
+
+    def test_short_write_commands_sets_permissions(self):
+        """Test that short_write_commands includes chmod."""
+        from serialwrap_reboot_test.fault_installer import short_write_commands
+
+        content = "#!/bin/sh\necho test\n"
+        commands = short_write_commands("/usr/sbin/test", content, "0755")
+
+        # Should include chmod command
+        chmod_found = any('chmod' in cmd for cmd in commands)
+        self.assertTrue(chmod_found, "Should include chmod command")
+
+
+class TestFaultInstallerArguments(unittest.TestCase):
+    """Test fault installer argument parsing (Task 4.2)."""
+
+    def test_parse_args_requires_selector(self):
+        """Test that --selector is required."""
+        from serialwrap_reboot_test.fault_installer import parse_args
+
+        with self.assertRaises(SystemExit) as cm:
+            parse_args([])
+
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_parse_args_with_selector(self):
+        """Test parsing with required --selector argument."""
+        from serialwrap_reboot_test.fault_installer import parse_args
+
+        args = parse_args(["--selector", "COM1"])
+        self.assertEqual(args.selector, "COM1")
+
+    def test_parse_args_validates_selector_format(self):
+        """Test that selector must be COMx format."""
+        from serialwrap_reboot_test.fault_installer import parse_args
+
+        # Valid formats
+        args = parse_args(["--selector", "COM0"])
+        self.assertEqual(args.selector, "COM0")
+
+        args = parse_args(["--selector", "COM1"])
+        self.assertEqual(args.selector, "COM1")
+
+
+class TestFaultInstallerDirectoryChecks(unittest.TestCase):
+    """Test directory validation before installation (Task 4.2)."""
+
+    def test_check_target_directories_success(self):
+        """Test directory check succeeds when directories exist."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+
+        class MockRunner:
+            def run(self, cmd):
+                # Simulate directories exist
+                return (0, "", "")
+
+            def run_target(self, cmd):
+                return self.run(cmd)
+
+            def run_host(self, args):
+                return (0, "", "")
+
+        installer = FaultInstaller("COM1", MockRunner())
+        # Should not raise
+        result = installer.check_target_directories()
+        self.assertTrue(result)
+
+    def test_check_target_directories_failure(self):
+        """Test directory check fails when directories missing."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+
+        class MockRunner:
+            def run(self, cmd):
+                # Simulate directory does not exist
+                return (1, "", "directory not found")
+
+            def run_target(self, cmd):
+                return self.run(cmd)
+
+            def run_host(self, args):
+                return (0, "", "")
+
+        installer = FaultInstaller("COM1", MockRunner())
+        result = installer.check_target_directories()
+        self.assertFalse(result)
+
+
+class TestFaultInstallerInstallation(unittest.TestCase):
+    """Test fault installer installation flow (Task 4.2)."""
+
+    def test_install_uses_file_transfer_first(self):
+        """Test that installer tries file transfer before fallback."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+
+        class MockRunner:
+            def __init__(self):
+                self.commands = []
+
+            def run(self, cmd):
+                self.commands.append(cmd)
+                # Directory checks succeed
+                if 'test -d' in cmd:
+                    return (0, "", "")
+                # base64 check succeeds (enables file transfer)
+                if 'which base64' in cmd:
+                    return (0, "/usr/bin/base64", "")
+                # File transfer succeeds
+                if 'file' in cmd and 'send' in cmd:
+                    return (0, "transferred", "")
+                # Other commands succeed
+                return (0, "", "")
+
+            def run_target(self, cmd):
+                return self.run(cmd)
+
+            def run_host(self, args):
+                # File send via run_host
+                self.commands.append(' '.join(args))
+                return (0, "transferred", "")
+
+        runner = MockRunner()
+        installer = FaultInstaller("COM1", runner)
+        installer.install()
+
+        # Should use either file transfer OR fallback (both are valid)
+        # Just check that installation commands were run
+        self.assertGreater(len(runner.commands), 0, "Should run installation commands")
+
+    def test_install_uses_fallback_when_transfer_fails(self):
+        """Test that installer uses fallback when file transfer fails."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+
+        class MockRunner:
+            def __init__(self):
+                self.commands = []
+
+            def run(self, cmd):
+                self.commands.append(cmd)
+                # Directory checks succeed
+                if 'test -d' in cmd:
+                    return (0, "", "")
+                # File transfer fails
+                if 'file' in cmd and 'send' in cmd:
+                    return (1, "", "transfer failed")
+                # Other commands succeed
+                return (0, "", "")
+
+            def run_target(self, cmd):
+                return self.run(cmd)
+
+            def run_host(self, args):
+                # File send via run_host fails
+                self.commands.append(' '.join(args))
+                return (1, "", "transfer failed")
+
+        runner = MockRunner()
+        installer = FaultInstaller("COM1", runner)
+        installer.install()
+
+        # Should have used fallback (base64 or echo commands)
+        fallback_used = any('base64' in cmd or 'echo' in cmd or '>>' in cmd
+                           for cmd in runner.commands)
+        self.assertTrue(fallback_used, "Should use fallback when transfer fails")
+
+    def test_install_sets_executable_permissions(self):
+        """Test that installer sets executable permissions."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+
+        class MockRunner:
+            def __init__(self):
+                self.commands = []
+
+            def run(self, cmd):
+                self.commands.append(cmd)
+                return (0, "", "")
+
+            def run_target(self, cmd):
+                return self.run(cmd)
+
+            def run_host(self, args):
+                self.commands.append(' '.join(args))
+                return (0, "", "")
+
+        runner = MockRunner()
+        installer = FaultInstaller("COM1", runner)
+        installer.install()
+
+        # Should have chmod commands for executables
+        chmod_commands = [cmd for cmd in runner.commands if 'chmod' in cmd]
+        self.assertGreater(len(chmod_commands), 0, "Should have chmod commands")
+
+    def test_install_creates_symlink(self):
+        """Test that installer creates rc.d symlink."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+
+        class MockRunner:
+            def __init__(self):
+                self.commands = []
+
+            def run(self, cmd):
+                self.commands.append(cmd)
+                return (0, "", "")
+
+            def run_target(self, cmd):
+                return self.run(cmd)
+
+            def run_host(self, args):
+                self.commands.append(' '.join(args))
+                return (0, "", "")
+
+        runner = MockRunner()
+        installer = FaultInstaller("COM1", runner)
+        installer.install()
+
+        # Should create symlink S50serialwrap-fault-injector
+        symlink_commands = [cmd for cmd in runner.commands if 'ln' in cmd and 'S50' in cmd]
+        self.assertGreater(len(symlink_commands), 0, "Should create S50 symlink")
+
+    def test_install_verifies_installation(self):
+        """Test that installer verifies files after installation."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+
+        class MockRunner:
+            def __init__(self):
+                self.commands = []
+
+            def run(self, cmd):
+                self.commands.append(cmd)
+                return (0, "", "")
+
+            def run_target(self, cmd):
+                return self.run(cmd)
+
+            def run_host(self, args):
+                self.commands.append(' '.join(args))
+                return (0, "", "")
+
+        runner = MockRunner()
+        installer = FaultInstaller("COM1", runner)
+        installer.install()
+
+        # Should verify files exist
+        verify_commands = [cmd for cmd in runner.commands
+                          if 'test' in cmd or 'ls' in cmd or '[' in cmd]
+        self.assertGreater(len(verify_commands), 0, "Should verify installation")
+
+
+class TestFaultInstallerMain(unittest.TestCase):
+    """Test fault installer main entry point (Task 4.2)."""
+
+    def test_main_returns_zero_on_success(self):
+        """Test that main returns 0 on successful installation."""
+        from serialwrap_reboot_test.fault_installer import main
+        from unittest.mock import patch
+
+        class MockInstaller:
+            def __init__(self, selector):
+                self.selector = selector
+
+            def install(self):
+                return True
+
+        with patch('serialwrap_reboot_test.fault_installer.FaultInstaller', MockInstaller):
+            with patch('sys.argv', ['serialwrap-fault-install', '--selector', 'COM1']):
+                result = main()
+                self.assertEqual(result, 0)
+
+    def test_main_returns_nonzero_on_failure(self):
+        """Test that main returns non-zero on installation failure."""
+        from serialwrap_reboot_test.fault_installer import main
+        import sys
+
+        # Mock sys.argv with invalid args
+        original_argv = sys.argv
+        try:
+            sys.argv = ['serialwrap-fault-install']  # Missing --selector
+            result = main()
+            self.assertNotEqual(result, 0)
+        except SystemExit as e:
+            # argparse raises SystemExit on error
+            self.assertNotEqual(e.code, 0)
+        finally:
+            sys.argv = original_argv
+
+
+class TestFileTransferPreferred(unittest.TestCase):
+    """Test that file transfer is preferred over fallback (Blocker 1)."""
+
+    def test_transfer_file_attempts_serialwrap_file_send(self):
+        """Test that transfer_file tries serialwrap file send first."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+
+        class MockRunner:
+            def __init__(self):
+                self.commands = []
+
+            def run(self, cmd):
+                self.commands.append(cmd)
+                # Directory checks succeed
+                if 'test -d' in cmd:
+                    return (0, "", "")
+                # File send succeeds
+                if 'file send' in cmd or 'file push' in cmd:
+                    return (0, "File transferred", "")
+                return (0, "", "")
+
+            def run_target(self, cmd):
+                return self.run(cmd)
+
+            def run_host(self, args):
+                self.commands.append(' '.join(args))
+                return (0, "File transferred", "")
+
+        runner = MockRunner()
+        installer = FaultInstaller("COM1", runner)
+        installer.install()
+
+        # Should have attempted file send/push via serialwrap
+        file_commands = [cmd for cmd in runner.commands if 'file send' in cmd or 'file push' in cmd]
+        self.assertGreater(len(file_commands), 0, "Should attempt serialwrap file transfer")
+
+    def test_transfer_file_uses_fallback_only_on_failure(self):
+        """Test that fallback is only used when file transfer fails."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+
+        class MockRunner:
+            def __init__(self):
+                self.commands = []
+
+            def run(self, cmd):
+                self.commands.append(cmd)
+                # Directory checks succeed
+                if 'test -d' in cmd:
+                    return (0, "", "")
+                # File send fails
+                if 'file send' in cmd or 'file push' in cmd:
+                    return (1, "", "transfer failed")
+                # Fallback commands succeed
+                return (0, "", "")
+
+            def run_target(self, cmd):
+                return self.run(cmd)
+
+            def run_host(self, args):
+                self.commands.append(' '.join(args))
+                return (1, "", "transfer failed")
+
+        runner = MockRunner()
+        installer = FaultInstaller("COM1", runner)
+        installer.install()
+
+        # Should have attempted file transfer first
+        file_commands = [cmd for cmd in runner.commands if 'file send' in cmd or 'file push' in cmd]
+        self.assertGreater(len(file_commands), 0, "Should attempt file transfer first")
+
+        # Should have used fallback (base64 or echo)
+        fallback_commands = [cmd for cmd in runner.commands if 'base64' in cmd or 'echo' in cmd]
+        self.assertGreater(len(fallback_commands), 0, "Should use fallback when transfer fails")
+
+    def test_transfer_file_does_not_use_fallback_on_success(self):
+        """Test that fallback is not used when file transfer succeeds."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+
+        class MockRunner:
+            def __init__(self):
+                self.commands = []
+
+            def run(self, cmd):
+                self.commands.append(cmd)
+                # Directory checks succeed
+                if 'test -d' in cmd:
+                    return (0, "", "")
+                # File send succeeds
+                if 'file send' in cmd or 'file push' in cmd:
+                    return (0, "transferred", "")
+                return (0, "", "")
+
+            def run_target(self, cmd):
+                return self.run(cmd)
+
+            def run_host(self, args):
+                self.commands.append(' '.join(args))
+                return (0, "transferred", "")
+
+        runner = MockRunner()
+        installer = FaultInstaller("COM1", runner)
+        installer.install()
+
+        # Should not use fallback commands when transfer succeeds
+        fallback_commands = [cmd for cmd in runner.commands if 'base64 -d' in cmd or ('echo' in cmd and '>>' in cmd)]
+        self.assertEqual(len(fallback_commands), 0, "Should not use fallback when transfer succeeds")
+
+
+class TestFaultInjectorCommands(unittest.TestCase):
+    """Test exact fault injector commands (Blocker 2)."""
+
+    def test_ethernet_fault_uses_ethctl_phy_reset(self):
+        """Test that 5G ethernet fault uses ethctl eth0 phy-reset."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Must use ethctl eth0 phy-reset for 5G ethernet AN rerun
+        self.assertIn('ethctl eth0 phy-reset', script)
+
+    def test_process_coredump_uses_sigabrt(self):
+        """Test that process coredump uses SIGABRT."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Must use SIGABRT for process coredump
+        self.assertIn('SIGABRT', script)
+
+    def test_system_crash_sysrq_correct_syntax(self):
+        """Test that system crash uses correct sysrq syntax."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Must write c to /proc/sysrq-trigger correctly
+        # Check that we have the command (not just commented)
+        # Should be: echo c > /proc/sysrq-trigger (without double redirect)
+        self.assertIn('/proc/sysrq-trigger', script)
+        # Check it's not double-redirected
+        self.assertNotIn('> /proc/sysrq-trigger > /dev/null', script)
+
+
+class TestSymlinkVerification(unittest.TestCase):
+    """Test symlink target verification (Blocker 3)."""
+
+    def test_verify_checks_symlink_target(self):
+        """Test that verify checks symlink points to init script."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+
+        class MockRunner:
+            def __init__(self):
+                self.commands = []
+
+            def run(self, cmd):
+                self.commands.append(cmd)
+                # Executables exist
+                if 'test -x' in cmd:
+                    return (0, "", "")
+                # Symlink exists
+                if 'test -L' in cmd:
+                    return (0, "", "")
+                # readlink returns correct target
+                if 'readlink' in cmd:
+                    return (0, "/etc/init.d/serialwrap-fault-injector", "")
+                return (0, "", "")
+
+            def run_target(self, cmd):
+                return self.run(cmd)
+
+            def run_host(self, args):
+                self.commands.append(' '.join(args))
+                return (0, "", "")
+
+        runner = MockRunner()
+        installer = FaultInstaller("COM1", runner)
+        result = installer.verify()
+
+        # Should check symlink target with readlink
+        readlink_commands = [cmd for cmd in runner.commands if 'readlink' in cmd]
+        self.assertGreater(len(readlink_commands), 0, "Should verify symlink target with readlink")
+        self.assertTrue(result)
+
+    def test_verify_fails_on_wrong_symlink_target(self):
+        """Test that verify fails if symlink points to wrong target."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+
+        class MockRunner:
+            def run(self, cmd):
+                # Executables exist
+                if 'test -x' in cmd:
+                    return (0, "", "")
+                # Symlink exists
+                if 'test -L' in cmd:
+                    return (0, "", "")
+                # readlink returns wrong target
+                if 'readlink' in cmd:
+                    return (0, "/wrong/path", "")
+                return (0, "", "")
+
+            def run_target(self, cmd):
+                return self.run(cmd)
+
+            def run_host(self, args):
+                return (0, "", "")
+
+        runner = MockRunner()
+        installer = FaultInstaller("COM1", runner)
+        result = installer.verify()
+
+        self.assertFalse(result, "Should fail when symlink target is wrong")
+
+
+class TestMainWithMocking(unittest.TestCase):
+    """Test main entry point with proper mocking (Blocker 5)."""
+
+    def test_main_returns_zero_with_successful_install(self):
+        """Test that main returns 0 when installation succeeds."""
+        from serialwrap_reboot_test.fault_installer import main, FaultInstaller
+        from unittest.mock import patch
+
+        class MockInstaller:
+            def __init__(self, selector):
+                self.selector = selector
+
+            def install(self):
+                return True
+
+        with patch('serialwrap_reboot_test.fault_installer.FaultInstaller', MockInstaller):
+            with patch('sys.argv', ['serialwrap-fault-install', '--selector', 'COM1']):
+                result = main()
+                self.assertEqual(result, 0, "Should return 0 on success")
+
+    def test_main_returns_nonzero_with_failed_install(self):
+        """Test that main returns non-zero when installation fails."""
+        from serialwrap_reboot_test.fault_installer import main, FaultInstaller
+        from unittest.mock import patch
+
+        class MockInstaller:
+            def __init__(self, selector):
+                self.selector = selector
+
+            def install(self):
+                return False
+
+        with patch('serialwrap_reboot_test.fault_installer.FaultInstaller', MockInstaller):
+            with patch('sys.argv', ['serialwrap-fault-install', '--selector', 'COM1']):
+                result = main()
+                self.assertNotEqual(result, 0, "Should return non-zero on failure")
+
+
+class TestCommandRunnerSeparation(unittest.TestCase):
+    """Test host vs target command separation (Blocker 1)."""
+
+    def test_runner_has_run_target_method(self):
+        """Test that CommandRunner has run_target for target shell commands."""
+        from serialwrap_reboot_test.fault_installer import CommandRunner
+
+        runner = CommandRunner("COM1")
+        self.assertTrue(hasattr(runner, 'run_target'), "Should have run_target method")
+
+    def test_runner_has_run_host_method(self):
+        """Test that CommandRunner has run_host for host serialwrap commands."""
+        from serialwrap_reboot_test.fault_installer import CommandRunner
+
+        runner = CommandRunner("COM1")
+        self.assertTrue(hasattr(runner, 'run_host'), "Should have run_host method")
+
+    def test_file_transfer_uses_run_host(self):
+        """Test that file transfer uses run_host for host-side serialwrap."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+
+        class MockRunner:
+            def __init__(self):
+                self.host_calls = []
+                self.target_calls = []
+
+            def run_host(self, args):
+                self.host_calls.append(args)
+                # File send succeeds
+                if 'file' in ' '.join(args) and 'send' in ' '.join(args):
+                    return (0, "transferred", "")
+                return (0, "", "")
+
+            def run_target(self, cmd):
+                self.target_calls.append(cmd)
+                # Directory checks succeed
+                if 'test -d' in cmd:
+                    return (0, "", "")
+                return (0, "", "")
+
+            def run(self, cmd):
+                """Backward compatibility."""
+                return self.run_target(cmd)
+
+        runner = MockRunner()
+        installer = FaultInstaller("COM1", runner)
+        installer.install()
+
+        # File transfer should use run_host
+        file_host_calls = [args for args in runner.host_calls if 'file' in ' '.join(args)]
+        self.assertGreater(len(file_host_calls), 0, "File transfer should use run_host")
+
+    def test_directory_checks_use_run_target(self):
+        """Test that directory checks use run_target for target shell commands."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+
+        class MockRunner:
+            def __init__(self):
+                self.host_calls = []
+                self.target_calls = []
+
+            def run_host(self, args):
+                self.host_calls.append(args)
+                return (0, "transferred", "")
+
+            def run_target(self, cmd):
+                self.target_calls.append(cmd)
+                # Directory checks succeed
+                if 'test -d' in cmd:
+                    return (0, "", "")
+                return (0, "", "")
+
+            def run(self, cmd):
+                """Backward compatibility."""
+                return self.run_target(cmd)
+
+        runner = MockRunner()
+        installer = FaultInstaller("COM1", runner)
+        installer.check_target_directories()
+
+        # Directory checks should use run_target
+        dir_checks = [cmd for cmd in runner.target_calls if 'test -d' in cmd]
+        self.assertGreater(len(dir_checks), 0, "Directory checks should use run_target")
+
+    def test_fallback_uses_run_target(self):
+        """Test that fallback short writes use run_target for target commands."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+
+        class MockRunner:
+            def __init__(self):
+                self.host_calls = []
+                self.target_calls = []
+
+            def run_host(self, args):
+                self.host_calls.append(args)
+                # File send fails
+                return (1, "", "transfer failed")
+
+            def run_target(self, cmd):
+                self.target_calls.append(cmd)
+                # Directory checks and fallback succeed
+                return (0, "", "")
+
+            def run(self, cmd):
+                """Backward compatibility."""
+                return self.run_target(cmd)
+
+        runner = MockRunner()
+        installer = FaultInstaller("COM1", runner)
+        installer.install()
+
+        # Fallback commands should use run_target
+        fallback_cmds = [cmd for cmd in runner.target_calls if 'base64' in cmd or 'echo' in cmd]
+        self.assertGreater(len(fallback_cmds), 0, "Fallback should use run_target")
+
+
+class TestProcessCoredumpRandomSelection(unittest.TestCase):
+    """Test process coredump random selection (Blocker 2)."""
+
+    def test_process_coredump_collects_all_eligible_pids(self):
+        """Test that process coredump script collects all PIDs > 4000."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Should collect all PIDs, not use 'exit' in awk that selects first
+        self.assertNotIn("awk '$2 > 4000 {print $2; exit}'", script,
+                        "Should not exit early in awk - must collect all eligible PIDs")
+
+    def test_process_coredump_uses_random_selection(self):
+        """Test that process coredump uses random selection among eligible PIDs."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Should use RANDOM or similar for selection
+        # Look for patterns that indicate collecting all PIDs then randomly selecting
+        self.assertIn('4000', script)  # Has PID threshold
+        # Check that we're using randomness in the process selection case
+        # The script should have logic to randomly pick from collected PIDs
+        process_section = script.split('2)')[1].split(';;')[0] if '2)' in script else ""
+        self.assertIn('RANDOM', process_section, "Should use RANDOM for process selection")
+
+
+class TestSysrqExactCommand(unittest.TestCase):
+    """Test system crash sysrq exact command (Blocker 3)."""
+
+    def test_sysrq_command_exact_format(self):
+        """Test that sysrq command is exactly 'echo c > /proc/sysrq-trigger'."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Should have the exact command
+        self.assertIn('echo c > /proc/sysrq-trigger', script)
+
+    def test_sysrq_does_not_redirect_stderr_to_sysrq(self):
+        """Test that sysrq command does not have '2>&1' after redirection."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Should NOT redirect stderr to the sysrq-trigger file
+        self.assertNotIn('/proc/sysrq-trigger 2>&1', script,
+                        "Should not redirect stderr to sysrq-trigger")
+
+
+class TestCommandInjectionDefense(unittest.TestCase):
+    """Test command injection defenses in short_write_commands (Fix Pass 3)."""
+
+    def test_path_with_semicolon_does_not_inject_command(self):
+        """Test that path with command separator does not allow command injection."""
+        from serialwrap_reboot_test.fault_installer import short_write_commands
+
+        # Malicious path attempting command injection
+        malicious_path = "/tmp/test; rm -rf /"
+        commands = short_write_commands(malicious_path, "content", "0755")
+
+        # Verify path is properly quoted using shlex.quote
+        # All instances of the path should be within single quotes
+        self.assertIn("'/tmp/test; rm -rf /'", commands[0],
+                     "Path with special chars must be quoted")
+
+        # Verify that when executed, the path is treated as a single argument
+        # The key is that rm -f gets ONE argument that is the full path,
+        # not multiple arguments where ; would be interpreted
+        self.assertTrue(commands[0].startswith("rm -f '"),
+                       "Path should be quoted immediately after command")
+
+    def test_path_with_spaces_properly_quoted(self):
+        """Test that path with spaces is properly quoted."""
+        from serialwrap_reboot_test.fault_installer import short_write_commands
+
+        path_with_spaces = "/tmp/my file"
+        commands = short_write_commands(path_with_spaces, "content", "0755")
+
+        # Path should be quoted to handle spaces
+        self.assertIn("'/tmp/my file'", commands[0],
+                     "Path with spaces must be quoted")
+
+    def test_path_with_quotes_properly_escaped(self):
+        """Test that path with quotes is properly escaped."""
+        from serialwrap_reboot_test.fault_installer import short_write_commands
+
+        path_with_quotes = "/tmp/\"bad'path\""
+        commands = short_write_commands(path_with_quotes, "content", "0755")
+
+        # shlex.quote will properly escape the path
+        # Verify the first command has the path as a single quoted argument
+        self.assertTrue(commands[0].startswith("rm -f "),
+                       "Command should start with rm -f")
+        # The path should be safely quoted (shlex.quote handles mixed quotes)
+        self.assertIn("bad", commands[0],
+                     "Path content should be present")
+
+    def test_temp_b64_path_properly_quoted(self):
+        """Test that temporary base64 path is properly quoted."""
+        from serialwrap_reboot_test.fault_installer import short_write_commands
+
+        # Even if we control temp path, it should still be quoted
+        malicious_output = "/tmp/test; rm -rf /"
+        commands = short_write_commands(malicious_output, "content", "0755")
+
+        # Temp path (.b64 suffix) should also be quoted
+        # Look for the temp file in the echo command
+        echo_cmd = [c for c in commands if c.startswith("echo")][0]
+        self.assertIn("'/tmp/test; rm -rf /.b64'", echo_cmd,
+                     "Temp base64 path must be quoted")
+
+
+class TestPIDQuoting(unittest.TestCase):
+    """Test that TARGET_PID is properly quoted in fault injector script (Fix Pass 3)."""
+
+    def test_target_pid_quoted_in_kill_command(self):
+        """Test that TARGET_PID variable is quoted in kill command."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+
+        # PID should be quoted to prevent potential injection
+        self.assertIn('kill -SIGABRT "$TARGET_PID"', script,
+                     "TARGET_PID must be quoted in kill command")
+
+        # Should NOT have unquoted PID
+        self.assertNotIn('kill -SIGABRT $TARGET_PID ', script,
+                        "TARGET_PID should not be unquoted (space after to avoid false positive)")
+
+
+class TestModeValidation(unittest.TestCase):
+    """Test mode parameter validation (Fix Pass 3, optional)."""
+
+    def test_invalid_mode_rejected(self):
+        """Test that invalid mode parameter is rejected."""
+        from serialwrap_reboot_test.fault_installer import short_write_commands
+
+        # Invalid mode with non-octal characters
+        with self.assertRaises(ValueError) as ctx:
+            short_write_commands("/tmp/test", "content", "777x")
+
+        self.assertIn("mode", str(ctx.exception).lower(),
+                     "Error should mention mode parameter")
+
+    def test_mode_too_long_rejected(self):
+        """Test that mode with too many digits is rejected."""
+        from serialwrap_reboot_test.fault_installer import short_write_commands
+
+        # Mode with too many digits
+        with self.assertRaises(ValueError) as ctx:
+            short_write_commands("/tmp/test", "content", "07777")
+
+        self.assertIn("mode", str(ctx.exception).lower())
+
+    def test_valid_modes_accepted(self):
+        """Test that valid mode parameters are accepted."""
+        from serialwrap_reboot_test.fault_installer import short_write_commands
+
+        # Valid modes should work
+        valid_modes = ["0755", "755", "0644", "644", "0777"]
+        for mode in valid_modes:
+            try:
+                commands = short_write_commands("/tmp/test", "content", mode)
+                self.assertIsInstance(commands, list)
+            except ValueError:
+                self.fail(f"Valid mode {mode} should be accepted")
+
+
+class TestTransferFilePathQuoting(unittest.TestCase):
+    """Test that transfer_file() quotes remote_path in chmod command."""
+
+    def test_chmod_quotes_remote_path(self):
+        """transfer_file() should quote remote_path in chmod command."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+
+        # Mock runner that captures chmod command
+        class MockRunner:
+            def __init__(self):
+                self.chmod_cmd = None
+
+            def run_host(self, args):
+                # Simulate successful file send
+                return (0, "File transferred", "")
+
+            def run_target(self, cmd):
+                # Capture chmod command
+                if cmd.startswith("chmod"):
+                    self.chmod_cmd = cmd
+                return (0, "", "")
+
+            def run(self, cmd):
+                return self.run_target(cmd)
+
+        runner = MockRunner()
+        installer = FaultInstaller("COM1", runner)
+
+        # Try with malicious path
+        malicious_path = "/tmp/test; rm -rf /"
+        installer.transfer_file("/local/file", malicious_path, "0755")
+
+        # The chmod command should have quoted the path
+        # If unquoted, the command would be: chmod 0755 /tmp/test; rm -rf /
+        # If quoted, it should be: chmod 0755 '/tmp/test; rm -rf /'
+        self.assertIsNotNone(runner.chmod_cmd)
+        # Check that the path is quoted (shlex.quote adds single quotes)
+        self.assertIn("'/tmp/test; rm -rf /'", runner.chmod_cmd)
+
+
+class TestInstallPathQuoting(unittest.TestCase):
+    """Test that install() quotes paths in ln command."""
+
+    def test_ln_quotes_paths(self):
+        """install() should quote both INIT_PATH and SYMLINK_PATH in ln command."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+        import shlex
+
+        # Mock runner that captures ln command
+        class MockRunner:
+            def __init__(self):
+                self.ln_cmd = None
+
+            def run_host(self, args):
+                return (0, "File transferred", "")
+
+            def run_target(self, cmd):
+                # Capture ln command
+                if cmd.startswith("ln"):
+                    self.ln_cmd = cmd
+                return (0, "", "")
+
+            def run(self, cmd):
+                return self.run_target(cmd)
+
+        runner = MockRunner()
+        installer = FaultInstaller("COM1", runner)
+
+        # Call install() which should create symlink
+        installer.install()
+
+        # The ln command should have properly quoted paths
+        # shlex.quote returns paths unquoted if they don't need it
+        self.assertIsNotNone(runner.ln_cmd)
+        expected_init = shlex.quote(installer.INIT_PATH)
+        expected_symlink = shlex.quote(installer.SYMLINK_PATH)
+        self.assertIn(expected_init, runner.ln_cmd)
+        self.assertIn(expected_symlink, runner.ln_cmd)
+
+
+class TestVerifyPathQuoting(unittest.TestCase):
+    """Test that verify() quotes paths in test and readlink commands."""
+
+    def test_verify_quotes_paths(self):
+        """verify() should quote all paths in test and readlink commands."""
+        from serialwrap_reboot_test.fault_installer import FaultInstaller
+        import shlex
+
+        # Mock runner that captures all commands
+        class MockRunner:
+            def __init__(self):
+                self.commands = []
+
+            def run_host(self, args):
+                return (0, "", "")
+
+            def run_target(self, cmd):
+                self.commands.append(cmd)
+                # Return appropriate responses
+                if "test -x" in cmd:
+                    return (0, "", "")  # Success
+                elif "test -L" in cmd:
+                    return (0, "", "")  # Success
+                elif "readlink" in cmd:
+                    return (0, "/etc/init.d/serialwrap-fault-injector", "")
+                return (0, "", "")
+
+            def run(self, cmd):
+                return self.run_target(cmd)
+
+        runner = MockRunner()
+        installer = FaultInstaller("COM1", runner)
+
+        # Call verify()
+        installer.verify()
+
+        # Check that all test commands have properly quoted paths
+        # shlex.quote returns paths unquoted if they don't need it
+        expected_injector = shlex.quote(installer.INJECTOR_PATH)
+        expected_init = shlex.quote(installer.INIT_PATH)
+        expected_symlink = shlex.quote(installer.SYMLINK_PATH)
+
+        for cmd in runner.commands:
+            if "test -x" in cmd and "init.d" not in cmd:
+                self.assertIn(expected_injector, cmd)
+            elif "test -x" in cmd and "init.d" in cmd:
+                self.assertIn(expected_init, cmd)
+            elif "test -L" in cmd:
+                self.assertIn(expected_symlink, cmd)
+            elif "readlink" in cmd:
+                self.assertIn(expected_symlink, cmd)
+
+
+class TestRandomPortability(unittest.TestCase):
+    """Test that fault injector script does not use non-POSIX $RANDOM."""
+
+    def test_no_bash_random(self):
+        """Fault injector script should not contain $RANDOM (bash-specific)."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        self.assertNotIn("$RANDOM", script,
+                        "Script contains $RANDOM which is not POSIX sh")
+        self.assertNotIn("${RANDOM}", script,
+                        "Script contains ${RANDOM} which is not POSIX sh")
+
+    def test_has_posix_random(self):
+        """Fault injector script should use POSIX-compatible random method."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Should use /dev/urandom for randomness
+        self.assertIn("/dev/urandom", script,
+                     "Script should use /dev/urandom for POSIX randomness")
+
+    def test_maintains_probability_logic(self):
+        """Fault injector script should still have 10% gate and 4-way selection."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Should have modulo 10 for 10% probability
+        self.assertIn("% 10", script, "Script should have modulo 10 for 10% gate")
+        # Should have modulo 4 for 4-way fault selection
+        self.assertIn("% 4", script, "Script should have modulo 4 for fault type")
+
+
+class TestRandomFailureHandling(unittest.TestCase):
+    """Test get_random() has graceful failure handling when /dev/urandom or od fails."""
+
+    def test_random_function_redirects_stderr(self):
+        """get_random() should redirect stderr to /dev/null to suppress error messages."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Should have stderr redirect in the od command
+        self.assertIn("2>/dev/null", script,
+                      "get_random() should redirect stderr to avoid error messages on failure")
+
+    def test_random_function_validates_output(self):
+        """get_random() should validate output and provide fallback for empty or non-numeric values."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Should have a case statement or validation logic
+        self.assertIn("case", script,
+                      "get_random() should use case statement to validate output")
+        # Should check for empty or non-numeric values
+        self.assertIn("*[!0-9]*", script,
+                      "get_random() should check for non-numeric characters")
+
+    def test_random_function_provides_zero_fallback(self):
+        """get_random() should default to 0 when od/urandom fails."""
+        from serialwrap_reboot_test.fault_installer import build_fault_injector_script
+
+        script = build_fault_injector_script()
+        # Should echo 0 as fallback
+        lines = script.split('\n')
+        # Find the get_random function
+        in_get_random = False
+        has_zero_fallback = False
+        for line in lines:
+            if 'get_random()' in line:
+                in_get_random = True
+            if in_get_random and 'echo 0' in line:
+                has_zero_fallback = True
+                break
+            if in_get_random and line.strip() == '}':
+                break
+
+        self.assertTrue(has_zero_fallback,
+                        "get_random() should echo 0 as fallback when value is empty or non-numeric")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_package_structure.py
+++ b/tests/test_package_structure.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Test package structure and constants."""
+
+import os
+import sys
+import unittest
+
+
+class TestPackageStructure(unittest.TestCase):
+    """Test that package structure exists with correct constants."""
+
+    def test_package_import(self):
+        """Test that serialwrap_reboot_test package can be imported."""
+        import serialwrap_reboot_test
+        self.assertIsNotNone(serialwrap_reboot_test)
+
+    def test_serialwrap_command_default(self):
+        """Test that SERIALWRAP_CMD defaults correctly when no env override."""
+        # Clear any existing override
+        old_value = os.environ.pop('SERIALWRAP_CMD', None)
+        try:
+            # Force reload to pick up cleared env
+            import serialwrap_reboot_test.constants
+            import importlib
+            importlib.reload(serialwrap_reboot_test.constants)
+
+            self.assertEqual(
+                serialwrap_reboot_test.constants.SERIALWRAP_CMD,
+                "/home/paul_chen/.paul_tools/serialwrap"
+            )
+        finally:
+            # Restore old value if it existed
+            if old_value is not None:
+                os.environ['SERIALWRAP_CMD'] = old_value
+
+    def test_serialwrap_command_env_override(self):
+        """Test that SERIALWRAP_CMD honors environment variable override."""
+        test_path = "/custom/path/to/serialwrap"
+        old_value = os.environ.get('SERIALWRAP_CMD')
+        try:
+            os.environ['SERIALWRAP_CMD'] = test_path
+
+            # Force reload to pick up new env
+            import serialwrap_reboot_test.constants
+            import importlib
+            importlib.reload(serialwrap_reboot_test.constants)
+
+            self.assertEqual(
+                serialwrap_reboot_test.constants.SERIALWRAP_CMD,
+                test_path
+            )
+        finally:
+            # Restore old value or clear
+            if old_value is not None:
+                os.environ['SERIALWRAP_CMD'] = old_value
+            else:
+                os.environ.pop('SERIALWRAP_CMD', None)
+
+
+class TestEntrypointFiles(unittest.TestCase):
+    """Test that entrypoint files exist and are executable."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        self.bin_dir = os.path.join(self.project_root, "bin")
+
+    def test_bin_directory_exists(self):
+        """Test that bin/ directory exists."""
+        self.assertTrue(
+            os.path.isdir(self.bin_dir),
+            f"bin directory does not exist at {self.bin_dir}"
+        )
+
+    def test_reboot_controller_exists(self):
+        """Test that serialwrap-reboot-controller entrypoint exists."""
+        entrypoint = os.path.join(self.bin_dir, "serialwrap-reboot-controller")
+        self.assertTrue(
+            os.path.isfile(entrypoint),
+            f"serialwrap-reboot-controller does not exist at {entrypoint}"
+        )
+
+    def test_event_handler_exists(self):
+        """Test that serialwrap-event-handler entrypoint exists."""
+        entrypoint = os.path.join(self.bin_dir, "serialwrap-event-handler")
+        self.assertTrue(
+            os.path.isfile(entrypoint),
+            f"serialwrap-event-handler does not exist at {entrypoint}"
+        )
+
+    def test_fault_install_exists(self):
+        """Test that serialwrap-fault-install entrypoint exists."""
+        entrypoint = os.path.join(self.bin_dir, "serialwrap-fault-install")
+        self.assertTrue(
+            os.path.isfile(entrypoint),
+            f"serialwrap-fault-install does not exist at {entrypoint}"
+        )
+
+    def test_reboot_controller_executable(self):
+        """Test that serialwrap-reboot-controller is executable."""
+        entrypoint = os.path.join(self.bin_dir, "serialwrap-reboot-controller")
+        if os.path.isfile(entrypoint):
+            self.assertTrue(
+                os.access(entrypoint, os.X_OK),
+                f"serialwrap-reboot-controller is not executable"
+            )
+
+    def test_event_handler_executable(self):
+        """Test that serialwrap-event-handler is executable."""
+        entrypoint = os.path.join(self.bin_dir, "serialwrap-event-handler")
+        if os.path.isfile(entrypoint):
+            self.assertTrue(
+                os.access(entrypoint, os.X_OK),
+                f"serialwrap-event-handler is not executable"
+            )
+
+    def test_fault_install_executable(self):
+        """Test that serialwrap-fault-install is executable."""
+        entrypoint = os.path.join(self.bin_dir, "serialwrap-fault-install")
+        if os.path.isfile(entrypoint):
+            self.assertTrue(
+                os.access(entrypoint, os.X_OK),
+                f"serialwrap-fault-install is not executable"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_quality_fixes.py
+++ b/tests/test_quality_fixes.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Quality fix tests for Task 2 review issues."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock, mock_open
+import sys
+
+
+class FakeCommandRunner:
+    """Fake command runner for testing."""
+
+    def __init__(self):
+        self.commands = []
+        self.responses = {}
+
+    def run(self, cmd, **kwargs):
+        """Record command and return configured response."""
+        self.commands.append(cmd)
+        cmd_str = ' '.join(cmd) if isinstance(cmd, list) else cmd
+
+        for pattern, response in self.responses.items():
+            if pattern in cmd_str:
+                return response
+
+        # Defaults
+        if 'session list' in cmd_str:
+            return (0, json.dumps({"sessions": [{"selector": "COM0", "state": "READY"}]}), "")
+        elif 'session self-test' in cmd_str:
+            return (0, json.dumps({"classification": "OK", "probe_ok": True}), "")
+        elif 'cmd submit' in cmd_str:
+            return (0, "", "")
+
+        return (0, "", "")
+
+    def set_response(self, pattern, returncode, stdout, stderr=""):
+        """Configure response for commands matching pattern."""
+        self.responses[pattern] = (returncode, stdout, stderr)
+
+
+class TestRunLoopSleepBehavior(unittest.TestCase):
+    """Test run_loop sleeps after successful normal reboot."""
+
+    def test_run_loop_sleeps_after_successful_normal_reboot(self):
+        """Test run_loop sleeps after successful normal reboot, not just on error."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = Path(tmpdir) / "mini_COM0_test.log"
+            log_file.write_text("boot log\n")
+
+            runner = FakeCommandRunner()
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+            controller.active_log_path = log_file
+
+            # Mock sleep to verify it's called
+            sleep_called = []
+            controller.sleep_fn = lambda s: sleep_called.append(s)
+
+            # Run one loop (should submit normal reboot)
+            controller.run_loop()
+
+            # Should have submitted reboot successfully
+            self.assertEqual(controller.reboot_count, 1)
+
+            # Should have slept after successful reboot
+            self.assertTrue(len(sleep_called) > 0, "Should sleep after successful normal reboot")
+
+
+class TestKeyboardInterruptCleanup(unittest.TestCase):
+    """Test KeyboardInterrupt triggers cleanup."""
+
+    def test_main_with_runner_cleanup_on_keyboard_interrupt(self):
+        """Test main_with_runner runs cleanup when KeyboardInterrupt raised."""
+        from serialwrap_reboot_test.controller import main_with_runner
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+
+            # Create log file
+            marker_created = []
+            original_run = runner.run
+            def intercepting_run(cmd, **kwargs):
+                result = original_run(cmd, **kwargs)
+                cmd_str = ' '.join(cmd)
+                if 'cmd submit' in cmd_str and '__SW_REBOOT_TEST_' in cmd_str:
+                    for part in cmd:
+                        if '__SW_REBOOT_TEST_' in part:
+                            marker = part.replace('echo ', '').strip()
+                            if marker not in marker_created:
+                                marker_created.append(marker)
+                                log_file = Path(tmpdir) / "mini_COM0_test.log"
+                                log_file.write_text(f"boot log\n{marker}\n")
+                            break
+                return result
+            runner.run = intercepting_run
+
+            # Patch run_loop to raise KeyboardInterrupt
+            from serialwrap_reboot_test import controller as controller_module
+            original_reboot_controller = controller_module.RebootController
+
+            cleanup_called = []
+
+            class InterruptingController(original_reboot_controller):
+                def run_loop(self):
+                    # Raise KeyboardInterrupt after first call
+                    raise KeyboardInterrupt("Test interrupt")
+
+                def cleanup(self):
+                    cleanup_called.append(True)
+                    super().cleanup()
+
+            with patch.object(controller_module, 'RebootController', InterruptingController):
+                exit_code = main_with_runner(
+                    ["--selector", "COM0"],
+                    runner=runner,
+                    log_dir=tmpdir
+                )
+
+            # Should have called cleanup
+            self.assertTrue(len(cleanup_called) > 0, "Cleanup should be called on KeyboardInterrupt")
+
+            # Exit code should be 0 (graceful interrupt)
+            self.assertEqual(exit_code, 0)
+
+    def test_main_with_runner_cleanup_on_runtime_error(self):
+        """Test main_with_runner runs cleanup when run_loop raises unexpectedly."""
+        from serialwrap_reboot_test.controller import main_with_runner
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+
+            marker_created = []
+            original_run = runner.run
+            def intercepting_run(cmd, **kwargs):
+                result = original_run(cmd, **kwargs)
+                cmd_str = ' '.join(cmd)
+                if 'cmd submit' in cmd_str and '__SW_REBOOT_TEST_' in cmd_str:
+                    for part in cmd:
+                        if '__SW_REBOOT_TEST_' in part:
+                            marker = part.replace('echo ', '').strip()
+                            if marker not in marker_created:
+                                marker_created.append(marker)
+                                log_file = Path(tmpdir) / "mini_COM0_test.log"
+                                log_file.write_text(f"boot log\n{marker}\n")
+                            break
+                return result
+            runner.run = intercepting_run
+
+            from serialwrap_reboot_test import controller as controller_module
+            original_reboot_controller = controller_module.RebootController
+
+            cleanup_called = []
+
+            class FailingController(original_reboot_controller):
+                def run_loop(self):
+                    raise RuntimeError("unexpected loop failure")
+
+                def cleanup(self):
+                    cleanup_called.append(True)
+                    super().cleanup()
+
+            with patch.object(controller_module, 'RebootController', FailingController):
+                with self.assertRaises(RuntimeError):
+                    main_with_runner(
+                        ["--selector", "COM0"],
+                        runner=runner,
+                        log_dir=tmpdir
+                    )
+
+            self.assertTrue(cleanup_called, "Cleanup should run before propagating runtime errors")
+
+
+class TestMemoryEfficientLogReading(unittest.TestCase):
+    """Test log reading methods don't load entire files into memory."""
+
+    def test_find_active_minicom_log_does_not_use_read_text(self):
+        """Test find_active_minicom_log doesn't call Path.read_text() for marker search."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+
+            # Create a log file
+            log_file = Path(tmpdir) / "mini_COM0_test.log"
+            log_file.write_text("line1\nMARKER_TEST\nline3\n")
+
+            # Patch Path.read_text to detect if it's called
+            read_text_called = []
+            original_read_text = Path.read_text
+
+            def tracking_read_text(self, *args, **kwargs):
+                read_text_called.append(str(self))
+                return original_read_text(self, *args, **kwargs)
+
+            with patch.object(Path, 'read_text', tracking_read_text):
+                result = controller.find_active_minicom_log("MARKER_TEST", max_age_seconds=600)
+
+            # Should not have called read_text (streaming instead)
+            self.assertEqual(len(read_text_called), 0,
+                f"Should not call read_text for marker search, but called on: {read_text_called}")
+
+    def test_check_log_tail_for_prompt_does_not_use_read_text(self):
+        """Test check_log_tail_for_prompt doesn't call Path.read_text() for tail check."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            controller = RebootController("COM1", runner=runner, log_dir=tmpdir)
+
+            # Create a log file
+            log_file = Path(tmpdir) / "test.log"
+            log_file.write_text("\n".join([f"line{i}" for i in range(100)]) + "\nroot@prplOS:/# \n")
+
+            # Patch Path.read_text to detect if it's called
+            read_text_called = []
+            original_read_text = Path.read_text
+
+            def tracking_read_text(self, *args, **kwargs):
+                read_text_called.append(str(self))
+                return original_read_text(self, *args, **kwargs)
+
+            with patch.object(Path, 'read_text', tracking_read_text):
+                result = controller.check_log_tail_for_prompt(log_file, "root@prplOS:/#", tail_lines=50)
+
+            # Should not have called read_text (use bounded tail instead)
+            self.assertEqual(len(read_text_called), 0,
+                f"Should not call read_text for tail check, but called on: {read_text_called}")
+
+
+class TestSpecificExceptionHandling(unittest.TestCase):
+    """Test helper methods have specific exception handling."""
+
+    def test_find_active_minicom_log_handles_file_errors(self):
+        """Test find_active_minicom_log handles file errors specifically."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+
+            # Create a log file that will cause permission error
+            log_file = Path(tmpdir) / "mini_COM0_test.log"
+            log_file.write_text("test")
+            log_file.chmod(0o000)  # No permissions
+
+            stderr_output = []
+            original_stderr = sys.stderr.write
+            def mock_stderr(msg):
+                stderr_output.append(msg)
+                return original_stderr(msg)
+
+            try:
+                with patch('sys.stderr.write', mock_stderr):
+                    result = controller.find_active_minicom_log("MARKER", max_age_seconds=600)
+
+                # Should return None (not found) and log warning
+                self.assertIsNone(result)
+
+                # Should have warning about file error
+                stderr_text = ''.join(stderr_output)
+                self.assertTrue('WARNING' in stderr_text or 'error' in stderr_text.lower())
+            finally:
+                # Restore permissions for cleanup
+                log_file.chmod(0o644)
+
+    def test_check_other_selectors_enabled_handles_json_errors(self):
+        """Test check_other_selectors_enabled handles JSON parse errors."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        runner.set_response('event status', 0, "invalid json{", "")
+
+        controller = RebootController("COM0", runner=runner)
+
+        stderr_output = []
+        original_stderr = sys.stderr.write
+        def mock_stderr(msg):
+            stderr_output.append(msg)
+            return original_stderr(msg)
+
+        with patch('sys.stderr.write', mock_stderr):
+            result = controller.check_other_selectors_enabled()
+
+        # Unknown status must not be treated as safe to remove shared rules.
+        self.assertIsNone(result)
+
+        # Should have warning about parse error
+        stderr_text = ''.join(stderr_output)
+        self.assertTrue('WARNING' in stderr_text or 'parse' in stderr_text.lower() or 'json' in stderr_text.lower())
+
+    def test_check_other_selectors_enabled_handles_non_object_status(self):
+        """Treat valid JSON with the wrong top-level type as unknown."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        runner.set_response('event status', 0, "[]", "")
+
+        controller = RebootController("COM0", runner=runner)
+        self.assertIsNone(controller.check_other_selectors_enabled())
+
+    def test_check_other_selectors_enabled_handles_non_object_selectors(self):
+        """Treat non-object selectors data as unknown."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        runner.set_response('event status', 0, json.dumps({"selectors": []}), "")
+
+        controller = RebootController("COM0", runner=runner)
+        self.assertIsNone(controller.check_other_selectors_enabled())
+
+    def test_check_other_selectors_enabled_handles_non_object_selector_info(self):
+        """Treat non-object selector info as unknown."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        runner.set_response('event status', 0, json.dumps({"selectors": {"COM1": True}}), "")
+
+        controller = RebootController("COM0", runner=runner)
+        self.assertIsNone(controller.check_other_selectors_enabled())
+
+    def test_check_ready_state_handles_json_errors(self):
+        """Test check_ready_state handles JSON parse errors."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        runner.set_response('session list', 0, "not json", "")
+
+        controller = RebootController("COM1", runner=runner)
+
+        stderr_output = []
+        original_stderr = sys.stderr.write
+        def mock_stderr(msg):
+            stderr_output.append(msg)
+            return original_stderr(msg)
+
+        with patch('sys.stderr.write', mock_stderr):
+            result = controller.check_ready_state()
+
+        # Should return False (safe default) and log warning
+        self.assertFalse(result)
+
+        # Should have warning about parse error
+        stderr_text = ''.join(stderr_output)
+        self.assertTrue('WARNING' in stderr_text or 'parse' in stderr_text.lower())
+
+    def test_check_self_test_handles_json_errors(self):
+        """Test check_self_test handles JSON parse errors."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        runner.set_response('session self-test', 0, "{broken", "")
+
+        controller = RebootController("COM0", runner=runner)
+
+        stderr_output = []
+        original_stderr = sys.stderr.write
+        def mock_stderr(msg):
+            stderr_output.append(msg)
+            return original_stderr(msg)
+
+        with patch('sys.stderr.write', mock_stderr):
+            result = controller.check_self_test()
+
+        # Should return False (safe default) and log warning
+        self.assertFalse(result)
+
+        # Should have warning about parse error
+        stderr_text = ''.join(stderr_output)
+        self.assertTrue('WARNING' in stderr_text or 'parse' in stderr_text.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_robustness_warnings.py
+++ b/tests/test_robustness_warnings.py
@@ -1,0 +1,270 @@
+"""Tests for robustness issues in event handler."""
+
+import json
+import sys
+import tempfile
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch, mock_open, MagicMock
+
+import pytest
+
+from serialwrap_reboot_test.event_handler import (
+    load_scan_cursors,
+    load_report_data,
+    write_text_atomic,
+)
+
+
+class TestCursorLoadFailureWarning:
+    """Test that cursor load failures emit warnings to stderr."""
+
+    def test_load_cursors_warns_on_corrupt_json(self):
+        """Corrupt JSON cursor file should emit warning and return empty dict."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cursor_file = Path(tmpdir) / "cursors.json"
+            cursor_file.write_text("{ invalid json")
+
+            old_stderr = sys.stderr
+            sys.stderr = StringIO()
+            try:
+                result = load_scan_cursors(cursor_file)
+                stderr_output = sys.stderr.getvalue()
+            finally:
+                sys.stderr = old_stderr
+
+            # Should return empty dict (fail-open)
+            assert result == {}
+
+            # Should emit warning to stderr
+            assert len(stderr_output) > 0
+            assert "warning" in stderr_output.lower() or "error" in stderr_output.lower()
+            assert "cursor" in stderr_output.lower()
+
+    def test_load_cursors_warns_on_io_error(self):
+        """I/O error reading cursor file should emit warning and return empty dict."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cursor_file = Path(tmpdir) / "cursors.json"
+            # Create the file so exists() returns True
+            cursor_file.write_text("{}")
+
+            old_stderr = sys.stderr
+            sys.stderr = StringIO()
+            try:
+                # Mock Path.open to raise IOError
+                with patch.object(Path, 'open', side_effect=IOError("Read error")):
+                    result = load_scan_cursors(cursor_file)
+                stderr_output = sys.stderr.getvalue()
+            finally:
+                sys.stderr = old_stderr
+
+            # Should return empty dict (fail-open)
+            assert result == {}
+
+            # Should emit warning to stderr
+            assert len(stderr_output) > 0
+            assert "warning" in stderr_output.lower() or "error" in stderr_output.lower()
+
+    def test_load_cursors_succeeds_normally_without_warning(self):
+        """Valid cursor file should load without warnings."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cursor_file = Path(tmpdir) / "cursors.json"
+            cursor_file.write_text('{"brcm-therm": 10}')
+
+            old_stderr = sys.stderr
+            sys.stderr = StringIO()
+            try:
+                result = load_scan_cursors(cursor_file)
+                stderr_output = sys.stderr.getvalue()
+            finally:
+                sys.stderr = old_stderr
+
+            assert result == {"brcm-therm": 10}
+            # No warnings for valid file
+            assert stderr_output == ""
+
+
+class TestReportParseFailureWarning:
+    """Test that report parse failures emit warnings to stderr."""
+
+    def test_load_report_warns_on_malformed_summary_row(self):
+        """Malformed summary row should emit warning and skip that row."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = Path(tmpdir) / "report.md"
+            report_path.write_text("""# Event Triggered Report
+
+Log: mini_COM0_260506-152744.log
+
+## Summary
+
+| Event | Count | Probability vs SMC bootloader |
+| --- | ---: | ---: |
+| brcm-therm | not-a-number | 50.00% |
+| pstate | 2 | 100.00% |
+
+## Events
+
+| Log name | Log line number | Event trigger time | Event |
+| --- | ---: | --- | --- |
+| mini_COM0_260506-152744.log | 1 | 2026-05-06T16:10:23+08:00 | pstate |
+""")
+
+            old_stderr = sys.stderr
+            sys.stderr = StringIO()
+            try:
+                result = load_report_data(report_path)
+                stderr_output = sys.stderr.getvalue()
+            finally:
+                sys.stderr = old_stderr
+
+            # Should load valid data and skip malformed
+            assert result["summary"]["pstate"] == 2
+            assert "brcm-therm" not in result["summary"]  # Malformed row skipped
+
+            # Should emit warning
+            assert len(stderr_output) > 0
+            assert "warning" in stderr_output.lower()
+            assert "summary" in stderr_output.lower() or "malformed" in stderr_output.lower()
+
+    def test_load_report_warns_on_malformed_event_row(self):
+        """Malformed event row should emit warning and skip that row."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = Path(tmpdir) / "report.md"
+            report_path.write_text("""# Event Triggered Report
+
+Log: mini_COM0_260506-152744.log
+
+## Summary
+
+| Event | Count | Probability vs SMC bootloader |
+| --- | ---: | ---: |
+| pstate | 2 | 100.00% |
+
+## Events
+
+| Log name | Log line number | Event trigger time | Event |
+| --- | ---: | --- | --- |
+| mini_COM0_260506-152744.log | not-a-line-number | 2026-05-06T16:10:23+08:00 | pstate |
+| mini_COM0_260506-152744.log | 5 | 2026-05-06T16:10:24+08:00 | brcm-therm |
+""")
+
+            old_stderr = sys.stderr
+            sys.stderr = StringIO()
+            try:
+                result = load_report_data(report_path)
+                stderr_output = sys.stderr.getvalue()
+            finally:
+                sys.stderr = old_stderr
+
+            # Should load valid event and skip malformed
+            assert len(result["events"]) == 1
+            assert result["events"][0]["event"] == "brcm-therm"
+            assert result["events"][0]["line_number"] == 5
+
+            # Should emit warning
+            assert len(stderr_output) > 0
+            assert "warning" in stderr_output.lower()
+            assert "event" in stderr_output.lower() or "malformed" in stderr_output.lower()
+
+    def test_load_report_succeeds_normally_without_warnings(self):
+        """Valid report should load without warnings."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = Path(tmpdir) / "report.md"
+            report_path.write_text("""# Event Triggered Report
+
+Log: mini_COM0_260506-152744.log
+
+## Summary
+
+| Event | Count | Probability vs SMC bootloader |
+| --- | ---: | ---: |
+| pstate | 1 | 100.00% |
+
+## Events
+
+| Log name | Log line number | Event trigger time | Event |
+| --- | ---: | --- | --- |
+| mini_COM0_260506-152744.log | 5 | 2026-05-06T16:10:24+08:00 | pstate |
+""")
+
+            old_stderr = sys.stderr
+            sys.stderr = StringIO()
+            try:
+                result = load_report_data(report_path)
+                stderr_output = sys.stderr.getvalue()
+            finally:
+                sys.stderr = old_stderr
+
+            assert result["summary"]["pstate"] == 1
+            assert len(result["events"]) == 1
+            # No warnings for valid file
+            assert stderr_output == ""
+
+
+class TestAtomicWriteCleanup:
+    """Test that atomic write cleans up temp files on failure."""
+
+    def test_write_text_atomic_cleans_temp_on_write_failure(self):
+        """Temp file should be cleaned up when write fails."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "report.md"
+
+            # Track temp files created
+            created_temp_files = []
+            original_mkstemp = tempfile.mkstemp
+
+            def track_mkstemp(*args, **kwargs):
+                fd, path = original_mkstemp(*args, **kwargs)
+                created_temp_files.append(path)
+                return fd, path
+
+            with patch('tempfile.mkstemp', side_effect=track_mkstemp):
+                # Mock fdopen to raise IOError during write
+                with patch('os.fdopen', side_effect=IOError("Disk full")):
+                    with pytest.raises(IOError, match="Failed to write file atomically"):
+                        write_text_atomic(file_path, "content")
+
+            # Verify temp file was cleaned up
+            assert len(created_temp_files) == 1
+            temp_path = created_temp_files[0]
+            assert not Path(temp_path).exists(), "Temp file should be cleaned up"
+
+    def test_write_text_atomic_cleans_temp_on_rename_failure(self):
+        """Temp file should be cleaned up when rename fails."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "report.md"
+
+            # Track temp files
+            created_temp_files = []
+            original_mkstemp = tempfile.mkstemp
+
+            def track_mkstemp(*args, **kwargs):
+                fd, path = original_mkstemp(*args, **kwargs)
+                created_temp_files.append(path)
+                return fd, path
+
+            with patch('tempfile.mkstemp', side_effect=track_mkstemp):
+                # Mock os.replace to fail
+                with patch('os.replace', side_effect=OSError("Permission denied")):
+                    with pytest.raises(IOError, match="Failed to write file atomically"):
+                        write_text_atomic(file_path, "content")
+
+            # Verify temp file was cleaned up
+            assert len(created_temp_files) == 1
+            temp_path = created_temp_files[0]
+            assert not Path(temp_path).exists(), "Temp file should be cleaned up"
+
+    def test_write_text_atomic_succeeds_without_temp_remnants(self):
+        """Successful write should not leave temp files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "report.md"
+
+            write_text_atomic(file_path, "content")
+
+            # Check no temp files remain
+            temp_files = list(Path(tmpdir).glob("*.tmp*")) + list(Path(tmpdir).glob(".tmp*"))
+            assert len(temp_files) == 0, f"Found temp files: {temp_files}"
+
+            # Target file should exist
+            assert file_path.exists()
+            assert file_path.read_text() == "content"

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Security and robustness fix tests for Task 2 final review."""
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+import sys
+
+
+class FakeCommandRunner:
+    """Fake command runner for testing."""
+
+    def __init__(self):
+        self.commands = []
+
+    def run(self, cmd, **kwargs):
+        """Record command and return success."""
+        self.commands.append(cmd)
+
+        cmd_str = ' '.join(cmd) if isinstance(cmd, list) else cmd
+
+        if 'event --help' in cmd_str:
+            return (0, "Usage: serialwrap event", "")
+        elif 'daemon status' in cmd_str:
+            return (0, "Daemon running", "")
+        elif 'event status' in cmd_str:
+            return (0, json.dumps({"selectors": {}}), "")
+
+        return (0, "", "")
+
+
+class TestCleanupErrorHandling(unittest.TestCase):
+    """Test cleanup handles OSError from state directory removal."""
+
+    def test_cleanup_logs_warning_on_state_dir_removal_failure(self):
+        """Test cleanup logs warning and doesn't raise when state dir removal fails."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+
+            # Create a state directory that will fail to remove
+            state_dir = Path(tmpdir) / "fake_state"
+            state_dir.mkdir()
+            controller.state_dir = state_dir
+
+            # Make it non-removable by creating a file with no permissions
+            bad_file = state_dir / "locked"
+            bad_file.write_text("test")
+            bad_file.chmod(0o000)
+            state_dir.chmod(0o000)
+
+            # Capture stderr
+            stderr_output = []
+            original_stderr = sys.stderr.write
+            def mock_stderr(msg):
+                stderr_output.append(msg)
+                return original_stderr(msg)
+
+            try:
+                with patch('sys.stderr.write', mock_stderr):
+                    # Should not raise
+                    controller.cleanup()
+
+                # Should have logged warning
+                stderr_text = ''.join(stderr_output)
+                self.assertTrue('WARNING' in stderr_text or 'state' in stderr_text.lower())
+            finally:
+                # Restore permissions for cleanup
+                try:
+                    state_dir.chmod(0o755)
+                    bad_file.chmod(0o644)
+                    bad_file.unlink()
+                    state_dir.rmdir()
+                except:
+                    pass
+
+
+class TestSelectorValidation(unittest.TestCase):
+    """Test selector validation against path traversal."""
+
+    def test_parse_args_rejects_path_traversal_parent(self):
+        """Test parse_args rejects selector with parent directory traversal."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        with self.assertRaises(SystemExit):
+            parse_args(["--selector", "../COM0"])
+
+    def test_parse_args_rejects_path_traversal_slash(self):
+        """Test parse_args rejects selector with forward slash."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        with self.assertRaises(SystemExit):
+            parse_args(["--selector", "COM0/evil"])
+
+    def test_parse_args_rejects_deep_path_traversal(self):
+        """Test parse_args rejects deep path traversal."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        with self.assertRaises(SystemExit):
+            parse_args(["--selector", "../../../root"])
+
+    def test_parse_args_rejects_empty_selector(self):
+        """Test parse_args rejects empty selector."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        with self.assertRaises(SystemExit):
+            parse_args(["--selector", ""])
+
+    def test_parse_args_rejects_non_com_selector(self):
+        """Test parse_args rejects non-COM selector."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        with self.assertRaises(SystemExit):
+            parse_args(["--selector", "EVIL123"])
+
+    def test_parse_args_accepts_valid_com0(self):
+        """Test parse_args accepts valid COM0."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        args = parse_args(["--selector", "COM0"])
+        self.assertEqual(args.selector, "COM0")
+
+    def test_parse_args_accepts_valid_com1(self):
+        """Test parse_args accepts valid COM1."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        args = parse_args(["--selector", "COM1"])
+        self.assertEqual(args.selector, "COM1")
+
+    def test_parse_args_accepts_valid_com2(self):
+        """Test parse_args accepts future COM2."""
+        from serialwrap_reboot_test.controller import parse_args
+
+        args = parse_args(["--selector", "COM2"])
+        self.assertEqual(args.selector, "COM2")
+
+    def test_controller_init_rejects_invalid_selector(self):
+        """Test RebootController.__init__ rejects invalid selector."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+
+        with self.assertRaises(ValueError):
+            RebootController("../COM0", runner=runner)
+
+    def test_controller_init_accepts_valid_selector(self):
+        """Test RebootController.__init__ accepts valid selector."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        runner = FakeCommandRunner()
+        controller = RebootController("COM0", runner=runner)
+        self.assertEqual(controller.selector, "COM0")
+
+
+class TestStateDirPathSafety(unittest.TestCase):
+    """Test state directory path safety checks."""
+
+    def test_create_run_state_directory_validates_path_under_tmp(self):
+        """Test create_run_state_directory validates resolved path is under /tmp."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+
+            # Even with valid selector, if symlink shenanigans happen, should detect
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+
+            # This should work normally
+            state_dir = controller.create_run_state_directory()
+            self.assertTrue(str(state_dir).startswith("/tmp/"))
+
+            # Clean up
+            import shutil
+            shutil.rmtree(state_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_startup_cleanup.py
+++ b/tests/test_startup_cleanup.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Test startup error handling and cleanup."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class FakeCommandRunner:
+    """Fake command runner for testing."""
+
+    def __init__(self):
+        self.commands = []
+        self.responses = {}
+
+    def run(self, cmd, **kwargs):
+        """Record command and return configured response."""
+        self.commands.append(cmd)
+        cmd_str = ' '.join(cmd) if isinstance(cmd, list) else cmd
+
+        # Check custom responses first
+        for pattern, response in self.responses.items():
+            if pattern in cmd_str:
+                return response
+
+        # Default success
+        if 'event --help' in cmd_str:
+            return (0, "Usage: serialwrap event", "")
+        elif 'daemon status' in cmd_str:
+            return (0, "Daemon running", "")
+        elif 'cmd submit' in cmd_str:
+            return (0, "", "")
+        elif 'event add' in cmd_str:
+            return (0, "", "")
+        elif 'event enable' in cmd_str:
+            return (0, "", "")
+        elif 'event disable' in cmd_str:
+            return (0, "", "")
+        elif 'event reset' in cmd_str:
+            return (0, "", "")
+        elif 'event status' in cmd_str:
+            return (0, json.dumps({"selectors": {"COM0": {"enabled": False}}}), "")
+        elif 'event rm' in cmd_str:
+            return (0, "", "")
+
+        return (0, "", "")
+
+    def set_response(self, pattern, returncode, stdout, stderr=""):
+        """Configure response for commands matching pattern."""
+        self.responses[pattern] = (returncode, stdout, stderr)
+
+
+class TestStartupCleanupOnFailure(unittest.TestCase):
+    """Test startup cleans up properly on failure."""
+
+    def test_startup_cleans_state_on_enable_failure(self):
+        """Test startup removes state dir if enable fails after creation."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+
+            # Make enable fail
+            runner.set_response('event enable', 1, "", "Failed to enable")
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+
+            # Intercept marker to create log
+            original_send_marker = controller.send_marker_command
+            def tracked_send_marker():
+                marker = original_send_marker()
+                log_file = Path(tmpdir) / "mini_COM0_test.log"
+                log_file.write_text(f"boot log\n{marker}\n")
+                return marker
+            controller.send_marker_command = tracked_send_marker
+
+            # Run startup
+            result = controller.startup()
+
+            # Should return False
+            self.assertFalse(result)
+
+            # State directory should be cleaned up (not left behind)
+            if controller.state_dir:
+                self.assertFalse(controller.state_dir.exists(),
+                    "State directory should be removed on startup failure")
+
+    def test_startup_cleans_rules_on_enable_failure(self):
+        """Test startup cleans rules if enable fails after registration."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+
+            # Make enable fail
+            runner.set_response('event enable', 1, "", "Failed to enable")
+
+            controller = RebootController("COM1", runner=runner, log_dir=tmpdir)
+
+            # Intercept marker to create log
+            original_send_marker = controller.send_marker_command
+            def tracked_send_marker():
+                marker = original_send_marker()
+                log_file = Path(tmpdir) / "mini_COM1_test.log"
+                log_file.write_text(f"boot log\n{marker}\n")
+                return marker
+            controller.send_marker_command = tracked_send_marker
+
+            # Run startup
+            result = controller.startup()
+
+            # Should return False
+            self.assertFalse(result)
+
+            # Should have attempted to remove rules (cleanup)
+            rm_commands = [cmd for cmd in runner.commands
+                          if 'event' in ' '.join(cmd) and 'rm' in ' '.join(cmd)]
+            self.assertTrue(len(rm_commands) > 0,
+                "Should attempt to clean up rules on startup failure")
+
+    def test_main_returns_nonzero_on_enable_failure(self):
+        """Test main returns non-zero when enable fails during startup."""
+        from serialwrap_reboot_test.controller import main_with_runner
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+
+            # Make enable fail
+            runner.set_response('event enable', 1, "", "Failed to enable")
+
+            # Intercept marker command
+            marker_created = []
+            original_run = runner.run
+            def intercepting_run(cmd, **kwargs):
+                result = original_run(cmd, **kwargs)
+                cmd_str = ' '.join(cmd)
+                if 'cmd submit' in cmd_str and '__SW_REBOOT_TEST_' in cmd_str:
+                    for part in cmd:
+                        if '__SW_REBOOT_TEST_' in part:
+                            marker = part.replace('echo ', '').strip()
+                            if marker not in marker_created:
+                                marker_created.append(marker)
+                                log_file = Path(tmpdir) / "mini_COM0_test.log"
+                                log_file.write_text(f"boot log\n{marker}\n")
+                            break
+                return result
+            runner.run = intercepting_run
+
+            # Run main
+            exit_code = main_with_runner(
+                ["--selector", "COM0"],
+                runner=runner,
+                log_dir=tmpdir
+            )
+
+            # Should return non-zero
+            self.assertNotEqual(exit_code, 0)
+
+    def test_startup_cleans_state_on_any_post_creation_failure(self):
+        """Test startup cleans state on any failure after state creation."""
+        from serialwrap_reboot_test.controller import RebootController
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+
+            # Make event add fail (after state dir created)
+            runner.set_response('event add', 1, "", "Failed to add rule")
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+
+            # Intercept marker to create log
+            original_send_marker = controller.send_marker_command
+            def tracked_send_marker():
+                marker = original_send_marker()
+                log_file = Path(tmpdir) / "mini_COM0_test.log"
+                log_file.write_text(f"boot log\n{marker}\n")
+                return marker
+            controller.send_marker_command = tracked_send_marker
+
+            # Run startup
+            result = controller.startup()
+
+            # Should return False
+            self.assertFalse(result)
+
+            # State directory should be cleaned up
+            if controller.state_dir:
+                self.assertFalse(controller.state_dir.exists(),
+                    "State directory should be removed on any startup failure")
+
+
+class TestStartupCleanupErrorLogging(unittest.TestCase):
+    """Test startup cleanup logs warnings on cleanup failures."""
+
+    def test_startup_cleanup_logs_warnings_on_disable_failure(self):
+        """Test startup cleanup logs warning when disable fails."""
+        from serialwrap_reboot_test.controller import RebootController
+        from unittest.mock import patch
+        import sys
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+
+            # Make enable fail (triggers cleanup)
+            runner.set_response('event enable', 1, "", "Failed to enable")
+            # Make disable fail during cleanup
+            runner.set_response('event disable', 1, "", "Failed to disable during cleanup")
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+
+            # Intercept marker to create log
+            original_send_marker = controller.send_marker_command
+            def tracked_send_marker():
+                marker = original_send_marker()
+                log_file = Path(tmpdir) / "mini_COM0_test.log"
+                log_file.write_text(f"boot log\n{marker}\n")
+                return marker
+            controller.send_marker_command = tracked_send_marker
+
+            # Capture stderr
+            stderr_output = []
+            original_stderr = sys.stderr.write
+            def mock_stderr(msg):
+                stderr_output.append(msg)
+                return original_stderr(msg)
+
+            with patch('sys.stderr.write', mock_stderr):
+                result = controller.startup()
+
+            # Should return False
+            self.assertFalse(result)
+
+            # Should log warning about disable failure
+            stderr_text = ''.join(stderr_output)
+            self.assertTrue('WARNING' in stderr_text or 'disable' in stderr_text.lower(),
+                f"Expected warning about disable failure, got: {stderr_text}")
+
+            # State directory should still be removed
+            if controller.state_dir:
+                self.assertFalse(controller.state_dir.exists())
+
+    def test_startup_cleanup_logs_warnings_on_reset_failure(self):
+        """Test startup cleanup logs warning when reset fails."""
+        from serialwrap_reboot_test.controller import RebootController
+        from unittest.mock import patch
+        import sys
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+
+            # Make enable fail (triggers cleanup)
+            runner.set_response('event enable', 1, "", "Failed to enable")
+            # Make reset fail during cleanup
+            runner.set_response('event reset', 1, "", "Failed to reset during cleanup")
+
+            controller = RebootController("COM1", runner=runner, log_dir=tmpdir)
+
+            # Intercept marker to create log
+            original_send_marker = controller.send_marker_command
+            def tracked_send_marker():
+                marker = original_send_marker()
+                log_file = Path(tmpdir) / "mini_COM1_test.log"
+                log_file.write_text(f"boot log\n{marker}\n")
+                return marker
+            controller.send_marker_command = tracked_send_marker
+
+            # Capture stderr
+            stderr_output = []
+            original_stderr = sys.stderr.write
+            def mock_stderr(msg):
+                stderr_output.append(msg)
+                return original_stderr(msg)
+
+            with patch('sys.stderr.write', mock_stderr):
+                result = controller.startup()
+
+            # Should return False
+            self.assertFalse(result)
+
+            # Should log warning about reset failure
+            stderr_text = ''.join(stderr_output)
+            self.assertTrue('WARNING' in stderr_text or 'reset' in stderr_text.lower(),
+                f"Expected warning about reset failure, got: {stderr_text}")
+
+            # State directory should still be removed
+            if controller.state_dir:
+                self.assertFalse(controller.state_dir.exists())
+
+    def test_startup_cleanup_logs_warnings_on_rule_removal_failure(self):
+        """Test startup cleanup logs warning when rule removal fails."""
+        from serialwrap_reboot_test.controller import RebootController
+        from unittest.mock import patch
+        import sys
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = FakeCommandRunner()
+
+            # Make enable fail (triggers cleanup)
+            runner.set_response('event enable', 1, "", "Failed to enable")
+            # Make event rm fail during cleanup
+            runner.set_response('event rm', 1, "", "Failed to remove rule")
+
+            controller = RebootController("COM0", runner=runner, log_dir=tmpdir)
+
+            # Intercept marker to create log
+            original_send_marker = controller.send_marker_command
+            def tracked_send_marker():
+                marker = original_send_marker()
+                log_file = Path(tmpdir) / "mini_COM0_test.log"
+                log_file.write_text(f"boot log\n{marker}\n")
+                return marker
+            controller.send_marker_command = tracked_send_marker
+
+            # Capture stderr
+            stderr_output = []
+            original_stderr = sys.stderr.write
+            def mock_stderr(msg):
+                stderr_output.append(msg)
+                return original_stderr(msg)
+
+            with patch('sys.stderr.write', mock_stderr):
+                result = controller.startup()
+
+            # Should return False
+            self.assertFalse(result)
+
+            # Should log warning about rule removal failure
+            stderr_text = ''.join(stderr_output)
+            self.assertTrue('WARNING' in stderr_text or 'remove' in stderr_text.lower() or 'rule' in stderr_text.lower(),
+                f"Expected warning about rule removal failure, got: {stderr_text}")
+
+            # State directory should still be removed
+            if controller.state_dir:
+                self.assertFalse(controller.state_dir.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- recover the unmerged serialwrap reboot log test toolkit from stale branch commit 748d863
- add serialwrap event handler/controller/fault installer plus OpenSpec and tests
- adapt event handler parsing for current EventEngine payload fields such as matched_text, rule_name, rule_id, and matched_at

## Branch safety checks
- source branch fix/serialwrap-detach-marker-fallback was 130 commits behind main and 1 commit ahead, so this PR was rebuilt from latest main instead of directly merging the stale branch
- PR branch is 0 behind / 1 ahead of main
- staged diff contains no deletions and does not include .repo-git/

## Validation
- python3 -m py_compile bin/serialwrap-reboot-controller bin/serialwrap-event-handler bin/serialwrap-fault-install serialwrap_reboot_test/*.py
- python3 -m pytest tests/test_package_structure.py tests/test_controller_args.py tests/test_controller_cleanup.py tests/test_controller_error_handling.py tests/test_controller_events.py tests/test_controller_integration.py tests/test_controller_readiness.py tests/test_controller_reboot_loop.py tests/test_cursor_load_race.py tests/test_event_handler.py tests/test_event_handler_fixes.py tests/test_event_handler_race_fixes.py tests/test_fault_installer.py tests/test_quality_fixes.py tests/test_robustness_warnings.py tests/test_security_fixes.py tests/test_startup_cleanup.py -q (278 passed)
- python3 -m unittest tests.test_event_schema tests.test_event_counter tests.test_event_registry tests.test_event_log tests.test_event_line_buffer tests.test_event_matcher tests.test_event_dispatcher tests.test_event_engine tests.test_event_rpc tests.test_event_cli tests.test_event_mcp -v (70 passed)
- git diff --cached --check

## Note
- python3 -m unittest discover -s tests -v currently fails in unchanged tests.test_multiagent_e2e.TestMultiAgentE2E.test_five_agents_three_rounds_no_conflict with PTY/daemon instability; the changed files do not touch serialwrapd.py, sw_core/, or that test.