### PR TITLE
fix(minicom): 避免 broker 預設使用原生 capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `tools/minicom_router.sh` 的 broker minicom 自動 transcript 預設改為 `script -qef` wrapper，不再預設把 `-C` 傳給 minicom；新增 `MINICOM_CAPTURE_MODE=script|minicom|off` 控制模式，`MINICOM_CAPTURE_MODE=minicom` 才明確 opt-in 使用原生 capture。
+
+### Fixed
+
+- 修正 broker minicom 正常或非 0 結束時可能因 shell 被 `exec` 取代而跳過 `session console-detach` 的 lifecycle cleanup 風險。
+
 ## [0.1.0] - 2026-05-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ serialwrap file pull --selector COM0 --remote /etc/config/wireless --local ./wir
 1. 視需要自動啟動 daemon
 2. 視需要對 selector 執行 `session attach`
 3. 透過 `session console-attach` 取得專屬 PTY
-4. 預設用 minicom 內建 `-C` 記錄一份 `mini_<COM>_<timestamp>.log` transcript（預設在 `~/b-log`，可用 `BLOG_DIR` 覆寫）
+4. 預設用 `script -qef` 包住 minicom 記錄一份 `mini_<COM>_<timestamp>.log` transcript（預設在 `~/b-log`，可用 `BLOG_DIR` 覆寫），避免 minicom 內建 `-C` 在 PTY / resize / 高頻 RX 下的 native crash 風險
 5. 啟動 `minicom`
 6. 結束後自動 `session console-detach`
 
@@ -540,7 +540,11 @@ minicom -D /dev/ttyUSB0
 - 若 agent 在 human interactive 期間提交命令，daemon 會暫時掛起（suspend）human raw mode → 執行 agent 命令 → 完成後自動恢復（resume）。Human 在 agent 執行期間的按鍵會累積在 deferred buffer，agent 完成後 flush 到 UART。
 - 第二個以後的 minicom console 因為 interactive lease 已存在，仍走 line-buffer 模式（broker 提供本地回顯與 backspace 行編輯）。
 - bridge rebuild / reattach 時，broker 會盡量保留既有 console PTY 與 human ownership，避免既有 minicom 掛到 stale `/dev/pts/*`。
-- 若要保留舊版「完整 terminal transcript」行為，可顯式設定 `MINICOM_CAPTURE_WRAPPER=1`，此時 wrapper 會改用 `script -qef` 包一層 PTY；但這可能增加 human 體感延遲。
+- Broker minicom 的自動 transcript 可用 `MINICOM_CAPTURE_MODE=script|minicom|off` 控制：
+  - `script`（預設）：使用 `script -qef` 包住 minicom，不傳 `-C` 給 minicom。
+  - `minicom`：明確 opt-in 使用 minicom 內建 `-C`；此模式在 PTY / resize / 高頻輸出下較容易觸發 minicom native crash 風險。
+  - `off`：關閉自動 transcript，不建立 log、不使用 `script` wrapper，也不自動傳 `-C`。
+- Legacy `MINICOM_CAPTURE_WRAPPER=1` 仍等同 `MINICOM_CAPTURE_MODE=script`；若未設定 `MINICOM_CAPTURE_MODE` 且明確設定 `MINICOM_CAPTURE_WRAPPER=0`，仍保留舊版 minicom `-C` 行為。
 - 常見 human/minicom 互動式命令（例如 `vi`、`vim`、`top`、`htop`、`less`、`menuconfig`）會自動升級成 human interactive ownership，不再因為等不到 shell prompt 而自動觸發 recover / reboot。
 - 若直接打 `minicom` 沒有走 broker，先用 `type -a minicom` 檢查目前 shell 是否先命中 `~/.paul_tools/minicom`；若仍是 `/usr/bin/minicom`，代表 shell PATH 尚未把 wrapper 放到前面。
 

--- a/tests/test_minicom_router.py
+++ b/tests/test_minicom_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 import os
 import shutil
 import stat
@@ -11,30 +12,71 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ROUTER = REPO_ROOT / "tools" / "minicom_router.sh"
+TEMP_ROOT = REPO_ROOT / ".test-minicom-router.tmp"
 
 
 class TestMinicomRouter(unittest.TestCase):
