### PR TITLE
fix(minicom): 復原 broker auto-capture 預設為原生 -C（症狀2）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@
 - **command_capable 改以 ready_probe 為準（#51）**：`_attach_by_id` / `_attach_by_id_dynamic` / `_probe_existing_bridge` 不再以 `platform == "passthrough"` 寫死 `ok=False`，改以 `profile.command_capable` 判定——有設 `ready_probe` 的 target（含 passthrough）能走正常 probe 進 `READY`，無 `ready_probe` 者維持 `ATTACHED`。
 
 - **同步 policy 1.0.1**：`policy_version` 1.0.0 → 1.0.1（`.paul-project.yml` + 四份 agent 檔 + `managed-by@v1.0.1` + agent 檔內 engine pinned SHA），caller `policy-check` workflow 的 `uses:` 與 `policy_engine_ref` 重新雙重釘選至 `hamanpaul/paulsha-conventions@4ff59b6c35a46a87af3c3e641975743ee8fa0858`（含 R-17 / R-18）；agent 檔追加 R-17 / R-18 與語言規範說明
-- `tools/minicom_router.sh` 的 broker minicom 自動 transcript 預設改為 `script -qef` wrapper，不再預設把 `-C` 傳給 minicom；新增 `MINICOM_CAPTURE_MODE=script|minicom|off` 控制模式，`MINICOM_CAPTURE_MODE=minicom` 才明確 opt-in 使用原生 capture。
+- `tools/minicom_router.sh` 的 broker minicom 自動 transcript **預設維持 minicom 內建 `-C`**（乾淨序列 log）；新增 `MINICOM_CAPTURE_MODE=script|minicom|off` 控制模式，`script` 為顯式 opt-in 的完整終端 transcript。（修正先前一度把預設改為 `script` 導致 `mini_*.log` 夾帶 minicom UI ANSI 的回歸；查證「`-C` native crash」無實證。）
 - **採用 policy 1.0.4**：`policy_version` 1.0.1 → 1.0.4（`.paul-project.yml` + 四份 agent 檔 + workflow `uses:`/`policy_engine_ref` 重釘至 `hamanpaul/paulsha-conventions@v1.0.4`，SHA `77a3e83`）；`.paul-project.yml` 宣告 `tier: shareable`。
 - **強化 CLI help（`sw_core/cli.py`）**：為全部命令群組（`daemon`/`device`/`session`/`alias`/`cmd`/`stream`/`log`/`file`/`wal`/`event`）補上 `help=` 摘要與 `description=`，並為每個子命令（含先前看不到的 `recover`/`self-test`/`release`/`attach` 等）補繁中 `help=`；子命令選單 `metavar` 由冗長的 `{...}` 改為 `<group>`／`<command>`，`event` 既有英文 help 一併改為繁中；同步重生 `README.md` `## Usage` 的 `serialwrap-help` marker 區段（R-16）。純說明文字調整，不影響任何指令行為與參數。
 

--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ ocp-mcu-upgrade -d /tmp/serialwrap/dev/ttyMCU -b 115200 -t 8 -e -s -i fw.bin
 1. 視需要自動啟動 daemon
 2. 視需要對 selector 執行 `session attach`
 3. 透過 `session console-attach` 取得專屬 PTY
-4. 預設用 `script -qef` 包住 minicom 記錄一份 `mini_<COM>_<timestamp>.log` transcript（預設在 `~/b-log`，可用 `BLOG_DIR` 覆寫），避免 minicom 內建 `-C` 在 PTY / resize / 高頻 RX 下的 native crash 風險
+4. 預設用 minicom 內建 `-C` 記錄一份 `mini_<COM>_<timestamp>.log` 純序列 transcript（預設在 `~/b-log`，可用 `BLOG_DIR` 覆寫）；需要含完整終端畫面的 transcript 可設 `MINICOM_CAPTURE_MODE=script` 改用 `script -qef` 包裹
 5. 啟動 `minicom`
 6. 結束後自動 `session console-detach`
 
@@ -638,8 +638,8 @@ minicom -D /dev/ttyUSB0
 - 第二個以後的 minicom console 因為 interactive lease 已存在，仍走 line-buffer 模式（broker 提供本地回顯與 backspace 行編輯）。
 - bridge rebuild / reattach 時，broker 會盡量保留既有 console PTY 與 human ownership，避免既有 minicom 掛到 stale `/dev/pts/*`。
 - Broker minicom 的自動 transcript 可用 `MINICOM_CAPTURE_MODE=script|minicom|off` 控制：
