### PR TITLE
fix(tests): 補 mkdtemp 臨時目錄清理，消除 /tmp 殘留洩漏（test hygiene）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- **測試臨時目錄洩漏修正（test hygiene）**：數個測試以 `tempfile.mkdtemp()`（不會自動清）建臨時目錄卻無對應清理，每跑一次就在 `/tmp` 留下殘骸（`sw-wal-*` 等 prefix 與 generic `/tmp/tmpXXXX`）；累積會混淆實機除錯（誤把測試殘留當 production WAL 洩漏）。修正：`tests/test_event_engine.py`（`sw-wal-` wal_dir）、`tests/test_file_transfer.py`（2 處 `outdir`）、`tests/test_session_capture.py`（8 處 setUp `self._tmpdir` + 4 處 local `tmpdir`）各以 `self.addCleanup(shutil.rmtree, <dir>, ignore_errors=True)` 補清（失敗亦清、不依賴 tearDown）。production `sw_core/` 不受影響（WalWriter 寫 XDG state dir，從不建 `/tmp/sw-wal-*`）。
 - **daemon start/connect 韌性強化（#108 #1/#2 hardening）**：#108 頭號根因（POSIX daemon 啟動改寫 `config.yaml`）已由 #84 PORT-4 POSIX guard（PR #109）修掉；本變更補其殘留兩項：
   - **#1：`serialwrap daemon start` 納入監管模式 gate（`sw_core/cli.py` `_run_daemon_start`）**——systemd 模式下重導到 `service start`（回應含 `_routed_to:"service start"`，對稱於既有 `daemon stop`→`service stop`），不再顯式 spawn 非託管 daemon；故 `minicom_router` 的 `AUTO_START_DAEMON=1` 在 systemd 模式不再生 coexist daemon。on-demand 模式 spawn 前以 `health.ping` 冪等探測（`_probe_healthy_daemon`），已有健康 daemon 時回 `{ok:true, already_running:true}` no-op。`daemon start` subparser 補 `--with-sudo`；`should_auto_spawn()` 由 dead code 接回使用。
   - **#2：`_resolve_endpoint` 對 dangling socket 依 `supervision_mode` fallback**——當 `config.yaml` 的 `socket_path` 為不可連的 unix socket 時，依 `supervision_mode` 推 canonical endpoint（`systemd-system`→`SYSTEM_SOCKET`；其餘→`SOCKET_PATH`）並改連之（stderr 提示），canonical 不可連或同值則回原值讓既有錯誤照常浮現；新增 `_endpoint_alive()` helper（unix connect probe，非 unix endpoint 跳過）。CLI 對 `config.yaml` 維持唯讀、不 self-heal 改寫。明確 `--endpoint`/`--socket` 不受 fallback 影響。

--- a/tests/test_event_engine.py
+++ b/tests/test_event_engine.py
@@ -112,6 +112,7 @@ class TestBridgeWiring(unittest.TestCase):
             received: list[tuple[str, str, int]] = []
 
             wal_dir = tempfile.mkdtemp(prefix="sw-wal-")
+            self.addCleanup(shutil.rmtree, wal_dir, ignore_errors=True)
             wal = WalWriter(wal_dir=wal_dir)
 
             def on_rx(data: bytes) -> None:

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import os
+import shutil
 import tempfile
 import unittest
 from typing import Any
