### PR TITLE
ci(tests): 新增 pytest workflow 在 PR 執行測試（修補 R-19）

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: Tests
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: 安裝測試相依
+        run: python3 -m pip install --disable-pip-version-check pytest pyyaml
+      - name: 執行測試套件
+        run: python3 -m pytest -q tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- 新增 `.github/workflows/tests.yml`：在 PR 上以 `python3 -m pytest -q tests/` 執行測試套件（修補 R-19：repo 有 `tests/` 但無 CI 執行測試）。
+
 ### Changed
 
 - **同步 policy 1.0.1**：`policy_version` 1.0.0 → 1.0.1（`.paul-project.yml` + 四份 agent 檔 + `managed-by@v1.0.1` + agent 檔內 engine pinned SHA），caller `policy-check` workflow 的 `uses:` 與 `policy_engine_ref` 重新雙重釘選至 `hamanpaul/paulsha-conventions@4ff59b6c35a46a87af3c3e641975743ee8fa0858`（含 R-17 / R-18）；agent 檔追加 R-17 / R-18 與語言規範說明


### PR DESCRIPTION
## 目的

修補 **R-19**（pre-existing）：serialwrap 有 `tests/`（427 tests）但 CI 沒有任何 workflow 執行它們（先前只有 `policy-check.yml`）。本 PR 新增一個跑 pytest 的 CI workflow。延續先前的 secret 清掃（serialwrap，已合併的 PR 編號 56），R-19 在那次已標示為 pre-existing、另案處理。

## 變更

- 新增 `.github/workflows/tests.yml`：`on: [pull_request]`，在 Python 3.12 安裝 `pytest` + `pyyaml`，執行 `python3 -m pytest -q tests/`。
- `CHANGELOG.md [Unreleased]` 加 Added 條目。

相依僅 `pytest` + `pyyaml`（其餘皆 stdlib；「subtests」為 unittest `self.subTest`，不需 pytest-subtests 外掛）。

## 驗收

- 本 PR 的 `pytest` CI job 已綠（在 GitHub runner 實跑 427 passed）。
- `python3 -m policy_check --repo .` → **0 fail**（R-19 由本 workflow 滿足、R-09 CHANGELOG pass）。

## Policy Checklist（R-11）

- [x] 分支不是 `main`（`feature/serialwrap-r19-pytest-ci`）
- [x] `CHANGELOG.md` 已更新（Added）
- [x] `VERSION` 已更新 — N/A（無版本號變動）
- [x] `python3 -m pytest -q tests/` 通過（427 passed，無新失敗）
- [x] `python3 -m policy_check --repo .` 通過（0 fail）
- [x] 四份 agent 檔案已同步 — N/A（未修改）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