-  - `script`（預設）：使用 `script -qef` 包住 minicom，不傳 `-C` 給 minicom。
-  - `minicom`：明確 opt-in 使用 minicom 內建 `-C`；此模式在 PTY / resize / 高頻輸出下較容易觸發 minicom native crash 風險。
+  - `script`：使用 `script -qef` 包住 minicom（完整終端 transcript，會含 minicom 自身 UI/顏色），不傳 `-C` 給 minicom。
+  - `minicom`（預設）：使用 minicom 內建 `-C`，產生不含 minicom UI 的乾淨序列 log。
   - `off`：關閉自動 transcript，不建立 log、不使用 `script` wrapper，也不自動傳 `-C`。
 - Legacy `MINICOM_CAPTURE_WRAPPER=1` 仍等同 `MINICOM_CAPTURE_MODE=script`；若未設定 `MINICOM_CAPTURE_MODE` 且明確設定 `MINICOM_CAPTURE_WRAPPER=0`，仍保留舊版 minicom `-C` 行為。
 - 常見 human/minicom 互動式命令（例如 `vi`、`vim`、`top`、`htop`、`less`、`menuconfig`）會自動升級成 human interactive ownership，不再因為等不到 shell prompt 而自動觸發 recover / reboot。

--- a/docs/serialwrap-spec.md
+++ b/docs/serialwrap-spec.md
@@ -577,7 +577,7 @@ background mode 的 `command.result_tail` 在 capture 尚未建立時，會回�
 
 `minicom_router.sh` 不再依賴 session 單一 `vtty` 當唯一入口。
 
-預設 transcript 走 minicom 內建 `-C` capturefile；只有在明確設定 `MINICOM_CAPTURE_WRAPPER=1` 時，才改用 `script -qef` 包一層 PTY 來保留完整 terminal transcript。後者可能增加 human 體感延遲。
+預設 transcript 走 minicom 內建 `-C` capturefile（乾淨序列 log，不含 minicom UI）；可設 `MINICOM_CAPTURE_MODE=script`（或舊式 `MINICOM_CAPTURE_WRAPPER=1`）改用 `script -qef` 包一層 PTY 來保留含完整終端畫面的 transcript。後者可能增加 human 體感延遲。
 
 ## 13. Profile 規格
 

--- a/openspec/changes/revert-minicom-capture-default/.openspec.yaml
+++ b/openspec/changes/revert-minicom-capture-default/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-29

