### PR TITLE
docs: #61 review 後續 — CHANGELOG/bootloader 文件 cosmetic 修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - **同步 policy 1.0.1**：`policy_version` 1.0.0 → 1.0.1（`.paul-project.yml` + 四份 agent 檔 + `managed-by@v1.0.1` + agent 檔內 engine pinned SHA），caller `policy-check` workflow 的 `uses:` 與 `policy_engine_ref` 重新雙重釘選至 `hamanpaul/paulsha-conventions@4ff59b6c35a46a87af3c3e641975743ee8fa0858`（含 R-17 / R-18）；agent 檔追加 R-17 / R-18 與語言規範說明
 - `tools/minicom_router.sh` 的 broker minicom 自動 transcript 預設改為 `script -qef` wrapper，不再預設把 `-C` 傳給 minicom；新增 `MINICOM_CAPTURE_MODE=script|minicom|off` 控制模式，`MINICOM_CAPTURE_MODE=minicom` 才明確 opt-in 使用原生 capture。
-- **採用 policy 1.0.4**：`policy_version` 1.0.1 → 1.0.4（`.paul-project.yml` + 四份 agent 檔 + workflow `uses:`/`policy_engine_ref` 重釘至 `hamanpaul/paulsha-conventions@v1.0.4`（SHA `77a3e83`）；`.paul-project.yml` 宣告 `tier: shareable`。
+- **採用 policy 1.0.4**：`policy_version` 1.0.1 → 1.0.4（`.paul-project.yml` + 四份 agent 檔 + workflow `uses:`/`policy_engine_ref` 重釘至 `hamanpaul/paulsha-conventions@v1.0.4`，SHA `77a3e83`）；`.paul-project.yml` 宣告 `tier: shareable`。
 
 ### Security
 

--- a/docs/superpowers/plans/2026-05-07-issue-44-bootloader-recovery-and-conventions.md
+++ b/docs/superpowers/plans/2026-05-07-issue-44-bootloader-recovery-and-conventions.md
@@ -2489,7 +2489,7 @@ Closes #44. Adds an agent-driven bootloader recovery interactive lease that pres
 - [x] `python3 -m pytest -q tests/` green (new file: `tests/test_bootloader_recovery.py` with 20+ scenarios)
 - [x] `python3 -m policy_check --repo .` green (R-01 ~ R-16)
 - [x] `openspec validate 2026-05-07-bootloader-recovery-44 --strict` green
-- [ ] Manual hardware verification on Broadcom CFE 平台 in U-Boot (see PR body / commit messages)
+- [ ] Manual hardware verification on a Broadcom CFE platform in U-Boot (see PR body / commit messages)
 
 ## Policy Checklist (R-11)
 

--- a/openspec/changes/archive/2026-05-08-2026-05-07-bootloader-recovery-44/design.md
+++ b/openspec/changes/archive/2026-05-08-2026-05-07-bootloader-recovery-44/design.md
@@ -50,7 +50,7 @@ bootloader_prompts:                  # 新增；opt-in；預設 []
 ### 2.2 文件位置
 
 - profile schema 文件：`docs/serialwrap-spec.md`（profile 章節）。
-- 第一波 vendor profile 至少補：Broadcom CFE 平台+ 一個 Marvell 平台（若 repo 已有）。
+- 第一波 vendor profile 至少補：一個 Broadcom CFE 平台 + 一個 Marvell 平台（若 repo 已有）。
 
 ## 3. `SessionManager.self_test` 行為
 


### PR DESCRIPTION
## 目的

PR 61（policy 1.0.4 採用）的 code review 後續 tidy：修掉 blanket-sed 留下的 3 處 cosmetic 缺陷（非功能性，policy/CI 皆已綠）。這些修正原應併入 PR 61，但 squash 時漏 stage 而未進；以此 follow-up 補上。

## 變更（純文件/CHANGELOG）

- `CHANGELOG.md [Unreleased]`「採用 policy 1.0.4」條目：括號不對稱 → 補正。
- `openspec/changes/archive/.../bootloader-recovery-44/design.md:53`：`Broadcom CFE 平台+ 一個 Marvell` → 補空格 `一個 Broadcom CFE 平台 + 一個 Marvell 平台`。
- `docs/superpowers/plans/...issue-44...:2492`：中英混排 → 純英文 `a Broadcom CFE platform`。

## 驗收

- `python3 -m policy_check --repo .` → 0 fail / 0 warn。
- 無 code 變動（docs/CHANGELOG only）。

## Policy Checklist（R-11）

- [x] 分支不是 `main`（`fix/serialwrap-changelog-doc-tidy`）
- [x] `CHANGELOG.md` 已更新（修正既有條目）
- [x] `VERSION` 已更新 — N/A
- [x] `python3 -m pytest -q tests/` — N/A（docs-only，未動 code）
- [x] `python3 -m policy_check --repo .` 通過（0 fail）
- [x] 四份 agent 檔已同步 — N/A（未修改）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
