### PR TITLE
chore(policy): 同步 policy 1.0.1（R-17/R-18 + 語言規範）

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
-<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.0 -->
+<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.1 -->
 <!-- 若修改此檔，同步更新 CLAUDE.md / AGENTS.md / GEMINI.md / .github/copilot-instructions.md 四份 -->
-policy_version: 1.0.0
+policy_version: 1.0.1
 <!-- policy_version 為 policy_check R-14 machine-readable marker；需保持裸行格式，請勿移入 frontmatter 或 code block。 -->
 
 # Copilot Instructions — serialwrap
@@ -199,3 +199,12 @@ MCP 只是 RPC 的薄轉接層。新增或改名工具時，要把 `sw_mcp/serve
 - `tests/test_multiagent_e2e.py` 會啟動真實 daemon，再用 PTY 假 target 驗證 `READY` 流程與多 agent 序列化，任何跨 `service / arbiter / session_manager / uart_io` 的改動都很適合先看這個測試。
 - `tests/test_wal.py`、`tests/test_login_fsm.py`、`tests/test_session_bind.py` 分別對應 WAL、登入狀態機與綁定/持久化行為。
 - `install.sh` 不是單純複製檔案：它還會移除 legacy `serialwrap_lib.py`，並在偵測到唯一一個 `/dev/serial/by-id/*` 且 `profiles/default.yaml` 仍是 placeholder 時，自動改寫預設 target。
+
+## v1.0.1 新增規則（issue 連結 / docs 對齊 / 語言）
+> 本段於 policy 1.0.1 隨 R-17 / R-18 與語言規範新增。
+
+- **R-17（PR↔issue，FAIL gate）**：PR body 引用 issue（`#N`）時必須為 closing-keyword 形式（`Closes` / `Fixes` / `Resolves #N`），merge 由 GitHub 原生自動關閉 issue 並留下 cross-reference；只引用不關閉時上 `policy-exempt:issue-link`。
+- **R-18（docs 對齊，WARN，不擋 merge）**：`code_paths` 有變動但 `README.md` / `docs/**` 未同步時提醒；純內部變動可上 `policy-exempt:docs-sync`。
+- **語言規範（checklist）**：依 repo 來源決定語言——`github.com/hamanpaul/*`、`github.com/paulc-arc/*` → zh-tw；arcadyan GitLab → en_US。涵蓋 PR 標題／內文與所有 comment。本 repo 屬 `hamanpaul` → zh-tw。
+- **動工前（軟性，不打斷流程）**：若任務對應某 issue，`gh issue view <N>` 核對相關性後分支可命名 `feature/<N>-<slug>`，開 PR 於 body 寫 `Closes #N`；查無對應 issue 照常進行，不另開、不停。
+- **Exemption 白名單新增**：`policy-exempt:issue-link`（R-17）、`policy-exempt:docs-sync`（R-18）。

--- a/.github/workflows/policy-check.yml
+++ b/.github/workflows/policy-check.yml
@@ -6,8 +6,8 @@ permissions:
 
 jobs:
   policy:
-    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@ff1a031172ec24fc155699f9f3ce5bdea24d9e24
+    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@4ff59b6c35a46a87af3c3e641975743ee8fa0858
     with:
       policy_profile: flat
-      policy_version: "1.0.0"
-      policy_engine_ref: ff1a031172ec24fc155699f9f3ce5bdea24d9e24
+      policy_version: "1.0.1"
+      policy_engine_ref: 4ff59b6c35a46a87af3c3e641975743ee8fa0858

--- a/.paul-project.yml
+++ b/.paul-project.yml
@@ -1,5 +1,5 @@
 policy_profile: flat
-policy_version: "1.0.0"
+policy_version: "1.0.1"
 code_paths:
   - "sw_core/**"
   - "sw_mcp/**"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.0 -->
+<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.1 -->
 <!-- 若修改此檔，同步更新 CLAUDE.md / AGENTS.md / GEMINI.md / .github/copilot-instructions.md 四份 -->
-policy_version: 1.0.0
+policy_version: 1.0.1
 <!-- policy_version 為 policy_check R-14 machine-readable marker；需保持裸行格式，請勿移入 frontmatter 或 code block。 -->
 
 # serialwrap — AI Agent Policy Checklist
@@ -37,11 +37,11 @@ policy_version: 1.0.0
   ```bash
   python3 -m policy_check --repo .
   ```
-- policy engine pinned SHA：`ff1a031172ec24fc155699f9f3ce5bdea24d9e24`。
+- policy engine pinned SHA：`4ff59b6c35a46a87af3c3e641975743ee8fa0858`。
 - 安裝命令：
   ```bash
   python3 -m pip install --user --disable-pip-version-check \
-    "git+https://github.com/hamanpaul/paulsha-conventions.git@ff1a031172ec24fc155699f9f3ce5bdea24d9e24"
+    "git+https://github.com/hamanpaul/paulsha-conventions.git@4ff59b6c35a46a87af3c3e641975743ee8fa0858"
   ```
 
 ## Agent 檔案同步政策
@@ -53,7 +53,7 @@ policy_version: 1.0.0
   - `.github/copilot-instructions.md`（marker 區段）
 - 檔案首行必須保留：
   ```
-  <!-- managed-by: hamanpaul/paulsha-conventions@v1.0.0 -->
+  <!-- managed-by: hamanpaul/paulsha-conventions@v1.0.1 -->
   ```
 
 ## PR 政策
@@ -89,3 +89,12 @@ policy_version: 1.0.0
   ```
   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
   ```
+
+## v1.0.1 新增規則（issue 連結 / docs 對齊 / 語言）
+> 本段於 policy 1.0.1 隨 R-17 / R-18 與語言規範新增。
+
+- **R-17（PR↔issue，FAIL gate）**：PR body 引用 issue（`#N`）時必須為 closing-keyword 形式（`Closes` / `Fixes` / `Resolves #N`），merge 由 GitHub 原生自動關閉 issue 並留下 cross-reference；只引用不關閉時上 `policy-exempt:issue-link`。
+- **R-18（docs 對齊，WARN，不擋 merge）**：`code_paths` 有變動但 `README.md` / `docs/**` 未同步時提醒；純內部變動可上 `policy-exempt:docs-sync`。
+- **語言規範（checklist）**：依 repo 來源決定語言——`github.com/hamanpaul/*`、`github.com/paulc-arc/*` → zh-tw；arcadyan GitLab → en_US。涵蓋 PR 標題／內文與所有 comment。本 repo 屬 `hamanpaul` → zh-tw。
+- **動工前（軟性，不打斷流程）**：若任務對應某 issue，`gh issue view <N>` 核對相關性後分支可命名 `feature/<N>-<slug>`，開 PR 於 body 寫 `Closes #N`；查無對應 issue 照常進行，不另開、不停。
+- **Exemption 白名單新增**：`policy-exempt:issue-link`（R-17）、`policy-exempt:docs-sync`（R-18）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 
+- **同步 policy 1.0.1**：`policy_version` 1.0.0 → 1.0.1（`.paul-project.yml` + 四份 agent 檔 + `managed-by@v1.0.1` + agent 檔內 engine pinned SHA），caller `policy-check` workflow 的 `uses:` 與 `policy_engine_ref` 重新雙重釘選至 `hamanpaul/paulsha-conventions@4ff59b6c35a46a87af3c3e641975743ee8fa0858`（含 R-17 / R-18）；agent 檔追加 R-17 / R-18 與語言規範說明
 - `tools/minicom_router.sh` 的 broker minicom 自動 transcript 預設改為 `script -qef` wrapper，不再預設把 `-C` 傳給 minicom；新增 `MINICOM_CAPTURE_MODE=script|minicom|off` 控制模式，`MINICOM_CAPTURE_MODE=minicom` 才明確 opt-in 使用原生 capture。
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.0 -->
+<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.1 -->
 <!-- 若修改此檔，同步更新 CLAUDE.md / AGENTS.md / GEMINI.md / .github/copilot-instructions.md 四份 -->
-policy_version: 1.0.0
+policy_version: 1.0.1
 <!-- policy_version 為 policy_check R-14 machine-readable marker；需保持裸行格式，請勿移入 frontmatter 或 code block。 -->
 
 # serialwrap — AI Agent Policy Checklist
@@ -37,11 +37,11 @@ policy_version: 1.0.0
   ```bash
   python3 -m policy_check --repo .
   ```
-- policy engine pinned SHA：`ff1a031172ec24fc155699f9f3ce5bdea24d9e24`。
+- policy engine pinned SHA：`4ff59b6c35a46a87af3c3e641975743ee8fa0858`。
 - 安裝命令：
   ```bash
   python3 -m pip install --user --disable-pip-version-check \
-    "git+https://github.com/hamanpaul/paulsha-conventions.git@ff1a031172ec24fc155699f9f3ce5bdea24d9e24"
+    "git+https://github.com/hamanpaul/paulsha-conventions.git@4ff59b6c35a46a87af3c3e641975743ee8fa0858"
   ```
 
 ## Agent 檔案同步政策
@@ -53,7 +53,7 @@ policy_version: 1.0.0
   - `.github/copilot-instructions.md`（marker 區段）
 - 檔案首行必須保留：
   ```
-  <!-- managed-by: hamanpaul/paulsha-conventions@v1.0.0 -->
+  <!-- managed-by: hamanpaul/paulsha-conventions@v1.0.1 -->
   ```
 
 ## PR 政策
@@ -89,3 +89,12 @@ policy_version: 1.0.0
   ```
   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
   ```
+
+## v1.0.1 新增規則（issue 連結 / docs 對齊 / 語言）
+> 本段於 policy 1.0.1 隨 R-17 / R-18 與語言規範新增。
+
+- **R-17（PR↔issue，FAIL gate）**：PR body 引用 issue（`#N`）時必須為 closing-keyword 形式（`Closes` / `Fixes` / `Resolves #N`），merge 由 GitHub 原生自動關閉 issue 並留下 cross-reference；只引用不關閉時上 `policy-exempt:issue-link`。
+- **R-18（docs 對齊，WARN，不擋 merge）**：`code_paths` 有變動但 `README.md` / `docs/**` 未同步時提醒；純內部變動可上 `policy-exempt:docs-sync`。
+- **語言規範（checklist）**：依 repo 來源決定語言——`github.com/hamanpaul/*`、`github.com/paulc-arc/*` → zh-tw；arcadyan GitLab → en_US。涵蓋 PR 標題／內文與所有 comment。本 repo 屬 `hamanpaul` → zh-tw。
+- **動工前（軟性，不打斷流程）**：若任務對應某 issue，`gh issue view <N>` 核對相關性後分支可命名 `feature/<N>-<slug>`，開 PR 於 body 寫 `Closes #N`；查無對應 issue 照常進行，不另開、不停。
+- **Exemption 白名單新增**：`policy-exempt:issue-link`（R-17）、`policy-exempt:docs-sync`（R-18）。

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
-<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.0 -->
+<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.1 -->
 <!-- 若修改此檔，同步更新 CLAUDE.md / AGENTS.md / GEMINI.md / .github/copilot-instructions.md 四份 -->
-policy_version: 1.0.0
+policy_version: 1.0.1
 <!-- policy_version 為 policy_check R-14 machine-readable marker；需保持裸行格式，請勿移入 frontmatter 或 code block。 -->
 
 # serialwrap — AI Agent Policy Checklist
@@ -37,11 +37,11 @@ policy_version: 1.0.0
   ```bash
   python3 -m policy_check --repo .
   ```
-- policy engine pinned SHA：`ff1a031172ec24fc155699f9f3ce5bdea24d9e24`。
+- policy engine pinned SHA：`4ff59b6c35a46a87af3c3e641975743ee8fa0858`。
 - 安裝命令：
   ```bash
   python3 -m pip install --user --disable-pip-version-check \
-    "git+https://github.com/hamanpaul/paulsha-conventions.git@ff1a031172ec24fc155699f9f3ce5bdea24d9e24"
+    "git+https://github.com/hamanpaul/paulsha-conventions.git@4ff59b6c35a46a87af3c3e641975743ee8fa0858"
   ```
 
 ## Agent 檔案同步政策
@@ -53,7 +53,7 @@ policy_version: 1.0.0
   - `.github/copilot-instructions.md`（marker 區段）
 - 檔案首行必須保留：
   ```
-  <!-- managed-by: hamanpaul/paulsha-conventions@v1.0.0 -->
+  <!-- managed-by: hamanpaul/paulsha-conventions@v1.0.1 -->
   ```
 
 ## PR 政策
@@ -89,3 +89,12 @@ policy_version: 1.0.0
   ```
   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
   ```
+
+## v1.0.1 新增規則（issue 連結 / docs 對齊 / 語言）
+> 本段於 policy 1.0.1 隨 R-17 / R-18 與語言規範新增。
+
+- **R-17（PR↔issue，FAIL gate）**：PR body 引用 issue（`#N`）時必須為 closing-keyword 形式（`Closes` / `Fixes` / `Resolves #N`），merge 由 GitHub 原生自動關閉 issue 並留下 cross-reference；只引用不關閉時上 `policy-exempt:issue-link`。
+- **R-18（docs 對齊，WARN，不擋 merge）**：`code_paths` 有變動但 `README.md` / `docs/**` 未同步時提醒；純內部變動可上 `policy-exempt:docs-sync`。
+- **語言規範（checklist）**：依 repo 來源決定語言——`github.com/hamanpaul/*`、`github.com/paulc-arc/*` → zh-tw；arcadyan GitLab → en_US。涵蓋 PR 標題／內文與所有 comment。本 repo 屬 `hamanpaul` → zh-tw。
+- **動工前（軟性，不打斷流程）**：若任務對應某 issue，`gh issue view <N>` 核對相關性後分支可命名 `feature/<N>-<slug>`，開 PR 於 body 寫 `Closes #N`；查無對應 issue 照常進行，不另開、不停。
+- **Exemption 白名單新增**：`policy-exempt:issue-link`（R-17）、`policy-exempt:docs-sync`（R-18）。


### PR DESCRIPTION
## Summary
- [x] 同步 policy 1.0.1：bump `policy_version` 1.0.0→1.0.1，caller workflow `uses:` 與 `policy_engine_ref` 重新釘選至 `paulsha-conventions@4ff59b6`（含 R-17/R-18）
- [x] agent 檔追加 R-17（PR↔issue closing-keyword）、R-18（docs 對齊 WARN）與語言規範說明

## Issue Link
- [x] 本 PR 無對應 issue（已評估）

## Changelog
- [x] 已更新 `CHANGELOG.md [Unreleased]`

## Docs
- [x] 本 PR 為 policy metadata 同步，無 user-facing 文件需更新（R-18 為 WARN、非阻擋）

## Validation
- [x] policy_check（新引擎）0 fail（R-18 WARN 非阻擋）

## Branch and Policy
- [x] 來源分支符合 policy（feature/*）
- [x] 未直接 push 到 main
- [x] 未新增未列入白名單的 exemption label

## Notes
- Changelog 處理方式：已更新