--- a/openspec/changes/revert-minicom-capture-default/design.md
+++ b/openspec/changes/revert-minicom-capture-default/design.md
@@ -1,0 +1,37 @@
+## Context
+
+`minicom_router.sh` 的 `_resolve_capture_mode()`（`sw_core/assets/tools/minicom_router.sh:53-77`）以三層 precedence 決定 auto-capture 模式：
+
+1. 顯式 `MINICOM_CAPTURE_MODE`（`:54-65`，僅接受 `script|minicom|off`，否則報錯 exit 2）。
+2. legacy `MINICOM_CAPTURE_WRAPPER` 曾被設定（`:67-74`，`=1`→`script`、其餘如 `=0`→`minicom`）。
+3. 兩者皆未設的最終 fallback（`:76`，目前為 `printf 'script'`——即 `6df17a5` 翻成 script 的位置）。
+
+解析結果在 `_exec_minicom()` 消費：`script` 分支（`:221-229`，`script -qef -c "<cmdline>" logfile`，script 不存在則印 warning 降級為不帶 `-C` 跑 minicom）、`minicom` 分支（`:230-232`，`cmd+=("-C" logfile)`）、`off`（logfile 保持空、完全不注入）。`has_capture` 偵測（`:189-198`）涵蓋使用者自帶 `-C`/`--capturefile`，命中即跳過 auto 注入避免重複。
+
+歷史脈絡：`b883506`(script transcript) → `a4633bb`(改 `-C`，理由「降低 broker 延遲」) → `6df17a5`(又改回 `script`，理由查無實證的「-C native crash」)。本 change 把第 (3) 層預設復原為 `minicom`。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 預設 auto-transcript 產生**乾淨序列 RX**（不含 minicom 自身 UI/全螢幕重繪/狀態列/Leave 對話框）。
+- 完全保留 `MINICOM_CAPTURE_MODE` 與 legacy `MINICOM_CAPTURE_WRAPPER` 既有語意與 precedence。
+- docs（README/spec）與實作一致，並移除查無實證的 crash 斷言措辭。
+
+**Non-Goals:**
+- **不**追求「100% 無 ANSI」：target 自身輸出的 ANSI（如 `ls --color`、著色 prompt）仍會被 `-C` 如實記錄；要完全 strip 屬另案（daemon 端擷取或事後 strip），本 change 不做。
+- **不**碰 daemon／RPC／序列埠 I/O，**不**碰 console 生命週期（孤兒回收/raw ownership 由 PR-B 處理）。
+- **不**為 `-C` 加 `--capturefile-buffer-mode`：minicom 2.9 預設 N(Unbuffered) 逐字 flush，115200 無需 buffer；極高 baud 才考慮，列為未來。
+
+## Decisions
+
+- **單行變更**：`minicom_router.sh:76` 的 `printf 'script'` → `printf 'minicom'`。`:69`（WRAPPER=1→script，6 空格縮排）與 `:71`（WRAPPER=0→minicom）**不得動**；Edit 必須以上下文（含 `:74-77` 的 `return`/縮排）鎖定，避免誤改到同字串的 `:69`。
+- **precedence 自洽**：翻轉後唯一行為變動是「`MODE` 與 `WRAPPER` 皆未設」時 `script`→`minicom`；顯式 `MODE`、legacy `WRAPPER=1/0`、`off`、使用者自帶 `-C` 路徑皆不變。
+- **CHANGELOG 處置**：`[Unreleased]` 既有「改為 script…」一條尚未隨任何 release 出貨，直接**修正/取代**該條為「預設維持 minicom 原生 `-C`」，避免同一未出貨段落自相矛盾。
+- **docs 軟化**：README 對 `minicom` 模式的「native crash 風險」警語改為中性描述（如「全終端 transcript 請用 `MODE=script`」），不再宣稱 `-C` 會 crash（查無實證）。
+
+## Risks / Trade-offs
+
+- **是否引回「-C native crash」？** 評估為低：查證無 repro/test/Issue；minicom 2.9 `-C` 預設逐字 flush 無丟尾；115200 不會背壓。此為 PR 說明須點明的最大風險點。
+- **行為可見差異**：倚賴完整終端畫面錄製者，預設 log 內容會改變；補救路徑為 `MINICOM_CAPTURE_MODE=script`，需在 CHANGELOG/README 明示。
+- **Edit 誤改風險**：`:69` 與 `:76` 文字皆為 `printf 'script'`；誤改 `:69` 會破壞 legacy `WRAPPER=1==script` 契約並使 `test_wrapper_generates_transcript_log` 失敗——列為實作必檢項。
+- **測試耦合**：`test_default_capture_uses_script_...` 以 fake-minicom 見到 `-C` 即 exit 44 來鎖死「預設=script」，必須重寫；`test_script_unavailable_...` 依賴舊預設=script 才走 warning 降級，必須補 `MODE=script`。漏改任一會造成新預設下測試失敗。

