### PR TITLE
fix(setup): systemd-system 改 run-as-user 使 pipx 安裝可實際啟動，install 在 WSL 自動啟用 systemd (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-06-23
+### Fixed
+
+- **systemd-system 模式可在 pipx 使用者安裝下實際啟動（#76）**：原 system unit 寫死 `User=serialwrap` dedicated account 且 `ExecStart=/usr/local/bin/serialwrapd`，但 pipx 只把 serialwrapd 裝到安裝者家目錄 venv（`~/.local/bin/serialwrapd`）、且 install 從未建立 `serialwrap` 帳號 → `setup --system` 起不來。改為 **run-as-user**：`render_system_unit(exec_start, run_user=...)` 參數化 `User=`，`setup_cmd` 以 `_resolve_run_user()`（`SUDO_USER`→`getpass.getuser()`）帶安裝者本人帳號、`_resolve_serialwrapd_path()` 解析其 pipx serialwrapd 絕對路徑組 ExecStart。保留「非 root + dialout」安全邊界，socket 仍於 `/run/serialwrap`（不受 WSLg `/run/user` 遮蔽、不依賴脆弱的 `user@<uid>`）。
+
+### Added
+
+- **`serialwrap setup` 在 WSL 上主動啟用 systemd（#76）**：新增 `ensure_wsl_systemd()`——偵測到 WSL 但 systemd 尚未啟用時，合併寫入 `/etc/wsl.conf` `[boot] systemd=true`（保留既有段落／鍵，經 staging + `sudo install`，不破壞性丟棄無法解析內容），並早退提示使用者於 Windows 端 `wsl --shutdown` 重啟後再跑 `setup --system`。非 WSL 或 systemd 已啟用 → no-op。新增 `tests/test_wsl_systemd.py` 與 system unit run-as-user 測試。
+
 
 ### Added
 

--- a/sw_core/cli.py
+++ b/sw_core/cli.py
@@ -14,7 +14,14 @@ from .constants import CONFIG_DIR, LOCK_PATH, PROFILE_DIR, SOCKET_PATH
 from .doctor_cmd import run_doctor
 from .runtime_config import RuntimeConfig
 from .service_ctl import service_action
-from .setup_cmd import SYSTEM_SOCKET, FlashingBusy, detect_legacy_install, materialize_assets, reconcile
+from .setup_cmd import (
+    SYSTEM_SOCKET,
+    FlashingBusy,
+    detect_legacy_install,
+    ensure_wsl_systemd,
+    materialize_assets,
+    reconcile,
+)
 
 _USE_DEFAULT_ENV = object()
 LEGACY_DAEMON_ENV_FILE = "~/OPI.env"
@@ -334,6 +341,21 @@ def _run_setup(args: argparse.Namespace) -> int:
 
     # 5. 物化套件資產到使用者可寫位置。
     materialize_assets(force=args.force)
+
+    # 5b. WSL 偵測：若在 WSL 但 systemd 尚未啟用，主動寫 /etc/wsl.conf [boot] systemd=true，
+    #     並早退提示使用者 `wsl --shutdown` 重啟後再跑 setup（systemd 須重進 WSL 才生效，
+    #     當次無法直接起 systemd 服務）。已啟用或非 WSL → no-op，照常往下走。
+    wsl_info = ensure_wsl_systemd(fx, os.path.expanduser("~"))
+    if wsl_info.get("needs_restart"):
+        _print({
+            "ok": True,
+            "legacy": legacy,
+            "wsl_systemd_enabled": True,
+            "needs_restart": True,
+            "requested_mode": target,
+            "hint": wsl_info.get("hint"),
+        })
+        return 0
 
     # 6. 有效 socket：systemd-system 走系統固定 socket，其餘走使用者 XDG 預設（Codex #1a/#1b）。
     effective_socket = SYSTEM_SOCKET if target == "systemd-system" else SOCKET_PATH

--- a/sw_core/setup_cmd.py
+++ b/sw_core/setup_cmd.py
@@ -13,6 +13,8 @@
 
 from __future__ import annotations
 
+import configparser
+import getpass
 import importlib.resources
 import os
 import shutil
@@ -245,7 +247,90 @@ _SYSTEM_UNIT_PATH = "/etc/systemd/system/serialwrap.service"
 # 與 daemon --profile-dir 一致對齊（Codex #1a/#1b）。
 SYSTEM_SOCKET = "/run/serialwrap/serialwrapd.sock"
 SYSTEM_PROFILE_DIR = "/etc/serialwrap/profiles"
-_SYSTEM_EXEC_START = f"/usr/local/bin/serialwrapd --socket {SYSTEM_SOCKET} --profile-dir {SYSTEM_PROFILE_DIR}"
+
+
+def _resolve_run_user() -> str:
+    """解析 system unit 的執行身份（``User=``）。
+
+    pipx 使用者安裝下 serialwrapd binary 落在安裝者 venv（家目錄內），dedicated
+    ``serialwrap`` service account 讀不到該家目錄，故 system unit 改以「安裝者本人」
+    執行。優先取 ``SUDO_USER``（``sudo serialwrap setup`` 時為原始使用者），否則取
+    目前登入帳號。
+    """
+    return os.environ.get("SUDO_USER") or getpass.getuser()
+
+
+def _resolve_serialwrapd_path(home: Path) -> str:
+    """解析 system unit ExecStart 用的 serialwrapd 絕對路徑（pipx 使用者安裝）。
+
+    ExecStart 不能用 ``%h``（system unit 無使用者 home 展開），故解析成絕對路徑：
+    優先 ``which serialwrapd``（pipx shim，通常 ``~/.local/bin/serialwrapd``），
+    否則退回 ``home/.local/bin/serialwrapd``。
+    """
+    return shutil.which("serialwrapd") or str(home / ".local" / "bin" / "serialwrapd")
+
+
+def _system_exec_start(home: Path) -> str:
+    """組出 system unit 的 ExecStart（絕對 serialwrapd + 固定 socket/profile-dir）。"""
+    return f"{_resolve_serialwrapd_path(home)} --socket {SYSTEM_SOCKET} --profile-dir {SYSTEM_PROFILE_DIR}"
+
+
+def _merge_wsl_conf_systemd(existing: str) -> str:
+    """把現有 /etc/wsl.conf 內容合併出含 ``[boot] systemd=true`` 的版本（保留其他段落/鍵）。"""
+    import io
+
+    cp = configparser.ConfigParser()
+    cp.optionxform = str  # 保留鍵大小寫（wsl.conf 鍵大小寫敏感）
+    try:
+        cp.read_string(existing)
+    except configparser.Error:
+        # 既有檔不合法時不沿用，改寫成只含 [boot] 的乾淨版本（不破壞性丟棄無法解析內容）。
+        cp = configparser.ConfigParser()
+        cp.optionxform = str
+    if not cp.has_section("boot"):
+        cp.add_section("boot")
+    cp.set("boot", "systemd", "true")
+    buf = io.StringIO()
+    cp.write(buf)
+    return buf.getvalue()
+
+
+def ensure_wsl_systemd(fx, home) -> dict:
+    """WSL 上若 systemd 尚未啟用，寫 ``/etc/wsl.conf`` ``[boot] systemd=true``（需 sudo）。
+
+    - 非 WSL → no-op（``{"wsl": False}``）。
+    - 已啟用 systemd（``has_systemd``）→ no-op（``already=True``）。
+    - 需啟用 → staging + ``sudo install`` 寫 ``/etc/wsl.conf``，回報需於 Windows 端
+      ``wsl --shutdown`` 重啟（systemd 須重進 WSL 才生效，當次 setup 無法直接起 systemd 服務）。
+
+    以 Effects.run 經過 sudo install（非直接 sudo tee，避免空檔）。回傳結果字典供
+    cli 決定是否早退並提示使用者重啟。
+    """
+    if not fx.is_wsl():
+        return {"wsl": False, "already": False, "enabled_now": False, "needs_restart": False}
+    if fx.has_systemd():
+        return {"wsl": True, "already": True, "enabled_now": False, "needs_restart": False}
+    home = Path(home)
+    try:
+        existing = Path("/etc/wsl.conf").read_text(encoding="utf-8")
+    except OSError:
+        existing = ""
+    merged = _merge_wsl_conf_systemd(existing)
+    staging = home / ".local" / "share" / "serialwrap" / "wsl.conf"
+    staging.parent.mkdir(parents=True, exist_ok=True)
+    staging.write_text(merged, encoding="utf-8")
+    rc, _out, _err = fx.run(["sudo", "install", "-m", "0644", str(staging), "/etc/wsl.conf"])
+    return {
+        "wsl": True,
+        "already": False,
+        "enabled_now": rc == 0,
+        "needs_restart": rc == 0,
+        "rc": rc,
+        "hint": (
+            "已寫入 /etc/wsl.conf [boot] systemd=true；請在 Windows 端執行 "
+            "`wsl --shutdown`，重新進入 WSL 後再跑一次 `serialwrap setup --system --with-sudo`。"
+        ),
+    }
 
 
 def _stage_system_unit(home: Path) -> Path:
@@ -253,10 +338,14 @@ def _stage_system_unit(home: Path) -> Path:
 
     以 staging + ``sudo install`` 取代直接 ``sudo tee``：Effects.run 不帶 stdin，直接
     ``sudo tee`` 會寫出空檔；staging 讓非特權步驟先備妥真實內容，特權步驟只做複製。
+    unit 以安裝者本人帳號執行（run-as-user），ExecStart 指向其 pipx serialwrapd。
     """
     staging = home / ".local" / "share" / "serialwrap" / "serialwrap.service"
     staging.parent.mkdir(parents=True, exist_ok=True)
-    staging.write_text(render_system_unit(_SYSTEM_EXEC_START), encoding="utf-8")
+    staging.write_text(
+        render_system_unit(_system_exec_start(home), run_user=_resolve_run_user()),
+        encoding="utf-8",
+    )
     return staging
 
 

--- a/sw_core/systemd_units.py
+++ b/sw_core/systemd_units.py
@@ -39,16 +39,19 @@ RestartSec=2
 WantedBy=default.target"""
 
 
-def render_system_unit(exec_start: str) -> str:
+def render_system_unit(exec_start: str, run_user: str = "serialwrap") -> str:
     """
     產生 system scope（/etc/systemd/system/）的 serialwrap daemon unit 內容。
 
-    執行身份為 ``serialwrap`` service account，附加 ``dialout`` 群組以存取
+    執行身份為 ``run_user``（預設 ``serialwrap`` service account；pipx 使用者安裝
+    流程會帶入「安裝者本人的帳號」，因為 serialwrapd binary 落在該使用者 venv，
+    dedicated service account 讀不到其家目錄）。附加 ``dialout`` 群組以存取
     /dev/ttyUSB* 等 UART 裝置。
 
     Args:
         exec_start: ExecStart 指令字串，例如
-            ``/usr/local/bin/serialwrapd --socket /run/serialwrap/serialwrapd.sock``。
+            ``/home/<user>/.local/bin/serialwrapd --socket /run/serialwrap/serialwrapd.sock``。
+        run_user: service 執行身份（``User=``）；WSL／pipx 使用者安裝下為安裝者本人。
 
     Returns:
         完整的 systemd unit 檔案文字（不含尾端換行）。
@@ -62,7 +65,7 @@ After=multi-user.target
 
 [Service]
 Type=simple
-User=serialwrap
+User={run_user}
 SupplementaryGroups=dialout
 RuntimeDirectory=serialwrap
 StateDirectory=serialwrap

--- a/tests/test_codex_fixes.py
+++ b/tests/test_codex_fixes.py
@@ -31,7 +31,9 @@ def test_resolve_endpoint_uses_config_socket_when_socket_not_overridden(tmp_path
 # ── #1b：system unit ExecStart 帶 --profile-dir，且 install 會把 profiles 放到 /etc ──
 def test_system_exec_start_and_install_cover_profiles(tmp_path):
     from sw_core import setup_cmd as sc
-    assert "--profile-dir /etc/serialwrap/profiles" in sc._SYSTEM_EXEC_START
+    # #76：ExecStart 改由 _system_exec_start(home) 動態組（run-as-user pipx 路徑），
+    # 仍須帶固定 system --profile-dir。
+    assert "--profile-dir /etc/serialwrap/profiles" in sc._system_exec_start(Path(tmp_path))
     cmds = sc._system_install_cmds(Path(tmp_path), include_start=True)
     flat = [" ".join(c) for c in cmds]
     assert any("/etc/serialwrap/profiles" in f and "cp" in f for f in flat), flat

--- a/tests/test_setup_reconcile.py
+++ b/tests/test_setup_reconcile.py
@@ -102,16 +102,21 @@ def test_system_no_sudo_does_not_write_config_or_diverge(tmp_path):
 
 
 def test_system_with_sudo_installs_real_unit_content(tmp_path):
-    """I-2：system 模式帶 sudo → staging 寫出真實 unit 內容（非空檔），並以 sudo install 安裝。"""
+    """I-2：system 模式帶 sudo → staging 寫出真實 unit 內容（非空檔），並以 sudo install 安裝。
+
+    run-as-user（#76）：system unit 以安裝者本人帳號執行（非 serialwrap dedicated account），
+    ExecStart 指向其 pipx serialwrapd 絕對路徑 + 固定 system socket/profile-dir。
+    """
     from sw_core.sysenv import FakeEffects
-    from sw_core.setup_cmd import reconcile
+    from sw_core.setup_cmd import reconcile, _resolve_run_user, SYSTEM_SOCKET, SYSTEM_PROFILE_DIR
     fx = FakeEffects(systemd=True)
     reconcile(old_mode="on-demand", target_mode="systemd-system", fx=fx, home=tmp_path,
               daemon_running=False, with_sudo=True)
     staging = tmp_path / ".local" / "share" / "serialwrap" / "serialwrap.service"
     assert staging.is_file()
     content = staging.read_text(encoding="utf-8")
-    assert "User=serialwrap" in content and "ExecStart=" in content  # 真實 system unit
+    assert f"User={_resolve_run_user()}" in content          # run-as-user，非 serialwrap account
+    assert f"serialwrapd --socket {SYSTEM_SOCKET} --profile-dir {SYSTEM_PROFILE_DIR}" in content
     assert any(c[:2] == ["sudo", "install"] for c in fx.calls)
 
 

--- a/tests/test_systemd_units.py
+++ b/tests/test_systemd_units.py
@@ -25,3 +25,13 @@ def test_system_unit_runs_service_account_in_dialout():
 def test_exec_start_is_parameterized():
     from sw_core.systemd_units import render_user_unit
     assert "ExecStart=/custom/path/serialwrapd" in render_user_unit(exec_start="/custom/path/serialwrapd")
+
+
+def test_system_unit_run_user_parameterized():
+    """#76：system unit 的 User= 可帶安裝者本人帳號（run-as-user，pipx 使用者安裝）。"""
+    from sw_core.systemd_units import render_system_unit
+    text = render_system_unit(exec_start="/opt/serialwrap/serialwrapd", run_user="svcuser")
+    assert "User=svcuser" in text
+    assert "User=serialwrap" not in text
+    assert "SupplementaryGroups=dialout" in text
+    assert "ExecStart=/opt/serialwrap/serialwrapd" in text

--- a/tests/test_wsl_systemd.py
+++ b/tests/test_wsl_systemd.py
@@ -1,0 +1,57 @@
+"""tests/test_wsl_systemd.py — #76 WSL systemd 自動啟用（ensure_wsl_systemd）。"""
+import configparser
+
+from sw_core.setup_cmd import _merge_wsl_conf_systemd, ensure_wsl_systemd
+from sw_core.sysenv import FakeEffects
+
+
+def _parse(text: str) -> configparser.ConfigParser:
+    cp = configparser.ConfigParser()
+    cp.optionxform = str
+    cp.read_string(text)
+    return cp
+
+
+def test_merge_empty_adds_boot_systemd():
+    cp = _parse(_merge_wsl_conf_systemd(""))
+    assert cp.get("boot", "systemd") == "true"
+
+
+def test_merge_preserves_existing_sections():
+    existing = "[automount]\nenabled = true\n\n[network]\ngenerateResolvConf = true\n"
+    cp = _parse(_merge_wsl_conf_systemd(existing))
+    assert cp.get("boot", "systemd") == "true"
+    assert cp.get("automount", "enabled") == "true"
+    assert cp.get("network", "generateResolvConf") == "true"
+
+
+def test_merge_existing_boot_section_keeps_other_keys():
+    existing = "[boot]\ncommand = echo hi\n"
+    cp = _parse(_merge_wsl_conf_systemd(existing))
+    assert cp.get("boot", "systemd") == "true"
+    assert cp.get("boot", "command") == "echo hi"
+
+
+def test_ensure_non_wsl_is_noop():
+    fx = FakeEffects(wsl=False, systemd=False)
+    r = ensure_wsl_systemd(fx, "/home/x")
+    assert r["wsl"] is False and r["needs_restart"] is False
+    assert fx.calls == []
+
+
+def test_ensure_wsl_with_systemd_already_enabled_noop(tmp_path):
+    fx = FakeEffects(wsl=True, systemd=True)
+    r = ensure_wsl_systemd(fx, tmp_path)
+    assert r == {"wsl": True, "already": True, "enabled_now": False, "needs_restart": False}
+    assert fx.calls == []
+
+
+def test_ensure_wsl_without_systemd_writes_conf_and_needs_restart(tmp_path):
+    """WSL 但 systemd 未啟用 → 寫 staging wsl.conf（含 [boot] systemd=true）+ sudo install + 需重啟。"""
+    fx = FakeEffects(wsl=True, systemd=False)
+    r = ensure_wsl_systemd(fx, tmp_path)
+    assert r["enabled_now"] is True and r["needs_restart"] is True
+    staging = tmp_path / ".local" / "share" / "serialwrap" / "wsl.conf"
+    assert staging.is_file()
+    assert _parse(staging.read_text(encoding="utf-8")).get("boot", "systemd") == "true"
+    assert any(c[:2] == ["sudo", "install"] and c[-1] == "/etc/wsl.conf" for c in fx.calls)


### PR DESCRIPTION
## Summary

修正 **systemd-system 監管模式在 pipx 使用者安裝下根本起不來** 的問題，並讓 `serialwrap setup` 在 **WSL 偵測到 systemd 未啟用時主動啟用**。動機見 #76（WSL2 上 systemd-user 每次重開機都壞——`user@<uid>` timeout + WSLg 在 `/run/user/1000` 疊 tmpfs 遮蔽 socket）。改用可靠的 **system systemd（PID 1）+ run-as-user**，socket 落 `/run/serialwrap`（不受 WSLg 遮蔽、不依賴 user manager），達成可靠開機自動起。

### 變更
- **run-as-user system unit**：`render_system_unit(exec_start, run_user=...)` 參數化 `User=`；`setup_cmd` 以 `_resolve_run_user()`（`SUDO_USER`→`getpass.getuser()`）帶安裝者本人帳號、`_resolve_serialwrapd_path()` 解析其 pipx serialwrapd 絕對路徑組 ExecStart。原寫死的 `User=serialwrap` + `/usr/local/bin/serialwrapd` 在 pipx 使用者安裝下無對應帳號／binary，故 `setup --system` 必定起不來——這是核心修正。保留「非 root + dialout」安全邊界。
- **WSL systemd 自動啟用**：新增 `ensure_wsl_systemd()`，WSL 且 systemd 未啟用時合併寫 `/etc/wsl.conf` `[boot] systemd=true`（保留既有段落／鍵、staging + `sudo install`），早退提示 `wsl --shutdown`。`cli._run_setup` 接線。非 WSL／已啟用 → no-op。

## Test Plan

- [x] 執行 `python3 -m pytest -q tests/` — 無新增失敗（8 個既有失敗：`test_multiagent_e2e`（CLAUDE.md 載明的 pre-existing）、`test_human_agent_coexist` t2–t8（已 `git stash` 在 base main 重現相同 `READY 20s timeout`，屬本機環境 pre-existing；本 PR 僅改 install-time 程式碼，不被 runtime daemon 匯入）。新增/相關 install 測試全綠。）
- [x] 執行 `python3 -m policy_check --repo .` — 通過（R-21 已修；R-22 為 81 筆 pre-existing dangling 之 advisory warn）
- [x] 實機 dogfood：`serialwrap setup --system --with-sudo` → `serialwrap.service` active（`/system.slice`）、run-as-user 持有 ttyUSB0、socket `/run/serialwrap`、`is-enabled`=enabled、restart 後回 READY、`session self-test` OK／probe_ok=true。

## Policy Checklist (R-11)

- [x] 分支不是 `main`（`feature/76-systemd-system-wsl`）
- [x] `CHANGELOG.md` 已更新（`[Unreleased]`）
- [x] `VERSION` 不適用（本 PR 非 release，無版本號變動）
- [x] `python3 -m pytest -q tests/` 通過（無新失敗，詳 Test Plan）
- [x] `python3 -m policy_check --repo .` 通過
- [x] 四份 agent 檔案無修改（不適用）
- [x] 無適用 exemption label（不需豁免）

## Issue Reference

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