+    @contextmanager
+    def _temporary_directory(self):
+        TEMP_ROOT.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=TEMP_ROOT) as td:
+            yield td
+        try:
+            TEMP_ROOT.rmdir()
+        except OSError:
+            pass
+
+    def _write_executable(self, path: Path, content: str) -> None:
+        path.write_text(content, encoding="utf-8")
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+    def _write_unavailable_serialwrap(self, root: Path) -> Path:
+        fake_serialwrap = root / "fake-serialwrap.sh"
+        self._write_executable(
+            fake_serialwrap,
+            "#!/usr/bin/env bash\n"
+            "echo '{\"ok\":false}'\n",
+        )
+        return fake_serialwrap
+
+    def _base_env(self, root: Path, fake_minicom: Path, blog_dir: Path | None = None) -> dict[str, str]:
+        env = os.environ.copy()
+        env["MINICOM_BIN"] = str(fake_minicom)
+        env["BLOG_DIR"] = str(blog_dir or (root / "b-log"))
+        env["MINICOM_AUTO_CAPTURE"] = "1"
+        env["MINICOM_DEFAULT_COLOR"] = ""
+        env["SERIALWRAP_BIN"] = str(self._write_unavailable_serialwrap(root))
+        env["SERIALWRAP_AUTO_START_DAEMON"] = "0"
+        env["SERIALWRAP_SOCKET"] = str(root / "serialwrapd.sock")
+        env.pop("MINICOM_CAPTURE_MODE", None)
+        env.pop("MINICOM_CAPTURE_WRAPPER", None)
+        return env
+
+    def _path_without_script(self, root: Path) -> Path:
+        bin_dir = root / "bin-without-script"
+        bin_dir.mkdir(parents=True)
+        for name in ("bash", "date", "dirname", "jq", "mkdir", "tr"):
+            target = shutil.which(name)
+            if target is None:
+                self.skipTest(f"{name} command is required")
+            os.symlink(target, bin_dir / name)
+        return bin_dir
+
     @unittest.skipUnless(shutil.which("script"), "script command is required")
     def test_wrapper_generates_transcript_log(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
+        with self._temporary_directory() as td:
             root = Path(td)
             fake_minicom = root / "fake-minicom.sh"
             blog_dir = root / "b-log"
-            capture_out = root / "stdout.txt"
 
-            fake_minicom.write_text(
+            self._write_executable(
+                fake_minicom,
                 "#!/usr/bin/env bash\n"
                 "echo 'fake minicom output'\n",
-                encoding="utf-8",
             )
-            fake_minicom.chmod(fake_minicom.stat().st_mode | stat.S_IXUSR)
 
-            env = os.environ.copy()
-            env["MINICOM_BIN"] = str(fake_minicom)
-            env["BLOG_DIR"] = str(blog_dir)
-            env["MINICOM_AUTO_CAPTURE"] = "1"
+            env = self._base_env(root, fake_minicom, blog_dir)
             env["MINICOM_CAPTURE_WRAPPER"] = "1"
-            env["MINICOM_DEFAULT_COLOR"] = ""
 
             subprocess.run(
                 ["bash", str(ROUTER), "-D", "/dev/null"],
@@ -53,27 +95,23 @@ class TestMinicomRouter(unittest.TestCase):
 
     @unittest.skipUnless(shutil.which("script"), "script command is required")
     def test_wrapper_prefers_home_b_log_over_build_log_path(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
+        with self._temporary_directory() as td:
             root = Path(td)
             fake_minicom = root / "fake-minicom.sh"
             home_dir = root / "home"
             legacy_dir = root / "legacy-b-log"
             home_dir.mkdir(parents=True, exist_ok=True)
 
-            fake_minicom.write_text(
+            self._write_executable(
+                fake_minicom,
                 "#!/usr/bin/env bash\n"
                 "echo 'fake minicom output'\n",
-                encoding="utf-8",
             )
-            fake_minicom.chmod(fake_minicom.stat().st_mode | stat.S_IXUSR)
 
-            env = os.environ.copy()
+            env = self._base_env(root, fake_minicom)
             env["HOME"] = str(home_dir)
             env["BUILD_LOG_PATH"] = str(legacy_dir)
-            env["MINICOM_BIN"] = str(fake_minicom)
-            env["MINICOM_AUTO_CAPTURE"] = "1"
             env["MINICOM_CAPTURE_WRAPPER"] = "1"
-            env["MINICOM_DEFAULT_COLOR"] = ""
             env.pop("BLOG_DIR", None)
 
             subprocess.run(
@@ -90,14 +128,144 @@ class TestMinicomRouter(unittest.TestCase):
             self.assertEqual(len(logs), 1)
             self.assertFalse(legacy_dir.exists())
 
-    def test_default_capture_uses_minicom_capturefile_without_script_wrapper(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
+    @unittest.skipUnless(shutil.which("script"), "script command is required")
+    def test_default_capture_uses_script_wrapper_without_minicom_capturefile(self) -> None:
+        with self._temporary_directory() as td:
             root = Path(td)
             fake_minicom = root / "fake-minicom.sh"
             args_out = root / "args.txt"
             blog_dir = root / "b-log"
 
-            fake_minicom.write_text(
+            self._write_executable(
+                fake_minicom,
+                "#!/usr/bin/env bash\n"
+                "printf '%s\\n' \"$@\" > \"$FAKE_ARGS_OUT\"\n"
+                "for arg in \"$@\"; do\n"
+                "  if [[ \"$arg\" == '-C' || \"$arg\" == --capturefile* ]]; then\n"
+                "    echo 'unexpected minicom native capture arg' >&2\n"
+                "    exit 44\n"
+                "  fi\n"
+                "done\n"
+                "printf 'fake minicom output\\n'\n",
+            )
+
+            env = self._base_env(root, fake_minicom, blog_dir)
+            env["FAKE_ARGS_OUT"] = str(args_out)
+
+            subprocess.run(
+                ["bash", str(ROUTER), "-D", "/dev/null"],
+                check=True,
+                cwd=str(REPO_ROOT),
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+
+            args = args_out.read_text(encoding="utf-8")
+            self.assertNotIn("-C", args)
+            logs = sorted(blog_dir.glob("mini_*.log"))
+            self.assertEqual(len(logs), 1)
+            content = logs[0].read_text(encoding="utf-8", errors="replace")
+            self.assertIn("fake minicom output", content)
+
+    def test_user_capture_args_disable_auto_transcript(self) -> None:
+        cases = (
+            ("short", ["-C", "user-short.log"], ["-C", "user-short.log"], 1),
+            ("long", ["--capturefile=user-long.log"], ["--capturefile=user-long.log"], 0),
+        )
+        for name, capture_args, expected_args, expected_short_count in cases:
+            with self.subTest(name=name), self._temporary_directory() as td:
+                root = Path(td)
+                fake_minicom = root / "fake-minicom.sh"
+                fake_bin = root / "fake-bin"
+                args_out = root / "args.txt"
+                script_marker = root / "script-ran.txt"
+                blog_dir = root / "b-log"
+                fake_bin.mkdir()
+
+                self._write_executable(
+                    fake_minicom,
+                    "#!/usr/bin/env bash\n"
+                    "printf '%s\\n' \"$@\" > \"$FAKE_ARGS_OUT\"\n",
+                )
+                self._write_executable(
+                    fake_bin / "script",
+                    "#!/usr/bin/env bash\n"
+                    "echo 'script wrapper unexpectedly invoked' > \"$FAKE_SCRIPT_MARKER\"\n"
+                    "exit 66\n",
+                )
+
+                env = self._base_env(root, fake_minicom, blog_dir)
+                env["FAKE_ARGS_OUT"] = str(args_out)
+                env["FAKE_SCRIPT_MARKER"] = str(script_marker)
+                env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+                subprocess.run(
+                    ["bash", str(ROUTER), "-D", "/dev/null", *capture_args],
+                    check=True,
+                    cwd=str(REPO_ROOT),
+                    env=env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                )
+
+                args = args_out.read_text(encoding="utf-8").splitlines()
+                for expected in expected_args:
+                    self.assertIn(expected, args)
+                self.assertEqual(args.count("-C"), expected_short_count)
+                self.assertFalse(list(blog_dir.glob("mini_*.log")))
+                self.assertFalse(script_marker.exists())
+
+    def test_script_unavailable_warns_and_runs_without_native_capture(self) -> None:
+        with self._temporary_directory() as td:
+            root = Path(td)
+            fake_minicom = root / "fake-minicom.sh"
+            args_out = root / "args.txt"
+            blog_dir = root / "b-log"
+            path_without_script = self._path_without_script(root)
+            bash_bin = shutil.which("bash")
+            if bash_bin is None:
+                self.skipTest("bash command is required")
+
+            self._write_executable(
+                fake_minicom,
+                "#!/usr/bin/env bash\n"
+                "printf '%s\\n' \"$@\" > \"$FAKE_ARGS_OUT\"\n"
+                "exit 23\n",
+            )
+
+            env = self._base_env(root, fake_minicom, blog_dir)
+            env["FAKE_ARGS_OUT"] = str(args_out)
+            env["PATH"] = str(path_without_script)
+
+            result = subprocess.run(
+                [bash_bin, str(ROUTER), "-D", "/dev/null"],
+                check=False,
+                cwd=str(REPO_ROOT),
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 23)
+            self.assertIn("warning", result.stderr)
+            self.assertIn("script", result.stderr)
+            args = args_out.read_text(encoding="utf-8")
+            self.assertNotIn("-C", args)
+            self.assertFalse(list(blog_dir.glob("mini_*.log")))
+
+    def test_capture_mode_minicom_uses_native_capturefile(self) -> None:
+        with self._temporary_directory() as td:
+            root = Path(td)
+            fake_minicom = root / "fake-minicom.sh"
+            args_out = root / "args.txt"
+            blog_dir = root / "b-log"
+
+            self._write_executable(
+                fake_minicom,
                 "#!/usr/bin/env bash\n"
                 "printf '%s\\n' \"$@\" > \"$FAKE_ARGS_OUT\"\n"
                 "capture=''\n"
@@ -113,17 +281,11 @@ class TestMinicomRouter(unittest.TestCase):
                 "  printf 'fake minicom output\\n' > \"$capture\"\n"
                 "fi\n"
                 "printf 'fake minicom output\\n'\n",
-                encoding="utf-8",
             )
-            fake_minicom.chmod(fake_minicom.stat().st_mode | stat.S_IXUSR)
 
-            env = os.environ.copy()
-            env["MINICOM_BIN"] = str(fake_minicom)
-            env["BLOG_DIR"] = str(blog_dir)
-            env["MINICOM_AUTO_CAPTURE"] = "1"
-            env["MINICOM_DEFAULT_COLOR"] = ""
+            env = self._base_env(root, fake_minicom, blog_dir)
             env["FAKE_ARGS_OUT"] = str(args_out)
-            env.pop("MINICOM_CAPTURE_WRAPPER", None)
+            env["MINICOM_CAPTURE_MODE"] = "minicom"
 
             subprocess.run(
                 ["bash", str(ROUTER), "-D", "/dev/null"],
@@ -139,8 +301,173 @@ class TestMinicomRouter(unittest.TestCase):
             self.assertIn("-C", args)
             logs = sorted(blog_dir.glob("mini_*.log"))
             self.assertEqual(len(logs), 1)
-            content = logs[0].read_text(encoding="utf-8", errors="replace")
-            self.assertIn("fake minicom output", content)
+            self.assertIn("fake minicom output", logs[0].read_text(encoding="utf-8"))
+
+    def test_capture_mode_off_disables_auto_transcript(self) -> None:
+        with self._temporary_directory() as td:
+            root = Path(td)
+            fake_minicom = root / "fake-minicom.sh"
+            args_out = root / "args.txt"
+            blog_dir = root / "b-log"
+
+            self._write_executable(
+                fake_minicom,
+                "#!/usr/bin/env bash\n"
+                "printf '%s\\n' \"$@\" > \"$FAKE_ARGS_OUT\"\n"
+                "printf 'fake minicom output\\n'\n",
+            )
+
+            env = self._base_env(root, fake_minicom, blog_dir)
+            env["FAKE_ARGS_OUT"] = str(args_out)
+            env["MINICOM_CAPTURE_MODE"] = "off"
+
+            subprocess.run(
+                ["bash", str(ROUTER), "-D", "/dev/null"],
+                check=True,
+                cwd=str(REPO_ROOT),
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+
+            args = args_out.read_text(encoding="utf-8")
+            self.assertNotIn("-C", args)
+            self.assertFalse(list(blog_dir.glob("mini_*.log")))
+
+    def test_legacy_explicit_capture_wrapper_zero_uses_native_capturefile(self) -> None:
+        with self._temporary_directory() as td:
+            root = Path(td)
+            fake_minicom = root / "fake-minicom.sh"
+            args_out = root / "args.txt"
+            blog_dir = root / "b-log"
+
+            self._write_executable(
+                fake_minicom,
+                "#!/usr/bin/env bash\n"
+                "printf '%s\\n' \"$@\" > \"$FAKE_ARGS_OUT\"\n"
+                "capture=''\n"
+                "while [[ $# -gt 0 ]]; do\n"
+                "  if [[ \"$1\" == '-C' && $# -ge 2 ]]; then\n"
+                "    capture=\"$2\"\n"
+                "    shift 2\n"
+                "    continue\n"
+                "  fi\n"
+                "  shift\n"
+                "done\n"
+                "if [[ -n \"$capture\" ]]; then\n"
+                "  printf 'legacy capture\\n' > \"$capture\"\n"
+                "fi\n",
+            )
+
+            env = self._base_env(root, fake_minicom, blog_dir)
+            env["FAKE_ARGS_OUT"] = str(args_out)
+            env["MINICOM_CAPTURE_WRAPPER"] = "0"
+
+            subprocess.run(
+                ["bash", str(ROUTER), "-D", "/dev/null"],
+                check=True,
+                cwd=str(REPO_ROOT),
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+
+            args = args_out.read_text(encoding="utf-8")
+            self.assertIn("-C", args)
+            logs = sorted(blog_dir.glob("mini_*.log"))
+            self.assertEqual(len(logs), 1)
+            self.assertIn("legacy capture", logs[0].read_text(encoding="utf-8"))
+
+    def test_invalid_capture_mode_exits_with_clear_error(self) -> None:
+        with self._temporary_directory() as td:
+            root = Path(td)
+            fake_minicom = root / "fake-minicom.sh"
+            self._write_executable(
+                fake_minicom,
+                "#!/usr/bin/env bash\n"
+                "exit 0\n",
+            )
+
+            env = self._base_env(root, fake_minicom)
+            env["MINICOM_CAPTURE_MODE"] = "native"
+
+            result = subprocess.run(
+                ["bash", str(ROUTER), "-D", "/dev/null"],
+                check=False,
+                cwd=str(REPO_ROOT),
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("invalid MINICOM_CAPTURE_MODE", result.stdout)
+
+    def test_broker_console_detaches_after_minicom_nonzero_exit(self) -> None:
+        with self._temporary_directory() as td:
+            root = Path(td)
+            fake_minicom = root / "fake-minicom.sh"
+            fake_serialwrap = root / "fake-serialwrap.sh"
+            serialwrap_log = root / "serialwrap.log"
+            args_out = root / "args.txt"
+
+            self._write_executable(
+                fake_minicom,
+                "#!/usr/bin/env bash\n"
+                "printf '%s\\n' \"$@\" > \"$FAKE_ARGS_OUT\"\n"
+                "exit 37\n",
+            )
+            self._write_executable(
+                fake_serialwrap,
+                "#!/usr/bin/env bash\n"
+                "printf '%s\\n' \"$*\" >> \"$FAKE_SERIALWRAP_LOG\"\n"
+                "if [[ \"${1:-}\" == '--socket' ]]; then\n"
+                "  shift 2\n"
+                "fi\n"
+                "if [[ \"${1:-}\" == 'session' && \"${2:-}\" == 'list' ]]; then\n"
+                "  echo '{\"ok\":true,\"sessions\":[{\"com\":\"COM0\",\"alias\":\"default\",\"session_id\":\"s0\",\"state\":\"READY\"}]}'\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [[ \"${1:-}\" == 'session' && \"${2:-}\" == 'console-attach' ]]; then\n"
+                "  echo '{\"ok\":true,\"client_id\":\"client-1\",\"vtty\":\"/dev/null\"}'\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [[ \"${1:-}\" == 'session' && \"${2:-}\" == 'console-detach' ]]; then\n"
+                "  echo '{\"ok\":true}'\n"
+                "  exit 0\n"
+                "fi\n"
+                "echo '{\"ok\":false}'\n"
+                "exit 1\n",
+            )
+
+            env = os.environ.copy()
+            env["SERIALWRAP_BIN"] = str(fake_serialwrap)
+            env["SERIALWRAP_SOCKET"] = str(root / "serialwrapd.sock")
+            env["SERIALWRAP_AUTO_START_DAEMON"] = "0"
+            env["FAKE_SERIALWRAP_LOG"] = str(serialwrap_log)
+            env["MINICOM_BIN"] = str(fake_minicom)
+            env["FAKE_ARGS_OUT"] = str(args_out)
+            env["MINICOM_AUTO_CAPTURE"] = "0"
+            env["MINICOM_DEFAULT_COLOR"] = ""
+            env["MINICOM_CAPTURE_MODE"] = "off"
+
+            result = subprocess.run(
+                ["bash", str(ROUTER), "COM0"],
+                check=False,
+                cwd=str(REPO_ROOT),
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 37)
+            calls = serialwrap_log.read_text(encoding="utf-8").splitlines()
+            self.assertTrue(any("session console-attach" in call for call in calls))
+            self.assertTrue(any("session console-detach" in call for call in calls))
 
 
 if __name__ == "__main__":

--- a/tools/minicom_router.sh
+++ b/tools/minicom_router.sh
@@ -21,7 +21,12 @@ MINICOM_BIN="${MINICOM_BIN:-/usr/bin/minicom}"
 MINICOM_DEFAULT_COLOR="${MINICOM_DEFAULT_COLOR:-on}"
 MINICOM_AUTO_CAPTURE="${MINICOM_AUTO_CAPTURE:-1}"
 BLOG_DIR="${BLOG_DIR:-${HOME}/b-log}"
-MINICOM_CAPTURE_WRAPPER="${MINICOM_CAPTURE_WRAPPER:-0}"
+MINICOM_CAPTURE_WRAPPER_WAS_SET=0
+if [[ -v MINICOM_CAPTURE_WRAPPER ]]; then
+  MINICOM_CAPTURE_WRAPPER_WAS_SET=1
+fi
+MINICOM_CAPTURE_WRAPPER="${MINICOM_CAPTURE_WRAPPER:-}"
+MINICOM_CAPTURE_MODE="${MINICOM_CAPTURE_MODE:-}"
 
 _shell_join() {
   local -a quoted
@@ -33,6 +38,32 @@ _shell_join() {
   done
   local IFS=' '
   printf '%s' "${quoted[*]}"
+}
+
+_resolve_capture_mode() {
+  if [[ -n "${MINICOM_CAPTURE_MODE}" ]]; then
+    case "${MINICOM_CAPTURE_MODE}" in
+      script|minicom|off)
+        printf '%s' "${MINICOM_CAPTURE_MODE}"
+        return 0
+        ;;
+      *)
+        echo "minicom_router: invalid MINICOM_CAPTURE_MODE='${MINICOM_CAPTURE_MODE}' (expected script, minicom, or off)" >&2
+        return 2
+        ;;
+    esac
+  fi
+
+  if [[ "${MINICOM_CAPTURE_WRAPPER_WAS_SET}" == "1" ]]; then
+    if [[ "${MINICOM_CAPTURE_WRAPPER}" == "1" ]]; then
+      printf 'script'
+    else
+      printf 'minicom'
+    fi
+    return 0
+  fi
+
+  printf 'script'
 }
 
 selector=""
@@ -137,7 +168,10 @@ _exec_minicom() {
   fi
 
   local logfile=""
-  if [[ "${has_capture}" -eq 0 && "${MINICOM_AUTO_CAPTURE}" == "1" ]]; then
+  local capture_mode
+  capture_mode="$(_resolve_capture_mode)" || return $?
+
+  if [[ "${has_capture}" -eq 0 && "${MINICOM_AUTO_CAPTURE}" == "1" && "${capture_mode}" != "off" ]]; then
     mkdir -p "${BLOG_DIR}"
     local ts
     ts="$(date +%y%m%d-%H%M%S)"
@@ -148,15 +182,19 @@ _exec_minicom() {
 
   local -a cmd
   cmd=("${MINICOM_BIN}" -D "${device}" "${extra_args[@]}" "${user_args[@]}")
-  if [[ -n "${logfile}" && "${MINICOM_CAPTURE_WRAPPER}" == "1" ]] && command -v script >/dev/null 2>&1; then
-    local cmdline
-    cmdline="$(_shell_join "${cmd[@]}")"
-    exec script -qef -c "${cmdline}" "${logfile}"
+  if [[ -n "${logfile}" && "${capture_mode}" == "script" ]]; then
+    if command -v script >/dev/null 2>&1; then
+      local cmdline
+      cmdline="$(_shell_join "${cmd[@]}")"
+      script -qef -c "${cmdline}" "${logfile}"
+      return $?
+    fi
+    echo "minicom_router: warning: MINICOM_CAPTURE_MODE=script requested but 'script' command not found; auto transcript disabled" >&2
   fi
-  if [[ -n "${logfile}" ]]; then
+  if [[ -n "${logfile}" && "${capture_mode}" == "minicom" ]]; then
     cmd+=("-C" "${logfile}")
   fi
-  exec "${cmd[@]}"
+  "${cmd[@]}"
 }
 
 _ensure_daemon() {
@@ -247,8 +285,12 @@ _run_broker_minicom() {
     "${SERIALWRAP_BIN}" --socket "${SOCKET}" session console-detach --selector "${sel}" --client-id "${client_id}" >/dev/null 2>&1 || true
   }
   trap cleanup EXIT INT TERM
-  _exec_minicom "${vtty}" "${com_name}" "$@"
-  local rc=$?
+  local rc
+  if _exec_minicom "${vtty}" "${com_name}" "$@"; then
+    rc=0
+  else
+    rc=$?
+  fi
   trap - EXIT INT TERM
   cleanup
   return "${rc}"


### PR DESCRIPTION
> Supersedes #48. 這個 PR 只為修正 R-12 branch naming：對 main 的 PR head 必須是 feature/<slug>。

## Summary

- 將 broker minicom 預設 transcript 從原生 `-C` 改為 `script` wrapper，新增 `MINICOM_CAPTURE_MODE=script|minicom|off`
- 保留 legacy opt-in 與使用者自帶 `-C` / `--capturefile` 行為，避免重複注入 auto transcript
- 修正 minicom/script 非 0 退出後仍會 `session console-detach`，並同步更新 README、CHANGELOG 與回歸測試

## Test Plan

- [x] 執行 `python3 -m unittest tests.test_minicom_router -v`
- [x] 執行 `python3 -m pytest -q tests/` — 僅剩既有 baseline `tests/test_multiagent_e2e.py::TestMultiAgentE2E::test_five_agents_three_rounds_no_conflict`
- [x] 執行 `python3 -m policy_check --repo .` — 通過

## Policy Checklist (R-11)

- [x] 分支不是 `main`（不可直接 commit 到 main）
- [x] `CHANGELOG.md` 已更新（`[Unreleased]` 段落）
- [x] `VERSION` 未變動，無需更新
- [x] `python3 -m pytest -q tests/` 無新增失敗（僅既有 baseline）
- [x] `python3 -m policy_check --repo .` 通過
- [x] 四份 agent 檔案未修改，無需同步
- [x] 本 PR 無適用 release / exemption label

## Issue Reference

- N/A

