### PR TITLE
chore(policy): R-16 cli-help 覆蓋擴到 daemon/session/device 群組

### DIFF
--- a/.paul-project.yml
+++ b/.paul-project.yml
@@ -15,3 +15,16 @@ cli:
     help_args: ["--help"]
     reflected_in: "README.md"
     marker: "serialwrap-help"
+  # 群組 help（列出各群組子命令）——新增子命令但未同步 README 時 R-16 FAIL，補掉子命令層的漏記
+  - command: "./serialwrap daemon"
+    help_args: ["--help"]
+    reflected_in: "README.md"
+    marker: "serialwrap-daemon-help"
+  - command: "./serialwrap session"
+    help_args: ["--help"]
+    reflected_in: "README.md"
+    marker: "serialwrap-session-help"
+  - command: "./serialwrap device"
+    help_args: ["--help"]
+    reflected_in: "README.md"
+    marker: "serialwrap-device-help"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 
 - **說明文件對齊現行設計（除 spec）**：`CLAUDE.md` 補上 `sw_core/serial_port.py`（#84 PORT-1 SerialPort 抽象）/`sw_core/multi_open.py`（#101）到架構模組清單、human console 的 Windows TCP socket 路徑（#84 PORT-2）、COM 編號 by-id 確定性 rank（#100）與 daemon 多開被動偵測（#101）兩條慣例。`README.md` 修正過時敘述：WAL/state 預設路徑改 XDG（`~/.local/state/serialwrap/`，舊 `/tmp/serialwrap/` 標為舊版）、human attach 命令 `~/.paul_tools/minicom COMx`→`serialwrap-minicom COMx`、OPI 範例 profile 目錄改 `~/.config/serialwrap/profiles` 並改用 `serialwrap service restart`。`docs/design-file-transfer.md`（含 #59 已退役的 MCP 段）與 `docs/design-heartbeat-keepalive.md` 補「歷史快照」banner 指向現行來源。serialwrap **skill**（`sw_core/assets/skill/SKILL.md`）修正 socat 範例 socket 路徑（`/tmp/serialwrap/serialwrapd.sock`→`/run/serialwrap/serialwrapd.sock` + 監管模式註記）並補 #101 多開（two-reader）診斷 FAQ；CLI `daemon status` **help** 字串補 `multi_open` 偵測。spec（`docs/serialwrap-spec.md`、`openspec/specs/*`）與歷史快照／release notes 不在本次範圍。
+- **policy R-16 cli-help 覆蓋擴大**：`.paul-project.yml` 的 `cli` 段新增 `daemon`／`session`／`device` 三個群組 help 宣告，並於 `README.md` 補對應 `cli-help` marker 區塊（pin `serialwrap <group> --help` 輸出）。新增子命令但未同步 README 群組 help 時 R-16 會 FAIL，補掉「子命令層漏記」的盲區（policy 引擎側的範圍/語意擴充另記於 paulsha-conventions#26）。
 
 ## [0.2.1] - 2026-06-29
 

--- a/README.md
+++ b/README.md
@@ -1185,6 +1185,81 @@ examples:
   serialwrap --endpoint tcp://127.0.0.1:7777 cmd submit --selector COM0 --cmd 'uname -a'
 <!-- END: cli-help marker="serialwrap-help" -->
 