--- a/openspec/changes/revert-minicom-capture-default/proposal.md
+++ b/openspec/changes/revert-minicom-capture-default/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`minicom_router.sh` 的自動 transcript 預設於 commit `6df17a5`（PR #49，2026-06-01）從 minicom 原生 `-C` 翻成 `script -qef --color=on` 全終端 transcript，導致 `~/b-log/mini_<COM>_*.log` 從此夾帶大量 ANSI／控制碼（minicom 自身的全螢幕 UI：顏色、狀態列、游標定位、字元集切換、Leave 對話框）。實檔對照鐵證：早期 `mini_COM3_260611-095301.log` 0 個 ESC、純序列資料；近期 `mini_COM0_260627-114406.log` 含 185 個 ESC、首行為 `Script started … minicom … --color=on`。
+
+當初翻成 `script` 宣稱是「避免 minicom 內建 `-C` 在 PTY/resize/高頻 RX 的 native crash 風險」，但經查證該 crash **查無任何 reproduction／issue／測試**（PR #49 body 自述「Issue Reference: N/A」），且本機 115200（約 11.5 KB/s）遠不足以觸發背壓掉包；真正的 minicom 卡頓/掉字根因是 serialwrap 端 stale/orphan console 累積（issue #76），與 minicom `-C` 無關（由 PR-B 處理）。
+
+## What Changes
+
+- 將 `minicom_router.sh` 自動 transcript 的**最終預設**由 `script` 改回 minicom 原生 `-C`（即無 `MINICOM_CAPTURE_MODE`／`MINICOM_CAPTURE_WRAPPER` 時的 fallback）。
+- 保留 `MINICOM_CAPTURE_MODE=script|minicom|off` 與 legacy `MINICOM_CAPTURE_WRAPPER=1` 的既有語意：`script` 仍為**顯式 opt-in** 的全終端 transcript。
+- 同步對齊 `README.md`／`docs/serialwrap-spec.md`，並**軟化**查無實證的「minicom native crash」措辭。
+- **非破壞性**：預設 log 內容由「含 minicom UI 的全終端 transcript」改為「純序列 RX（仍含 target 自身輸出的 ANSI，如 `ls --color`）」；需要全終端錄製者顯式 `MINICOM_CAPTURE_MODE=script`。
+
+## Capabilities
+
+### New Capabilities
+- `minicom-console-capture`: broker minicom wrapper 的自動 transcript 行為——擷取模式（`script`/`minicom`/`off`）、其 precedence、以及預設為 minicom 原生 `-C` 的乾淨序列擷取契約。
+
+### Modified Capabilities
+（無 requirement 層級的既有 capability 變更。）
+
+## Impact
+
+- `sw_core/assets/tools/minicom_router.sh`（`_resolve_capture_mode` 最終 fallback 一行）。
+- `README.md`、`docs/serialwrap-spec.md`（docs 對齊 R-18；軟化 crash 措辭）。
+- `CHANGELOG.md`（[Unreleased] 既有「改為 script」一條尚未出貨，直接修正而非疊加矛盾條目）。
+- `tests/test_minicom_router.py`（重寫鎖死「預設=script」的測試、為 script-unavailable 測試補 `MODE=script`）。
+- 無 daemon／RPC／序列埠 I/O 變更（不碰 `sw_core/uart_io.py`、`session_manager.py`）。