@@ -215,6 +216,7 @@ class TestPullFileSuccess(unittest.TestCase):
         bridge.enqueue_rx(f"{md5}  /etc/test\r\n{_PROMPT}")
 
         outdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, outdir, ignore_errors=True)
         local = os.path.join(outdir, "pulled.bin")
         try:
             result = pull_file(
@@ -279,6 +281,7 @@ class TestPullFileSuccess(unittest.TestCase):
         bridge.enqueue_rx(f"{md5}  /tmp/binary.bin\r\n{_PROMPT}")
 
         outdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, outdir, ignore_errors=True)
         local = os.path.join(outdir, "ansi_pull.bin")
         try:
             result = pull_file(

--- a/tests/test_session_capture.py
+++ b/tests/test_session_capture.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
 import threading
 import time
@@ -48,6 +49,7 @@ class TestLogStartStop(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, ignore_errors=True)
         self._log_dir = os.path.join(self._tmpdir, "logs")
         self._wal_dir = os.path.join(self._tmpdir, "wal")
         os.makedirs(self._wal_dir, exist_ok=True)
@@ -172,6 +174,7 @@ class TestConfigLogDir(unittest.TestCase):
         import yaml
 
         tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
         yaml_content = {
             "defaults": {"log_dir": "/my/log/dir"},
             "profiles": {
@@ -205,6 +208,7 @@ class TestConfigLogDir(unittest.TestCase):
         import yaml
 
         tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
         yaml_content = {
             "defaults": {"log_dir": "/default/dir"},
             "profiles": {
@@ -238,6 +242,7 @@ class TestConfigLogDir(unittest.TestCase):
         import yaml
 
         tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
         yaml_content = {
             "defaults": {"log_dir": "/default/dir"},
             "profiles": {
@@ -275,6 +280,7 @@ class TestLogStartErrorPaths(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, ignore_errors=True)
         self._wal_dir = os.path.join(self._tmpdir, "wal")
         os.makedirs(self._wal_dir, exist_ok=True)
 
@@ -329,6 +335,7 @@ class TestLogStopFields(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, ignore_errors=True)
         self._log_dir = os.path.join(self._tmpdir, "logs")
         self._wal_dir = os.path.join(self._tmpdir, "wal")
         os.makedirs(self._wal_dir, exist_ok=True)
@@ -379,6 +386,7 @@ class TestRxEdgeCases(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, ignore_errors=True)
         self._log_dir = os.path.join(self._tmpdir, "logs")
         self._wal_dir = os.path.join(self._tmpdir, "wal")
         os.makedirs(self._wal_dir, exist_ok=True)
@@ -478,6 +486,7 @@ class TestMultiSessionCapture(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, ignore_errors=True)
         self._log_dir = os.path.join(self._tmpdir, "logs")
         self._wal_dir = os.path.join(self._tmpdir, "wal")
         os.makedirs(self._wal_dir, exist_ok=True)
@@ -540,6 +549,7 @@ class TestEnvVarLogDir(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, ignore_errors=True)
         self._wal_dir = os.path.join(self._tmpdir, "wal")
         os.makedirs(self._wal_dir, exist_ok=True)
 
@@ -580,6 +590,7 @@ class TestLogFilename(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, ignore_errors=True)
         self._log_dir = os.path.join(self._tmpdir, "logs")
         self._wal_dir = os.path.join(self._tmpdir, "wal")
         os.makedirs(self._wal_dir, exist_ok=True)
@@ -629,6 +640,7 @@ class TestPublicDictCapture(unittest.TestCase):
     def test_no_capture_returns_none(self) -> None:
         """無 active capture 時 capture 欄位為 None"""
         tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
         wal_dir = os.path.join(tmpdir, "wal")
         os.makedirs(wal_dir, exist_ok=True)
         profile = _make_profile("COM0", log_dir=tmpdir)
@@ -651,6 +663,7 @@ class TestSelectorVariants(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, ignore_errors=True)
         self._log_dir = os.path.join(self._tmpdir, "logs")
         self._wal_dir = os.path.join(self._tmpdir, "wal")
         os.makedirs(self._wal_dir, exist_ok=True)
@@ -692,6 +705,7 @@ class TestStopCaptureLocked(unittest.TestCase):
 
     def setUp(self) -> None:
         self._tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmpdir, ignore_errors=True)
         self._log_dir = os.path.join(self._tmpdir, "logs")
         self._wal_dir = os.path.join(self._tmpdir, "wal")
         os.makedirs(self._wal_dir, exist_ok=True)


### PR DESCRIPTION
## Summary

修正測試臨時目錄洩漏（test hygiene）。數個測試以 `tempfile.mkdtemp()`（**不會自動清**，不像 `TemporaryDirectory()` context manager）建臨時目錄卻無對應清理，每跑一次就在 `/tmp` 留下殘骸——`sw-wal-*` 等 prefix 與 generic `/tmp/tmpXXXX`。累積後會在實機除錯時造成混淆（誤把測試殘留當成 production WAL 洩漏）。

**Production 不受影響**：`sw_core/` 從不使用 `mkdtemp`/`sw-wal-`，`WalWriter` 寫 XDG state dir（`~/.local/state/serialwrap/wal`），不會產生 `/tmp/sw-wal-*`。本 PR 純測試衛生修正。

**修法**（皆以 `self.addCleanup(shutil.rmtree, <dir>, ignore_errors=True)`——失敗亦清、不依賴 tearDown 是否存在/執行）：

- `tests/test_event_engine.py`：line 114 的 `wal_dir`（`sw-wal-` prefix）。
- `tests/test_file_transfer.py`：2 處 `outdir`（補 `import shutil`）。
- `tests/test_session_capture.py`：8 處 setUp 的 `self._tmpdir` + 4 處 local `tmpdir`（補 `import shutil`）。

未動的測試（`test_event_cli` `finally: shutil.rmtree`、`test_event_counter/dispatcher/log/registry/rpc`、`test_human_agent_coexist` 等）本就有 `addCleanup`/`rmtree`，正常會清——不在本 PR 範圍。

## Test Plan

- [x] `python3 -m pytest -q tests/test_event_engine.py tests/test_file_transfer.py tests/test_session_capture.py tests/test_event_cli.py tests/test_event_counter.py tests/test_event_dispatcher.py tests/test_event_log.py tests/test_event_registry.py tests/test_event_rpc.py` → 96 passed
- [x] 跑後 `/tmp` 無新增 `sw-wal-*` / `sw-*` 殘留（前後計數不變）
- [x] `python3 -m policy_check --repo .` 通過

## Policy Checklist (R-11)

- [x] 分支不是 `main`（`feature/test-tmpdir-leak-cleanup`）
- [x] `CHANGELOG.md` 已更新（`[Unreleased]` → Fixed）
- [x] `VERSION` 已更新（若有版本號變動）— 無版本變動，N/A
- [x] `python3 -m pytest -q tests/` 通過（無新增失敗；純測試清理改動）
- [x] `python3 -m policy_check --repo .` 通過
- [x] `CLAUDE.md` 未改動（N/A）
- [x] 已標記 exemption label（若適用）— 無關聯 issue，N/A

## Issue Reference

無（實機除錯時發現的測試衛生問題）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