+### 子命令 help（R-16 同步管控）
+
+`serialwrap daemon --help`：
+
+<!-- BEGIN: cli-help marker="serialwrap-daemon-help" -->
+usage: serialwrap daemon [-h] <command> ...
+
+管理 serialwrap daemon 行程：啟動、停止與查詢執行狀態。
+
+positional arguments:
+  <command>
+    start     啟動 daemon（--foreground 可前景執行）
+    stop      停止執行中的 daemon
+    status    顯示 daemon 狀態（pid／sessions／devices／log 路徑／多開偵測 multi_open）
+
+options:
+  -h, --help  show this help message and exit
+<!-- END: cli-help marker="serialwrap-daemon-help" -->
+
+`serialwrap session --help`：
+
+<!-- BEGIN: cli-help marker="serialwrap-session-help" -->
+usage: serialwrap session [-h] <command> ...
+
+管理 session：列舉與綁定、健康探測（self-test）、recover、console 與 interactive lease、capture
+log。
+
+positional arguments:
+  <command>
+    list              列出所有 session 及其狀態
+    clear             清除 session（detach 後會自動 re-attach；交接外部請改用 device release）
+    bind              把 session 綁定到指定裝置 by-id
+    pin               把 device 釘到指定 profile（最高優先，繞過偵測）
+    unpin             解除 device 的 profile pin（保留 sticky）
+    attach            將 session attach 到裝置並建立 bridge
+    self-test         探測 session 健康度，回報 classification 與 recommended_action
+    activity          顯示 session 的 RX／TX／state 活動
+    recover           重建 bridge 修復不健康的 session（TARGET_UNRESPONSIVE 時用這個，非
+                      device attach）
+    console-attach    附加一個 console reader 到 session
+    console-detach    卸除指定的 console reader
+    console-list      列出 session 上的 console readers
+    interactive-open  開啟 interactive lease（給全螢幕互動程式用）
+    interactive-send  送出按鍵／資料到 interactive lease
+    interactive-status
+                      讀取 interactive lease 目前畫面與狀態
+    interactive-close
+                      關閉 interactive lease
+    log-start         開始該 session 的 capture log
+    log-stop          停止該 session 的 capture log
+    log-status        查詢該 session 的 capture log 狀態
+
+options:
+  -h, --help          show this help message and exit
+<!-- END: cli-help marker="serialwrap-session-help" -->
+
+`serialwrap device --help`：
+
+<!-- BEGIN: cli-help marker="serialwrap-device-help" -->
+usage: serialwrap device [-h] <command> ...
+
+管理實體 UART 裝置：列舉裝置，以及把 raw device 暫時交給外部工具獨佔再收回。
+
+positional arguments:
+  <command>
+    list      列出實體 UART 裝置（real_path 與 by-id）
+    release   釋放 raw 裝置給外部工具獨佔（如 MCU 燒錄），進入 RELEASED 不自動搶回
+    attach    收回先前 release 的裝置並重建 console（外部仍持有時回 DEVICE_STILL_HELD，--force
+              略過）
+
+options:
+  -h, --help  show this help message and exit
+<!-- END: cli-help marker="serialwrap-device-help" -->
+
+
 ```bash
 # 啟動 daemon（systemd 模式請改用 serialwrap service start；on-demand 模式才需手動啟動）
 # 經 serialwrap setup 後 profiles 已在 XDG 設定目錄，daemon 預設即可讀取，無需 --profile-dir


### PR DESCRIPTION
## Summary

擴大 policy R-16（cli-help sync）覆蓋面：原本只宣告 top-level `serialwrap --help`，新增 `daemon`／`session`／`device` 三個群組 help。

- `.paul-project.yml` 的 `cli` 段加 3 個群組宣告（`./serialwrap <group> --help` → README marker）。
- `README.md` Usage 段補對應 `cli-help` marker 區塊，pin 各群組 `--help` 輸出（含群組下所有子命令清單）。
- 效果：日後**新增子命令但未同步 README 群組 help → R-16 FAIL**，補掉「子命令層漏記」盲區。

> 背景：源於說明文件對齊稽核（PR #105）發現 policy 引擎對 doc drift 的覆蓋盲區。本 PR 是 repo 側可立即做的部分；引擎側的範圍/語意擴充（R-18/R-22 擴到 CLAUDE.md/SKILL.md、新增文件覆蓋率規則）已開於 paulsha-conventions#26。

## Test Plan

- [x] `python3 -m policy_check --repo .` — pass:21 / fail:0 / warn:1（R-22 advisory）；**R-16: All 4 CLI help markers are in sync**
- [x] marker 區塊由 `./serialwrap <group> --help` 實際輸出生成（byte-exact），CI 重跑比對通過
- [x] 純 config/docs 變更、無 code change（pytest 無新失敗，CI 確認）

## Policy Checklist (R-11)

- [x] 分支不是 `main`（`feature/policy-cli-coverage`）
- [x] `CHANGELOG.md` 已更新（`[Unreleased]` → `### Changed`）
- [x] `VERSION` 已更新（若有版本號變動）— 無版本變動，N/A
- [x] `python3 -m pytest -q tests/` 通過（無 code change，無新失敗）
- [x] `python3 -m policy_check --repo .` 通過（R-16 含 4 markers）
- [x] `CLAUDE.md` 未改（symlink 自動同步，N/A）
- [x] 已標記適用 label（`policy-exempt:issue-link`：body 引用 paulsha-conventions#26 為脈絡）

## Issue Reference

無關閉本 repo issue。引用 `paulsha-conventions#26`（引擎側後續）為脈絡（已上 `policy-exempt:issue-link`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