--- a/openspec/changes/revert-minicom-capture-default/specs/minicom-console-capture/spec.md
+++ b/openspec/changes/revert-minicom-capture-default/specs/minicom-console-capture/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: broker minicom 自動 transcript 預設使用 minicom 原生 `-C`
+
+當使用者未設定 `MINICOM_CAPTURE_MODE` 也未設定 `MINICOM_CAPTURE_WRAPPER` 時，`minicom_router.sh` 的自動 transcript SHALL 採 minicom 原生 `-C`（`minicom -D <vtty> -C <logfile>`）模式，使預設 `~/b-log/mini_<COM>_<timestamp>.log` 為**純序列擷取**——不得包含 minicom 自身的全螢幕 UI（顏色、狀態列、游標定位、字元集切換、選單/對話框）等控制序列。系統 SHALL NOT 在此預設下以 `script` wrapper 包裹 minicom。
+
+此預設 SHALL NOT 對 target 自身輸出的位元組做任何過濾——target 經序列埠送出的 ANSI（如 `ls --color`、著色 prompt）仍 SHALL 被如實記錄；本 requirement 僅排除 minicom **自身** UI 的污染。
+
+#### Scenario: 無 env 設定時預設走原生 -C
+- **WHEN** 啟動 `minicom_router.sh` 且未設 `MINICOM_CAPTURE_MODE` 與 `MINICOM_CAPTURE_WRAPPER`
+- **THEN** 傳給 minicom 的引數 SHALL 含 `-C <logfile>`，SHALL NOT 以 `script` 包裹，且產生的 `mini_<COM>_<ts>.log` 不含 `Script started` 標頭
+
+#### Scenario: 預設擷取檔不含 minicom UI 控制序列
+- **WHEN** 以預設模式擷取一段含 minicom 狀態列/選單重繪的工作階段
+- **THEN** 產出的 log 檔 SHALL NOT 含 minicom 自身的全螢幕重繪/狀態列/Leave 對話框等 UI 控制序列
+
+### Requirement: 擷取模式 precedence 與 opt-in 維持不變
+
+`minicom_router.sh` SHALL 以下列 precedence 解析擷取模式，且本 change 僅變動「最終 fallback」一層：
+
+1. 顯式 `MINICOM_CAPTURE_MODE`（`script`｜`minicom`｜`off`）最高優先；非法值 SHALL 報錯並以非零碼結束。
+2. 其次為 legacy `MINICOM_CAPTURE_WRAPPER`：曾被設定為 `1` SHALL 等同 `script`、設定為其他值（如 `0`）SHALL 等同 `minicom`。
+3. 兩者皆未設定時，最終 fallback SHALL 為 `minicom`（原生 `-C`）。
+
+`script` 模式（顯式 `MINICOM_CAPTURE_MODE=script` 或 legacy `MINICOM_CAPTURE_WRAPPER=1`）SHALL 維持為**顯式 opt-in** 的全終端 transcript（`script -qef`）。使用者自帶 `-C`/`--capturefile` 時 SHALL NOT 重複注入 auto transcript。`off` 模式 SHALL 不建立任何 log、不使用 `script`、不注入 `-C`。
+
+#### Scenario: 顯式 MODE=script 仍走全終端 transcript
+- **WHEN** 設 `MINICOM_CAPTURE_MODE=script`
+- **THEN** SHALL 以 `script -qef` 包裹 minicom 並產生全終端 transcript（行為與本 change 前一致）
+
+#### Scenario: legacy WRAPPER=1 仍等同 script
+- **WHEN** 設 `MINICOM_CAPTURE_WRAPPER=1` 且未設 `MINICOM_CAPTURE_MODE`
+- **THEN** 解析出的模式 SHALL 為 `script`
+
+#### Scenario: legacy WRAPPER=0 仍等同 minicom
+- **WHEN** 設 `MINICOM_CAPTURE_WRAPPER=0` 且未設 `MINICOM_CAPTURE_MODE`
+- **THEN** 解析出的模式 SHALL 為 `minicom`（原生 `-C`）
+
+#### Scenario: 使用者自帶 -C 不重複注入
+- **WHEN** 使用者在 minicom 引數自帶 `-C <file>` 或 `--capturefile`
+- **THEN** SHALL NOT 額外注入 auto transcript（無重複 `-C`、無 auto `mini_*.log`）
+
+#### Scenario: off 模式不擷取
+- **WHEN** 設 `MINICOM_CAPTURE_MODE=off`
+- **THEN** SHALL NOT 建立 log、SHALL NOT 以 `script` 包裹、SHALL NOT 注入 `-C`
+
+#### Scenario: script 不可用時的顯式降級
+- **WHEN** 模式解析為 `script`（顯式 MODE 或 WRAPPER=1）但系統無 `script` 指令
+- **THEN** SHALL 印出 warning 並改為不帶 `-C` 直接執行 minicom（維持既有降級行為）

--- a/openspec/changes/revert-minicom-capture-default/tasks.md
+++ b/openspec/changes/revert-minicom-capture-default/tasks.md
@@ -1,0 +1,23 @@
+## 1. 復原預設擷取模式
+
+- [ ] 1.1 `sw_core/assets/tools/minicom_router.sh`：`_resolve_capture_mode()` 最終 fallback（`:76`）由 `printf 'script'` 改為 `printf 'minicom'`。以上下文鎖定，**不得**動到 `:69`（WRAPPER=1→script，6 空格縮排）與 `:71`（WRAPPER=0→minicom）。
+- [ ] 1.2 以 `cat -A` 或 grep 確認改後 `:69` 仍為 `printf 'script'`、`:76` 為 `printf 'minicom'`，precedence 三層自洽。
+
+## 2. 測試對齊
+
+- [ ] 2.1 重寫 `tests/test_minicom_router.py::test_default_capture_uses_script_wrapper_without_minicom_capturefile` → `test_default_capture_uses_native_minicom_capturefile`：移除 `@skipUnless(script)`、fake-minicom 改為接受 `-C` 並寫入該檔、斷言 `assertIn('-C', args)` 且 BLOG_DIR 產生恰 1 個 `mini_*.log` 含 RX 內容。
+- [ ] 2.2 `tests/test_minicom_router.py::test_script_unavailable_warns_and_runs_without_native_capture`：加 `env['MINICOM_CAPTURE_MODE']='script'`，維持對 script-unavailable warning 降級的覆蓋（其餘斷言不變）。
+- [ ] 2.3 回歸確認（不需改）：`test_wrapper_generates_transcript_log`、`test_wrapper_prefers_home_b_log`（WRAPPER=1→script）、`test_legacy_explicit_capture_wrapper_zero`（WRAPPER=0→-C）、`test_capture_mode_minicom`、`test_capture_mode_off`、`test_invalid_capture_mode`、`test_user_capture_args_disable_auto_transcript`、`test_broker_console_detaches` 在新預設下原樣通過。
+- [ ] 2.4 執行 `python3 -m pytest -q tests/test_minicom_router.py` 全綠，再 `python3 -m pytest -q tests/` 確認無新失敗（既有 flaky t1/t5/t8 與 PTY 競態除外）。
+
+## 3. 文件與變更紀錄對齊
+
+- [ ] 3.1 `README.md`（約 :617/:640-642）：把「預設 script」敘述改回「預設 minicom 原生 `-C`」；軟化 `minicom` 模式的「native crash 風險」措辭為中性描述（要全終端 transcript 用 `MINICOM_CAPTURE_MODE=script`）。
+- [ ] 3.2 `docs/serialwrap-spec.md`（約 :580）：校正使其與 README/實作一致（復原後該句敘述反而正確，順手對齊後半句）。
+- [ ] 3.3 `CHANGELOG.md` `[Unreleased]`：修正/取代既有「預設改為 script…」一條為「預設維持 minicom 原生 `-C`；`script` 為顯式 opt-in」，避免同段矛盾。
+- [ ] 3.4 重生 README `serialwrap-help` marker（若受影響，R-16）。
+
+## 4. Policy gate
+
+- [ ] 4.1 `python3 -m policy_check --repo .` 通過（含 R-18 docs 對齊）。
+- [ ] 4.2 分支 `feature/<slug>`、PR body 填 Policy Checklist、commit 帶 Co-authored-by trailer。

