### PR TITLE
chore(security): brcm.env 改範本並停止追蹤，gitignore profiles/*.env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ htmlcov/
 .coverage
 *.log
 *.tmp
+
+# 本機憑證 profile（真值不提交；範本見 profiles/*.env.example）
+profiles/*.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - 修正 broker minicom 正常或非 0 結束時可能因 shell 被 `exec` 取代而跳過 `session console-detach` 的 lifecycle cleanup 風險。
 
+### Security
+
+- 將 `profiles/brcm.env`（含 `BRCM_USER` / `BRCM_PASS`）改為 `profiles/brcm.env.example` 範本並停止追蹤；`.gitignore` 新增 `profiles/*.env`，避免本機憑證 profile 被提交。實際憑證由使用者複製範本後在本機填入（`profiles/default.yaml` 的 brcm-template 仍以 `env_file: brcm.env` 載入）。
+
 ## [0.1.0] - 2026-05-15
 
 ### Added

--- a/profiles/brcm.env
+++ b/profiles/brcm.env
@@ -1,2 +1,0 @@
-BRCM_USER=admin
-BRCM_PASS=admin

--- a/profiles/brcm.env.example
+++ b/profiles/brcm.env.example
@@ -1,0 +1,5 @@
+# 範本：複製為 profiles/brcm.env 並填入實際 Broadcom 登入憑證。
+# profiles/brcm.env 已由 .gitignore 排除，不會被提交。
+# profiles/default.yaml 的 brcm-template 以 env_file: brcm.env 載入此檔。
+BRCM_USER=<your-brcm-user>
+BRCM_PASS=<your-brcm-pass>


### PR DESCRIPTION
## 目的

帳號可見性計畫 S1（機密清掃）：serialwrap 是 `tier: shareable`、維持 public，但 `profiles/brcm.env`（`BRCM_USER` / `BRCM_PASS`）以明文被 git 追蹤。本 PR 將其改為範本並停止追蹤，避免本機憑證 profile 被提交。

> 來源：account-visibility openspec change（`hamanpaul/paulsha-conventions`）tasks §4 / S1。

## 變更

- 新增 `profiles/brcm.env.example` 範本（值為占位符 + 使用說明）。
- `git rm --cached profiles/brcm.env` 停止追蹤（本機檔保留，由 gitignore 排除）。
- `.gitignore` 新增 `profiles/*.env`。
- `CHANGELOG.md [Unreleased]` 加 Security 條目。

實際值僅為預設 `admin/admin`（非真實機密），故未做憑證 rotate（經確認）。`profiles/default.yaml` 的 brcm-template 仍以 `env_file: brcm.env` 載入，使用者複製範本後本機填入即可。

## 驗收

- `git ls-files | grep -E '\.env$'` → 空（無 tracked `.env`）。
- 本機 `profiles/brcm.env` 仍在且 `git check-ignore` 確認已排除。
- `python3 -m pytest -q tests/` → **427 passed**（無新失敗）。
- unit test 用 tmp fixture、func-test 內嵌自己的 inline brcm.env、CI 僅 policy-check → 停止追蹤不影響測試/CI。

## Policy Checklist（R-11）

- [x] 分支不是 `main`（`feature/serialwrap-brcm-env-example`）
- [x] `CHANGELOG.md` 已更新（Security）
- [ ] `VERSION` 已更新 — N/A（無版本號變動）
- [x] `python3 -m pytest -q tests/` 通過（無新失敗）
- [ ] `python3 -m policy_check --repo .` — 見下方 R-19 說明
- [ ] 四份 agent 檔案已同步 — N/A（未修改）

## R-19（pre-existing，非本 PR 造成）

`policy_check` 唯一 fail 為 **R-19**：「`tests/` 有測試但無 CI workflow 執行（缺 pytest workflow）」。serialwrap 目前只有 `.github/workflows/policy-check.yml`，**此狀況在本 PR 之前已存在**（本 PR 未動 `tests/` 或 workflow）。serialwrap policy 1.0.1 的 exemption 白名單也未列 R-19 對應 label。建議**另開 PR 補一個跑 pytest 的 CI workflow** 來修 R-19，不混入本次 secret-hygiene 變更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