--- a/sw_core/assets/tools/minicom_router.sh
+++ b/sw_core/assets/tools/minicom_router.sh
@@ -73,7 +73,7 @@ _resolve_capture_mode() {
     return 0
   fi
 
-  printf 'script'
+  printf 'minicom'
 }
 
 selector=""

--- a/tests/test_minicom_router.py
+++ b/tests/test_minicom_router.py
@@ -128,8 +128,7 @@ class TestMinicomRouter(unittest.TestCase):
             self.assertEqual(len(logs), 1)
             self.assertFalse(legacy_dir.exists())
 
-    @unittest.skipUnless(shutil.which("script"), "script command is required")
-    def test_default_capture_uses_script_wrapper_without_minicom_capturefile(self) -> None:
+    def test_default_capture_uses_native_minicom_capturefile(self) -> None:
         with self._temporary_directory() as td:
             root = Path(td)
             fake_minicom = root / "fake-minicom.sh"
@@ -140,12 +139,18 @@ class TestMinicomRouter(unittest.TestCase):
                 fake_minicom,
                 "#!/usr/bin/env bash\n"
                 "printf '%s\\n' \"$@\" > \"$FAKE_ARGS_OUT\"\n"
-                "for arg in \"$@\"; do\n"
-                "  if [[ \"$arg\" == '-C' || \"$arg\" == --capturefile* ]]; then\n"
-                "    echo 'unexpected minicom native capture arg' >&2\n"
-                "    exit 44\n"
+                "capture=''\n"
+                "while [[ $# -gt 0 ]]; do\n"
+                "  if [[ \"$1\" == '-C' && $# -ge 2 ]]; then\n"
+                "    capture=\"$2\"\n"
+                "    shift 2\n"
+                "    continue\n"
                 "  fi\n"
+                "  shift\n"
                 "done\n"
+                "if [[ -n \"$capture\" ]]; then\n"
+                "  printf 'fake minicom output\\n' > \"$capture\"\n"
+                "fi\n"
                 "printf 'fake minicom output\\n'\n",
             )
 
@@ -163,11 +168,12 @@ class TestMinicomRouter(unittest.TestCase):
             )
 
             args = args_out.read_text(encoding="utf-8")
-            self.assertNotIn("-C", args)
+            self.assertIn("-C", args)
             logs = sorted(blog_dir.glob("mini_*.log"))
             self.assertEqual(len(logs), 1)
-            content = logs[0].read_text(encoding="utf-8", errors="replace")
+            content = logs[0].read_text(encoding="utf-8")
             self.assertIn("fake minicom output", content)
+            self.assertNotIn("Script started", content)
 
     def test_user_capture_args_disable_auto_transcript(self) -> None:
         cases = (
@@ -238,6 +244,7 @@ class TestMinicomRouter(unittest.TestCase):
 
             env = self._base_env(root, fake_minicom, blog_dir)
             env["FAKE_ARGS_OUT"] = str(args_out)
+            env["MINICOM_CAPTURE_MODE"] = "script"
             env["PATH"] = str(path_without_script)
 
             result = subprocess.run(

--- a/tests/test_minicom_router.py
+++ b/tests/test_minicom_router.py
@@ -39,6 +39,27 @@ class TestMinicomRouter(unittest.TestCase):
         )
         return fake_serialwrap
 
+    def _write_native_capture_fake_minicom(self, path: Path) -> None:
+        """fake-minicom：記錄 args、收到 -C <file> 時寫入 capture 檔，並輸出到 stdout。"""
+        self._write_executable(
+            path,
+            "#!/usr/bin/env bash\n"
+            "printf '%s\\n' \"$@\" > \"$FAKE_ARGS_OUT\"\n"
+            "capture=''\n"
+            "while [[ $# -gt 0 ]]; do\n"
+            "  if [[ \"$1\" == '-C' && $# -ge 2 ]]; then\n"
+            "    capture=\"$2\"\n"
+            "    shift 2\n"
+            "    continue\n"
+            "  fi\n"
+            "  shift\n"
+            "done\n"
+            "if [[ -n \"$capture\" ]]; then\n"
+            "  printf 'fake minicom output\\n' > \"$capture\"\n"
+            "fi\n"
+            "printf 'fake minicom output\\n'\n",
+        )
+
     def _base_env(self, root: Path, fake_minicom: Path, blog_dir: Path | None = None) -> dict[str, str]:
         env = os.environ.copy()
         env["MINICOM_BIN"] = str(fake_minicom)
@@ -135,24 +156,7 @@ class TestMinicomRouter(unittest.TestCase):
             args_out = root / "args.txt"
             blog_dir = root / "b-log"
 
-            self._write_executable(
-                fake_minicom,
-                "#!/usr/bin/env bash\n"
-                "printf '%s\\n' \"$@\" > \"$FAKE_ARGS_OUT\"\n"
-                "capture=''\n"
-                "while [[ $# -gt 0 ]]; do\n"
-                "  if [[ \"$1\" == '-C' && $# -ge 2 ]]; then\n"
-                "    capture=\"$2\"\n"
-                "    shift 2\n"
-                "    continue\n"
-                "  fi\n"
-                "  shift\n"
-                "done\n"
-                "if [[ -n \"$capture\" ]]; then\n"
-                "  printf 'fake minicom output\\n' > \"$capture\"\n"
-                "fi\n"
-                "printf 'fake minicom output\\n'\n",
-            )
+            self._write_native_capture_fake_minicom(fake_minicom)
 
             env = self._base_env(root, fake_minicom, blog_dir)
             env["FAKE_ARGS_OUT"] = str(args_out)
@@ -271,24 +275,7 @@ class TestMinicomRouter(unittest.TestCase):
             args_out = root / "args.txt"
             blog_dir = root / "b-log"
 
-            self._write_executable(
-                fake_minicom,
-                "#!/usr/bin/env bash\n"
-                "printf '%s\\n' \"$@\" > \"$FAKE_ARGS_OUT\"\n"
-                "capture=''\n"
-                "while [[ $# -gt 0 ]]; do\n"
-                "  if [[ \"$1\" == '-C' && $# -ge 2 ]]; then\n"
-                "    capture=\"$2\"\n"
-                "    shift 2\n"
-                "    continue\n"
-                "  fi\n"
-                "  shift\n"
-                "done\n"
-                "if [[ -n \"$capture\" ]]; then\n"
-                "  printf 'fake minicom output\\n' > \"$capture\"\n"
-                "fi\n"
-                "printf 'fake minicom output\\n'\n",
-            )
+            self._write_native_capture_fake_minicom(fake_minicom)
 
             env = self._base_env(root, fake_minicom, blog_dir)
             env["FAKE_ARGS_OUT"] = str(args_out)
@@ -308,7 +295,9 @@ class TestMinicomRouter(unittest.TestCase):
             self.assertIn("-C", args)
             logs = sorted(blog_dir.glob("mini_*.log"))
             self.assertEqual(len(logs), 1)
-            self.assertIn("fake minicom output", logs[0].read_text(encoding="utf-8"))
+            content = logs[0].read_text(encoding="utf-8")
+            self.assertIn("fake minicom output", content)
+            self.assertNotIn("Script started", content)
 
     def test_capture_mode_off_disables_auto_transcript(self) -> None:
         with self._temporary_directory() as td:


### PR DESCRIPTION
## Summary

復原 broker minicom 自動 transcript 的**預設**為 minicom 內建 `-C`（乾淨序列 log），修正 `6df17a5` 一度把預設翻成 `script -qef --color=on` 全終端 transcript 所造成的回歸——`~/b-log/mini_<COM>_*.log` 自此夾帶大量 minicom 自身 UI 的 ANSI/控制碼（顏色、狀態列、游標定位、Leave 對話框、`Script started` 標頭）。

實檔對照：早期 `mini_COM3_260611-095301.log` 0 個 ESC、純序列;近期 `mini_COM0_260627-114406.log` 185 個 ESC、首行 `Script started … --color=on`。

當初翻成 `script` 宣稱避免「minicom `-C` native crash」，但經查證**查無任何 reproduction／issue／測試**（PR #49 body 自述 `Issue Reference: N/A`）;115200（約 11.5 KB/s）也不足以觸發背壓掉包。真正的 minicom 卡頓/掉字屬 serialwrap 端 stale console 累積（issue #76），與 capture 模式無關，另由後續 PR 處理。

變更（最小面）：
- `sw_core/assets/tools/minicom_router.sh`：`_resolve_capture_mode()` 最終 fallback 由 `script` 改回 `minicom`（單行;`MINICOM_CAPTURE_WRAPPER=1`≡`script`、`=0`≡`-C`、顯式 `MINICOM_CAPTURE_MODE` 等 precedence **不變**）。
- `script` 模式維持為**顯式 opt-in**（`MINICOM_CAPTURE_MODE=script` 或 legacy `WRAPPER=1`）。
- docs（README/serialwrap-spec）對齊新預設並軟化未證實的 crash 措辭;CHANGELOG `[Unreleased]` 修正既有條目。
- OpenSpec change：`openspec/changes/revert-minicom-capture-default/`。

> 範圍說明：`-C` 仍會如實記錄 target 自身輸出的 ANSI（如 `ls --color`），本 PR 只排除 minicom **自身** UI 的污染。需要完整終端畫面者可設 `MINICOM_CAPTURE_MODE=script`。

## Test Plan

- [x] 先在**實機**用真 `minicom_router.sh` + 真 `script` 重現問題（default 產出含 `Script started` + ESC 的 transcript;`MODE=minicom` 產出 0 ESC 乾淨檔），再據此設計測試（TDD red→green）。
- [x] `python3 -m pytest -q tests/test_minicom_router.py` — 10 passed（含新 `test_default_capture_uses_native_minicom_capturefile` 鎖定 default→`-C` 且 log 無 `Script started`;`test_capture_mode_minicom_*` 對稱補同不變式;script-unavailable 測試補 `MODE=script`）。
- [x] `python3 -m pytest -q tests/` deterministic core — **717 passed**（`test_human_agent_coexist.py` 為既有 PTY-contention flaky：本機 live daemon + 2 個 minicom 持有 `/dev/pts` 時,兩次跑失敗集合不同〔5 vs 8〕證其非確定性,與本 PR 無關;PR-A 僅動 minicom wrapper shell + 其測試,不觸碰 daemon PTY coexistence 路徑）。
- [x] `python3 -m policy_check --repo .` — 通過（R-22 為既有 dangling-doc warn，非本 PR 新增）。

## Policy Checklist (R-11)

- [x] 分支不是 `main`（`feature/revert-minicom-capture-default`）
- [x] `CHANGELOG.md` 已更新（`[Unreleased]` 段落）
- [x] `VERSION` 無版本號變動（fix，維持 0.2.0）
- [x] `python3 -m pytest -q tests/` 通過（無新失敗）
- [x] `python3 -m policy_check --repo .` 通過
- [x] 未修改 `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` / `.github/copilot-instructions.md`，無需同步
- [x] 已標記 `policy-exempt:issue-link`（R-17：本 PR 只引用 `#49`/`#76` 作脈絡，不關閉任何 issue）

## Issue Reference

N/A（症狀2 capture 預設回歸;無對應 issue。#76 屬 serialwrap 端 stale console，將由後續 PR-B 處理。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)