### PR TITLE
fix(setup): 清理舊版 serialwrap-mcp legacy symlink（#59）＋英文 README／runtime path 修正＋brag brief

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`serialwrap setup` 清理舊版 serialwrap-mcp legacy symlink（#59）**：物化新版 `~/.agents/skills/serialwrap` skill 後，清理舊 `~/.agents/skills/serialwrap-mcp` legacy symlink，避免 agent 同時載入新舊 skill 誤走已退役 MCP 流程；僅清已知 legacy symlink，不刪同名真實目錄或一般檔。
+
+### Changed
+
+- **README：英文 operator reference + runtime path 修正**：新增英文 README 段；flash endpoint 與 daemon socket 範例路徑由舊 `/tmp/serialwrap/…` 改為 `<run-dir>/…`（RUN_DIR 預設 `$XDG_RUNTIME_DIR/serialwrap`，可 `SERIALWRAP_TTYMCU_PATH` / `SERIALWRAP_SOCKET` 覆寫），中英範例與 endpoint 對照表對齊。新增 `brag-output/composition-brief.md`（發表影片 composition brief），舊 `brag-plan.md` 改為指向 brief 的 tombstone。
+
 ## [0.2.2] - 2026-07-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,9 @@ policy_version: 1.0.10
 ## 語言政策
 
 - 本 repo 文件、註解、docstring、README、規格、commit message 與 AI 回覆**一律使用繁體中文**。
+- **例外（雙語／對外發布素材）**：
+  - `README.md` 採**中英雙語並存**（`English` 章節 + `繁體中文` 章節；英文段為繁中段的對照翻譯，供非中文操作者閱讀）——兩段內容須保持一致，非以英文取代繁中。
+  - `brag-output/**` 為**對外發布素材**（launch video composition brief 等，目標受眾與影片字幕皆為英文），以**英文**撰寫，不受「一律繁中」限制。此為刻意例外，範圍僅限該目錄。
 
 ## Commit 政策
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,367 @@
 # serialwrap
 
+> **[English](#english)** ｜ **[繁體中文](#繁體中文)**
+
+---
+
+## Install
+
+This README is the canonical operator reference. For a managed install that
+materializes profiles, the broker minicom wrapper, and daemon supervision, see
+[Quick Start](#quick-start). For the full Traditional Chinese reference,
+including diagrams and field validation notes, see [繁體中文](#繁體中文).
+
+```bash
+pipx install "git+https://github.com/hamanpaul/serialwrap@v0.2.2"
+serialwrap setup
+serialwrap doctor
+```
+
+## Usage
+
+`serialwrapd` owns the real UART. Agents, CLI users, and human consoles talk to
+the daemon through `serialwrap`, so command execution, raw console visibility,
+WAL capture, and recovery remain coordinated.
+
+```bash
+serialwrap daemon status
+serialwrap session list
+serialwrap session bind --selector COM0 --device-by-id /dev/serial/by-id/<target-by-id>
+serialwrap session attach --selector COM0
+serialwrap cmd submit --selector COM0 --mode line --source agent:diag --cmd "ifconfig"
+```
+
+## Version
+
+The canonical project version is [`VERSION`](./VERSION). Release history lives
+in [`CHANGELOG.md`](./CHANGELOG.md).
+
+---
+
+## English
+
+`serialwrap` is a broker for sharing one UART between multiple AI agents and
+multiple human consoles. The main runtime is `serialwrapd`; the `serialwrap` CLI
+and the broker-aware minicom wrapper are thin clients. The design keeps the
+target UART byte-clean while preserving single-writer arbitration, transparent
+console views, command result capture, and diagnostics.
+
+### Core Features
+
+- The target UART receives only raw commands or raw keystrokes; no begin/end
+  markers are injected into the target input stream.
+- Multiple minicom consoles can attach to the same COM session and observe the
+  same raw RX stream.
+- Foreground commands are serialized by the arbiter so agent and human writes do
+  not interleave.
+- Command execution supports `line`, `background`, and `interactive` modes.
+- Built-in `session self-test` and `session recover` classify missing devices,
+  TTY rebinding, stale bridges, target unresponsiveness, and login states.
+- Always-on `raw.wal.ndjson` plus `raw.mirror.log` and `log tail-text` provide
+  auditable UART evidence.
+
+### Prerequisites
+
+- **Python 3.10+**
+- **pipx**
+- **PyYAML** — installed automatically by the package metadata
+- **jq** — required by the broker minicom route
+- **minicom** — required for human console workflows on Linux/WSL
+
+For serial devices on Linux, add the user to `dialout` and log in again:
+
+```bash
+sudo usermod -aG dialout "$USER"
+```
+
+On WSL, enable systemd in `/etc/wsl.conf` and run `wsl --shutdown`; otherwise
+`serialwrap setup` falls back to on-demand daemon supervision.
+
+### Quick Start
+
+```bash
+# Managed install
+pipx install "git+https://github.com/hamanpaul/serialwrap@v0.2.2"
+serialwrap setup
+serialwrap doctor
+
+# Check daemon and sessions
+serialwrap daemon status
+serialwrap session list
+
+# Bind and attach the first target
+serialwrap session bind --selector COM0 --device-by-id /dev/serial/by-id/<target-by-id>
+serialwrap session attach --selector COM0
+
+# Run a foreground command
+serialwrap cmd submit --selector COM0 --mode line --source agent:diag --cmd "ifconfig"
+serialwrap cmd status --cmd-id <cmd_id>
+```
+
+For local development, run `./install.sh`; it performs the same package install
+and `serialwrap setup` flow from the checkout.
+
+### Architecture
+
+The broker path is:
+
+```text
+CLI / minicom wrapper
+  -> serialwrapd RPC
+  -> SerialwrapService
+  -> CommandArbiter / SessionManager
+  -> UARTBridge
+  -> target UART
+  -> WAL + mirror log + console fan-out
+```
+
+Key modules:
+
+- `sw_core/service.py` wires the service, RPC dispatch, arbiter, session
+  manager, device watcher, and WAL writer.
+- `sw_core/arbiter.py` runs one worker queue per session and enforces a single
+  UART writer.
+- `sw_core/session_manager.py` owns session state, binding, alias persistence,
+  console attach, interactive leases, recover, and capture.
+- `sw_core/uart_io.py` owns UART RX/TX, console fan-out, human raw mode, and
+  deferred human input during agent commands.
+- `sw_core/wal.py` writes `raw.wal.ndjson` and `raw.mirror.log`.
+
+### Session States
+
+Sessions normally move from `DETACHED` to `ATTACHING`, then either `ATTACHED`
+or `READY`.
+
+- `ATTACHED` means the bridge exists and human console access is available, but
+  line commands are not guaranteed to be frameable.
+- `READY` means the profile has a usable prompt and `ready_probe`; agent command
+  submission is allowed.
+- `RELEASED` means the real device has been handed off to an external tool.
+- `FLASHING` means the MCU flash endpoint is currently bridging an external
+  flasher.
+
+Command-capable profiles require a non-empty `ready_probe`. Passthrough-style
+profiles intentionally stay at `ATTACHED` and return
+`PROFILE_NOT_COMMAND_CAPABLE` for `cmd submit`.
+
+### Profiles and Binding
+
+Profiles live under `profiles/*.yaml` and define platform behavior, prompt
+matching, login prompts, ready probes, credentials environment variable names,
+and UART settings. Targets may be explicit, or the daemon can auto-detect a
+template from the current UART output.
+
+Profile selection precedence:
+
+```text
+pin > sticky > dynamic detection > others-template fallback
+```
+
+Use stable `/dev/serial/by-id/` or `/dev/serial/by-path/` selectors rather than
+volatile `/dev/ttyUSB*` names. If several boards use the same USB-serial chip
+and therefore share the same by-id value, prefer by-path.
+
+### Command Modes
+
+`line` is for commands that return to a prompt:
+
+```bash
+serialwrap cmd submit --selector COM0 --mode line --source agent:diag --cmd "ifconfig"
+serialwrap cmd status --cmd-id <cmd_id>
+```
+
+`background` is for commands that return a prompt early but keep producing
+output later:
+
+```bash
+serialwrap cmd submit --selector COM0 --mode background --source agent:bg --cmd "wl assoc scan"
+serialwrap cmd result-tail --cmd-id <cmd_id> --from-chunk 0 --limit 200
+```
+
+`interactive` is for full-screen or key-driven workflows:
+
+```bash
+serialwrap session interactive-open --selector COM0 --owner agent:menu --command "menuconfig"
+serialwrap session interactive-send --interactive-id <interactive_id> --data down --encoding key
+serialwrap session interactive-close --interactive-id <interactive_id>
+```
+
+Supported key encodings include `enter`, `tab`, `escape`, `ctrl-c`, `ctrl-d`,
+`up`, `down`, `left`, and `right`.
+
+### Human Console Coexistence
+
+The broker minicom wrapper is `serialwrap-minicom COMx`. The first human console
+attached to an `ATTACHED` or `READY` session receives raw interactive ownership,
+so arrow keys, Tab, and escape sequences behave like a direct minicom session.
+When an agent submits a command, the daemon suspends human raw mode, runs the
+agent command, then resumes the human console and flushes deferred input.
+
+```bash
+serialwrap-minicom COM0
+serialwrap session console-list --selector COM0
+serialwrap session console-detach --selector COM0 --client-id <client_id>
+```
+
+### File Transfer
+
+`file push` and `file pull` transfer files over UART using base64 chunks with
+checksum verification:
+
+```bash
+serialwrap file push --selector COM0 --local ./firmware.bin --remote /tmp/firmware.bin
+serialwrap file pull --selector COM0 --remote /etc/config/wireless --local ./wireless.bak
+```
+
+The session must be `READY`, and the target must provide `base64` and `md5sum`.
+
+### MCU Firmware Workflows
+
+For external flash tools that need exclusive access to the raw UART, release the
+device and reclaim it afterwards:
+
+```bash
+serialwrap device release --selector COM0 --source agent:flash --reason "flash CC2674"
+ocp-mcu-upgrade -d /dev/ttyUSB1 -b 115200 -t 8 -e -s -i fw.bin
+serialwrap device attach --selector COM0
+```
+
+Linux/WSL also supports the `/dev/ttyMCU` flash endpoint. The daemon remains the
+only real-device reader, probes for the MCU BSL ACK, bridges the external
+flasher only to the verified MCU line, and restores the session when flashing
+finishes:
+
+```bash
+serialwrap mcu patterns
+serialwrap mcu status
+# Endpoint is <run-dir>/dev/ttyMCU (SERIALWRAP_RUN_DIR, default
+# $XDG_RUNTIME_DIR/serialwrap; override with SERIALWRAP_TTYMCU_PATH). Point the flasher at it:
+ocp-mcu-upgrade -d "$XDG_RUNTIME_DIR/serialwrap/dev/ttyMCU" -b 115200 -t 8 -e -s -i fw.bin
+```
+
+### Diagnostics and Recovery
+
+Start with:
+
+```bash
+serialwrap session self-test --selector COM0
+serialwrap doctor
+serialwrap daemon status
+```
+
+Common classifications include `OK`, `DEVICE_MISSING`,
+`DEVICE_REBOUND_REQUIRED`, `BRIDGE_DOWN`, `VTTY_STALE`,
+`TARGET_UNRESPONSIVE`, `LOGIN_REQUIRED`, `ATTACHED_NOT_READY`,
+`REBOOTING`, `HUMAN_INTERACTIVE_ACTIVE`, and `PASSTHROUGH`.
+
+Use `recover` for unhealthy sessions:
+
+```bash
+serialwrap session recover --selector COM0
+```
+
+`recover` first tries to re-probe an attached bridge, then uses control
+characters for a `READY` shell, and finally reattaches when the bridge is gone
+but the device remains present.
+
+### Logs and Evidence
+
+Default output paths:
+
+| File | Purpose |
+|---|---|
+| `~/.local/state/serialwrap/wal/raw.wal.ndjson` | Authoritative append-only UART event log |
+| `~/.local/state/serialwrap/wal/raw.mirror.log` | Human-readable text mirror |
+| `~/.local/state/serialwrap/state.json` | Persistent aliases and binding overrides |
+| `~/b-log/{COM}_{YYMMDD}-{HHMMSS}.log` | Agent-triggered focused session capture |
+
+Useful commands:
+
+```bash
+serialwrap session log-start --selector COM0
+serialwrap session log-stop --selector COM0
+serialwrap log tail-text --selector COM0 --from-seq 0 --limit 200
+serialwrap wal export --from-seq 0 --limit 500
+serialwrap wal reset
+```
+
+### Windows Support
+
+Windows uses pyserial for `COMx` access and a loopback TCP RPC endpoint instead
+of Unix sockets. Human console transport uses a TCP listener that can be opened
+from TeraTerm or PuTTY.
+
+```powershell
+serialwrapd.exe --socket tcp://127.0.0.1:48700
+serialwrap.exe daemon status
+serialwrap.exe session list
+serialwrap.exe cmd submit --selector COM0 --cmd "ver"
+```
+
+On Windows, MCU flashing should use `device release` / `device attach`; the
+Linux `/dev/ttyMCU` PTY bridge model is not used.
+
+### Remote Support
+
+Remote operation is normally done through an SSH tunnel. The remote FAE host
+exposes the daemon Unix socket to loopback TCP with `socat`, and the RD host
+forwards that port through SSH:
+
+```bash
+# On the FAE host — the daemon socket is <run-dir>/serialwrapd.sock
+# (default $XDG_RUNTIME_DIR/serialwrap; override with SERIALWRAP_SOCKET).
+socat TCP-LISTEN:7777,bind=127.0.0.1,reuseaddr,fork \
+      UNIX-CONNECT:"$XDG_RUNTIME_DIR/serialwrap/serialwrapd.sock" &
+
+# On the RD host
+ssh -N -L 127.0.0.1:7777:127.0.0.1:7777 fae_user@fae_host
+serialwrap --endpoint tcp://127.0.0.1:7777 session list
+```
+
+Never expose the TCP bridge on a non-loopback interface; serialwrap RPC can
+submit commands, transfer files, and control the daemon.
+
+### Event Trigger Engine
+
+The event trigger engine watches UART RX lines and spawns bounded handler
+processes when rules match:
+
+```bash
+serialwrap event add --file rule.json
+serialwrap event list --selector COM0
+serialwrap event enable --selector COM0
+serialwrap event status --selector COM0
+serialwrap event tail --rule-id ops.kernel-panic -n 20
+```
+
+Handlers must finish within `timeout_ms`, avoid daemonizing, read the JSON
+payload from stdin, and use exit code `0` for success.
+
+### Testing
+
+```bash
+python3 -m pytest -q tests/
+```
+
+`pytest` is the policy reference because it loads the environment isolation and
+live-daemon guard in `tests/conftest.py`. `unittest` is still available for
+focused debugging:
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+### Further Reading
+
+- Detailed design and API contract: [`docs/serialwrap-spec.md`](./docs/serialwrap-spec.md)
+- Heartbeat keepalive design: [`docs/design-heartbeat-keepalive.md`](./docs/design-heartbeat-keepalive.md)
+- File transfer design: [`docs/design-file-transfer.md`](./docs/design-file-transfer.md)
+- Event trigger design: [`docs/plan-event-trigger.md`](./docs/plan-event-trigger.md)
+
+---
+
+## 繁體中文
+
 `serialwrap` 是面向單一 UART、多 agent 與多人 console 共用的 broker。主線由 `serialwrapd`、`serialwrap` CLI 與 `minicom_router.sh` 組成，目標是在不污染 target UART 輸入的前提下，保留單寫入仲裁、透明 console 視圖、結果擷取與故障診斷能力。
 
 ## 核心特性
@@ -606,8 +968,9 @@ serialwrap mcu patterns
 serialwrap mcu status
 
 # 1) 先在 DUT console（serialwrap console session）把 MCU 帶進 BSL（GPIO reset，依板而定）
-# 2) host 改用 serialwrap 端點取代原本的 raw /dev/ttyUSBx：
-ocp-mcu-upgrade -d /tmp/serialwrap/dev/ttyMCU -b 115200 -t 8 -e -s -i fw.bin
+# 2) host 改用 serialwrap 端點取代原本的 raw /dev/ttyUSBx（端點為 <run-dir>/dev/ttyMCU；
+#    RUN_DIR 預設 $XDG_RUNTIME_DIR/serialwrap，可用 SERIALWRAP_TTYMCU_PATH 覆寫）：
+ocp-mcu-upgrade -d "$XDG_RUNTIME_DIR/serialwrap/dev/ttyMCU" -b 115200 -t 8 -e -s -i fw.bin
 # serialwrap 自動 sync-probe 認線 → bridge → 期望 Return error code : 0x0；燒完該 session 自動恢復 console
 ```
 
@@ -1051,8 +1414,9 @@ CLI（`bind` 只改 device、`recover`/`clear` 沿用舊 profile）。在 produc
 **步驟 1**：以 `socat` 將 Unix socket 暴露成 TCP（**只 bind loopback，不可對外**）：
 
 ```bash
+# socket 為 <run-dir>/serialwrapd.sock（RUN_DIR 預設 $XDG_RUNTIME_DIR/serialwrap，可 SERIALWRAP_SOCKET 覆寫）
 socat TCP-LISTEN:7777,bind=127.0.0.1,reuseaddr,fork \
-      UNIX-CONNECT:/tmp/serialwrap/serialwrapd.sock &
+      UNIX-CONNECT:"$XDG_RUNTIME_DIR/serialwrap/serialwrapd.sock" &
 ```
 
 > ⚠️ **安全注意**：
@@ -1104,8 +1468,8 @@ serialwrap --endpoint tcp://127.0.0.1:7777 cmd submit \
 
 | 格式 | 用途 |
 |---|---|
-| `/tmp/serialwrap/serialwrapd.sock` | 本機 Unix socket（預設，向後相容） |
-| `unix:///tmp/serialwrap/serialwrapd.sock` | 本機 Unix socket（顯式指定） |
+| `<run-dir>/serialwrapd.sock` | 本機 Unix socket（預設；RUN_DIR 預設 `$XDG_RUNTIME_DIR/serialwrap`，可 `SERIALWRAP_SOCKET` 覆寫） |
+| `unix://<run-dir>/serialwrapd.sock` | 本機 Unix socket（顯式 `unix://` 前綴） |
 | `tcp://127.0.0.1:7777` | 透過 ssh-tunnel 連接遠端 daemon |
 
 ### 限制與注意事項
@@ -1193,7 +1557,7 @@ Handler **建議**：
 
 - 詳細決策與 API 契約：[`docs/serialwrap-spec.md`](./docs/serialwrap-spec.md)
 
-## Install
+## 安裝
 
 ```bash
 pipx install "git+https://github.com/hamanpaul/serialwrap@v0.2.2"
@@ -1208,7 +1572,7 @@ serialwrap doctor    # 驗證環境
 
 依賴：Python 3.10+（`pipx install` 自動帶入 `pyyaml`）；human console 路徑另需 `jq` 與 `minicom`。
 
-## Usage
+## 使用方式
 
 <!-- BEGIN: cli-help marker="serialwrap-help" -->
 usage: serialwrap [-h] [--socket SOCKET] [--endpoint ENDPOINT]
@@ -1338,6 +1702,6 @@ serialwrap session bind --selector COM0 --device-by-id /dev/serial/by-id/<target
 serialwrap session attach --selector COM0
 ```
 
-## Version
+## 版本
 
 目前版本請見 [`VERSION`](./VERSION) 檔案。版本歷程請見 [`CHANGELOG.md`](./CHANGELOG.md)。

--- a/brag-output/brag-plan.md
+++ b/brag-output/brag-plan.md
@@ -1,0 +1,11 @@
+# Brag Plan — SUPERSEDED (tombstone)
+
+> **This file is intentionally a stub.** The single authoritative, publish-safe launch-video spec is
+> **[`composition-brief.md`](./composition-brief.md)** — grounded in the current serialwrap **0.2.2**
+> architecture and **real measured pilot data** (agent-over-one-UART, raw-tty vs serialwrap).
+>
+> The earlier plan that used to live here referenced a **2026-02 internal webinar** as source material
+> and a superseded (tmux/marker) architecture narrative. That material is **not used** and must not be
+> revived — it would break the publish-safe constraint ("recreate, never embed; Feb demo not used").
+>
+> **Use `composition-brief.md`. Ignore this file except as a pointer.**

--- a/brag-output/composition-brief.md
+++ b/brag-output/composition-brief.md
@@ -1,0 +1,159 @@
+# serialwrap — Launch Video Composition Brief
+
+> **This is the English composition prompt** (the primary deliverable). It hands a complete,
+> publish-safe spec to the video generator (Hyperframes). It is grounded in the **current 0.2.2
+> architecture** and **real measured pilot data** captured on a live Orange Pi over one UART.
+> The Feb-2026 demo footage is **not** used (it shows a superseded tmux/marker architecture).
+
+---
+
+## 1. One-liner
+
+**An AI agent drives real firmware over one serial line — two ways. serialwrap makes it faster,
+cleaner, and safe for many agents at once.**
+
+## 2. Format & tone
+
+- **Format:** landscape, 1920×1080.
+- **Duration:** ~24 s (5 scenes).
+- **Tone:** polished, cinematic-leaning. Quiet, confident, systems-grade. Drama only at the open
+  (the mess) and the close (the wordmark). No hype, no fake urgency.
+- **Register:** honest and technical. This audience (developers, firmware/embedded engineers) rewards
+  specificity and punishes spin.
+
+## 3. Thesis (the product angle)
+
+Not an abstract "many users share nicely" claim. A concrete contrast on **one real task**:
+
+- **Raw tty (the baseline):** hand an agent only `/dev/ttyUSB0`. It must build its own framing — set
+  the line, poke for a prompt, invent a delimiter, guess when output ends. It works, but it is slow
+  and laborious.
+- **serialwrap:** the agent submits a command and reads back clean, framed output. No line config, no
+  marker, no guessing.
+
+Then the payoff the bare device **cannot** match: **many agents on one wire at once, plus a human
+console watching — arbitrated, serialized, zero collisions.**
+
+## 4. What is real (source material — recreate, do not embed)
+
+All scenes are **recreated originals**. These are the true facts to depict faithfully:
+
+- **Board:** an Orange Pi single-board computer, reached over one UART (`ttyUSB0`, a CH340 adapter).
+- **Task:** capture ~5 s of packets with `tcpdump` on `wlan0` while making one HTTPS request, then
+  compute the **TCP three-way-handshake time** (SYN → SYN-ACK). Real answer landed at **~80 ms**
+  (cross-checked by `curl`'s own connect timing).
+- **Agent:** a headless coding agent (depict generically as "AI agent"). Both arms ran method-pure
+  (every command audited); both reached a correct answer.
+- **Measured difference (single pilot run per arm — illustrative, not a benchmark):**
+  - **Wall-clock time:** raw tty **~8.0 min** vs serialwrap **~3.7 min**  → **~2.1× faster**.
+  - **Agent effort (generated tokens):** raw tty **~2.3×** more than serialwrap.
+  - Token *bill* overall was about the same — the difference is **time and effort**, not spend.
+- **Raw-tty process (depict this literally — it is the visceral proof):** `stty -F /dev/ttyUSB0 …`,
+  then Python opening the device, writing `\x03\r\n`, inventing a `__CHK_START__` marker, timed reads
+  with retries.
+- **serialwrap process:** `serialwrap cmd submit --selector COM0 --cmd '…'` → `serialwrap cmd status`
+  → one clean stdout line.
+- **Multi-agent (real):** two agents (`alpha`, `bravo`) with unrelated jobs fired at COM0 **at the
+  same instant** (submits at +0.00/+0.08/+0.15 s). The arbiter ran them **one at a time** (execution
+  windows never overlapped). All **6/6** outputs came back clean, no interleaving. A human `minicom`
+  console watched the same wire live; its control was suspended during each agent command and resumed
+  after.
+
+## 5. Visual identity
+
+- **Ground:** terminal near-black `#0d1411` (faint green bias). This is a CLI/daemon product — the
+  terminal *is* its face.
+- **Color = role** (from the project's own diagram language):
+  - **AI agent / human** → blue `#3f8fd0` (second agent: violet `#9070d8`).
+  - **serialwrap core / arbiter** → green `#46c489`.
+  - **UART / WAL / IO** → amber `#e0954a`.
+  - **collision / the old mess** → red `#d9553f`.
+- **Type:** monospace for everything on the "wire" (commands, output, data) — the terminal voice;
+  a clean humanist sans for captions and the wordmark. Large, confident, few words.
+- **Restraint rule:** one accent moment per scene. Motion is crisp (0.3–0.6 s), then holds so text is
+  readable (short label ~0.8 s; a sentence ~0.3 s/word).
+
+## 6. Storyboard
+
+### Scene 1 — The old way (hook) — 3.5 s
+Dark terminal. An agent pokes a **raw serial device** by hand: `stty -F /dev/ttyUSB0 115200 raw -echo`
+types in, then fragments flash — `write \x03\r\n`, `__CHK_START__`, a timed read that returns garbled,
+a retry. The screen feels effortful and messy (amber device text, red glitches on the retries).
+Caption **SLAMS in and holds**: **"To drive one serial port, the agent builds its own protocol."**
+- Sequential/interaction: yes — the hand-rolled framing steps appear one by one, with one red retry.
+- Audio: sparse keystrokes; a small dissonant tick on the retry. Music barely in, ducked.
+- Transition: hard cut → Scene 2.
+
+### Scene 2 — serialwrap (reveal) — 4.5 s
+Same task. The mess resolves into two clean lines:
+`serialwrap cmd submit --selector COM0 --cmd '…'` then `serialwrap cmd status` → a single framed
+result line. The `serialwrap` wordmark (green) settles above it; the agent reads
+**`handshake ≈ 80 ms`**. Caption holds: **"serialwrap: submit, read, done."**
+- Sequential/interaction: yes — the two commands land, then the clean result; the handshake number
+  counts up to 80 ms.
+- Audio: one low "resolve" tick as garbage → clean; music bed steps up and stabilizes.
+- Transition: soft crossfade → Scene 3.
+
+### Scene 3 — The difference (highlight) — 4.5 s
+Two lanes, same task. A time bar fills for each: **raw tty 8.0 min** (amber, long) vs
+**serialwrap 3.7 min** (green, short), with **"~2× faster"** landing on the gap. A quieter secondary
+line: **"and ~half the agent's effort."** Caption: **"Same wire. Same task. Half the time."**
+- Sequential/interaction: yes — the two time bars grow (raw-tty bar visibly longer), then the ratio
+  stamps in. Hold each readable.
+- Audio: two measured beats as the bars land; one accent on "~2× faster".
+- Transition: clean wipe → Scene 4.
+
+### Scene 4 — Many agents, one wire (capability) — 7 s
+The differentiator the bare device can't do. Two agent chips — **alpha (blue)** and **bravo (violet)**
+— fire commands at one green **UART** lane **at the same time** (their submit tokens overlap). They
+funnel through an **arbiter** node that releases them **one at a time**; six clean result rows appear
+in execution order, each tagged to its own agent, none interleaved. A small **human `minicom`** panel
+sits alongside, watching the same wire (it dims — "suspended" — as each agent command runs, then
+brightens — "resumed"). Badges settle: **"serialized ✓  zero collision ✓  6/6"**.
+Caption: **"Many agents. One wire. Nobody collides."**
+- Sequential/interaction: yes — concurrent submit (overlapping) → serialized execution (one by one) →
+  clean rows; the human panel suspend/resume pulses with each command.
+- Audio: a steady tick per released command (rhythmic, one-at-a-time); a soft down/up pair on the
+  human suspend/resume.
+- Transition: dramatic-but-restrained hold → Scene 5.
+
+### Scene 5 — Close (outro) — 4 s
+Everything quiets to the **serialwrap** wordmark, green core breathing. Tagline holds:
+**"One UART. Many masters. Zero collisions."** Below it: `pipx install serialwrap`.
+- Audio: one low logo hit aligned to the music's strong cue (~16 s mark of the bed), then fade.
+- Transition: hold → end.
+
+**Music mood:** cinematic, restrained.
+**Audio arc:** low bed enters at the open and is ducked under the mess; steps up and stabilizes when
+serialwrap resolves the task; keeps a measured pulse under the time bars and the one-at-a-time agent
+execution; lands one logo hit at the wordmark, then fades.
+
+## 7. Audio direction
+
+- **Music:** bundled `happy-beats-business-moves-vol-1` (~120 BPM), low volume throughout, ducked at
+  the Scene-1 mess, faded at the end. Its strong-cue cluster (~16 s) targets the Scene-5 wordmark.
+- **SFX:** sparse, motion-matched, professional — keystrokes (Scene 1), one resolve tick (Scene 2),
+  one accent (Scene 3), a per-command tick + a suspend/resume pair (Scene 4), one logo hit (Scene 5).
+- **Restraint:** audio never crowds the "mess → clean" contrast; no continuous busy percussion.
+
+## 8. Publish-safe rules (hard)
+
+- **Recreate, never embed.** No screen recordings, no participant faces, no confidential material.
+- **Mask all identifiers.** Any IP → `192.168.x.x`; MACs hidden; hostname may stay generic
+  (`orangepi3`). No internal paths, no internal product/CVE specifics.
+- **Numbers are honest.** Show the pilot values as measured; do not inflate. The token *bill* was
+  ~tied — do not imply a large token saving. Lead with **time** and **effort**, which are real.
+
+## 9. Share copy (draft)
+
+> Watch an AI agent drive real firmware over one serial line. Hand it a raw tty and it hand-builds a
+> protocol; give it serialwrap and it just submits and reads — ~2× faster. And unlike the bare device,
+> serialwrap lets many agents (and a human console) share one UART with zero collisions.
+> **One UART. Many masters. Zero collisions.** 🧵
+
+## 10. Delivery gates
+
+- Runtime 20–25 s; every readable line holds long enough to read.
+- At least one scene shows the product *doing the work* (Scenes 2 & 4 do).
+- Every claim on screen is backed by the measured pilot data in §4.
+- `npx hyperframes lint` / `validate` pass before render.

--- a/changelog.d/59-clean-legacy-skill.md
+++ b/changelog.d/59-clean-legacy-skill.md
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 59
+scope: setup
+---
+`serialwrap setup` 物化新版 `~/.agents/skills/serialwrap` skill 後，會清理舊版 `~/.agents/skills/serialwrap-mcp` legacy symlink，避免 agent 同時載入新舊 skill 並誤走已退役 MCP 流程；清理僅針對已知 legacy symlink，不刪除同名真實目錄或一般檔。

--- a/sw_core/setup_cmd.py
+++ b/sw_core/setup_cmd.py
@@ -57,6 +57,7 @@ def _user_dirs(home: Path | str | None) -> dict[str, Path]:
         "config": config,
         "data": data,
         "agents_skill_link": home_path / ".agents" / "skills" / "serialwrap",
+        "legacy_agents_skill_link": home_path / ".agents" / "skills" / "serialwrap-mcp",
         "bin": home_path / ".local" / "bin",
     }
 
@@ -79,6 +80,19 @@ def _force_symlink(link: Path, target: Path) -> None:
     elif link.exists():
         link.unlink()
     link.symlink_to(target)
+
+
+def _remove_legacy_serialwrap_mcp_link(link: Path) -> None:
+    """移除舊版 ``serialwrap-mcp`` skill symlink，避免 agent 同時載入新舊 skill。
+
+    僅清理已知 legacy symlink；若使用者放的是真實目錄、一般檔或指向非
+    ``serialwrap-mcp`` 目標的 symlink，一律保留。
+    """
+    if not link.is_symlink():
+        return
+    target = link.readlink()
+    if target.name == "serialwrap-mcp" or "custom-skills/serialwrap-mcp" in str(target):
+        link.unlink()
 
 
 def _copy_profile_file(src_item: importlib.resources.abc.Traversable, dest: Path, *, force: bool) -> None:
@@ -196,6 +210,7 @@ def materialize_assets(
     skill_dest = dirs["data"] / "skill"
     _assets.copy_tree("skill", skill_dest)
     _force_symlink(dirs["agents_skill_link"], skill_dest)
+    _remove_legacy_serialwrap_mcp_link(dirs["legacy_agents_skill_link"])
 
     # ── 3. Minicom wrappers → ~/.local/bin（設可執行權限）───────────────
     bin_dest = dirs["bin"]

--- a/tests/test_flash_endpoint.py
+++ b/tests/test_flash_endpoint.py
@@ -17,6 +17,11 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def _open_noctty(path: str, flags: int) -> int:
+    """測試開 PTY slave 時避免取得 controlling terminal，防止 close 時收到 SIGHUP。"""
+    return os.open(path, flags | getattr(os, "O_NOCTTY", 0))
+
+
 def test_creates_pty_and_symlink():
     with tempfile.TemporaryDirectory() as d:
         link = os.path.join(d, "dev", "ttyMCU")
@@ -37,7 +42,7 @@ def test_endpoint_stays_silent_when_no_flash():
         ep = FlashEndpoint(link_path=link, on_flash_open=None)
         ep.start()
         try:
-            fd = os.open(link, os.O_RDONLY | os.O_NONBLOCK)
+            fd = _open_noctty(link, os.O_RDONLY | os.O_NONBLOCK)
             try:
                 time.sleep(0.8)            # 等數個 loop 週期
                 got = b""
@@ -63,7 +68,7 @@ def test_silent_even_after_client_write_when_no_match():
         ep = FlashEndpoint(link_path=link, on_flash_open=None)
         ep.start()
         try:
-            fd = os.open(link, os.O_RDWR | os.O_NONBLOCK)
+            fd = _open_noctty(link, os.O_RDWR | os.O_NONBLOCK)
             try:
                 os.write(fd, b"\x55\x55")   # 模擬 flasher sync
                 time.sleep(0.6)
@@ -102,7 +107,7 @@ def test_endpoint_slave_is_raw_for_byte_transparency():
         ep = FlashEndpoint(link_path=link)
         ep.start()
         try:
-            fd = os.open(link, os.O_RDWR | os.O_NONBLOCK)
+            fd = _open_noctty(link, os.O_RDWR | os.O_NONBLOCK)
             try:
                 oflag, lflag = termios.tcgetattr(fd)[1], termios.tcgetattr(fd)[3]
                 assert not (lflag & termios.ICANON)   # 非 canonical（不行緩衝）
@@ -123,7 +128,7 @@ def test_loop_survives_on_flash_open_exception():
         ep = FlashEndpoint(link_path=link, on_flash_open=boom)
         ep.start()
         try:
-            fd = os.open(link, os.O_RDWR | os.O_NONBLOCK)
+            fd = _open_noctty(link, os.O_RDWR | os.O_NONBLOCK)
             try:
                 os.write(fd, b"\x55\x55")        # 觸發 on_flash_open → 拋例外
                 time.sleep(0.5)

--- a/tests/test_setup_materialize.py
+++ b/tests/test_setup_materialize.py
@@ -58,6 +58,35 @@ def test_materialize_replaces_stale_real_directory_at_link(tmp_path, monkeypatch
     assert (stale / "SKILL.md").is_file()
 
 
+def test_materialize_removes_legacy_serialwrap_mcp_symlink(tmp_path, monkeypatch):
+    """新版 skill 已改名為 serialwrap；setup 須清掉舊 serialwrap-mcp symlink 避免雙載入。"""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    legacy_target = tmp_path / "custom-skills" / "serialwrap-mcp"
+    legacy_target.mkdir(parents=True)
+    (legacy_target / "SKILL.md").write_text("name: serialwrap-mcp\n", encoding="utf-8")
+    legacy_link = tmp_path / ".agents" / "skills" / "serialwrap-mcp"
+    legacy_link.parent.mkdir(parents=True)
+    legacy_link.symlink_to(legacy_target)
+    from sw_core.setup_cmd import materialize_assets
+    materialize_assets(home=tmp_path)
+    assert not legacy_link.exists()
+    assert (tmp_path / ".agents" / "skills" / "serialwrap").is_symlink()
+
+
+def test_materialize_keeps_real_legacy_named_directory(tmp_path, monkeypatch):
+    """清理只針對 symlink，避免刪除使用者手動放置的同名資料夾。"""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    legacy_dir = tmp_path / ".agents" / "skills" / "serialwrap-mcp"
+    legacy_dir.mkdir(parents=True)
+    (legacy_dir / "keep.txt").write_text("manual", encoding="utf-8")
+    from sw_core.setup_cmd import materialize_assets
+    materialize_assets(home=tmp_path)
+    assert legacy_dir.is_dir()
+    assert (legacy_dir / "keep.txt").read_text(encoding="utf-8") == "manual"
+
+
 def test_materialize_honors_serialwrap_config_dir_matching_daemon_profile_dir(tmp_path, monkeypatch):
     """I-B：只設 SERIALWRAP_CONFIG_DIR 時，setup 物化的 profiles 必須等於 daemon 讀的 PROFILE_DIR。"""
     import importlib


### PR DESCRIPTION
## Summary

三塊變更打包一起：

1. **fix(setup)（#59）** — `serialwrap setup` 物化新版 `~/.agents/skills/serialwrap` skill 後，清理舊版 `~/.agents/skills/serialwrap-mcp` legacy symlink，避免 agent 同時載入新舊 skill 並誤走已退役的 MCP 流程。清理僅針對已知 legacy symlink，不刪除同名真實目錄或一般檔。含 `tests/test_flash_endpoint.py`、`tests/test_setup_materialize.py` 對應測試。
2. **docs(readme)** — 新增英文 operator reference 段（Install / Usage / English 全段）；並修正 flash endpoint 與 daemon socket 的 runtime path：舊 `/tmp/serialwrap/…` → `<run-dir>/…`（RUN_DIR 預設 `$XDG_RUNTIME_DIR/serialwrap`，可用 `SERIALWRAP_TTYMCU_PATH` / `SERIALWRAP_SOCKET` 覆寫）。中英範例與 endpoint 對照表一併對齊，`~/.local/state/.../wal` 的「舊版 `/tmp`」歷史標註保留不動。
3. **docs(brag)** — 新增 `brag-output/composition-brief.md`：serialwrap 發表影片的英文 composition brief，publish-safe，以現行 0.2.2 架構與真實 pilot 數據（agent-over-one-UART、raw-tty vs serialwrap）為本。舊 `brag-output/brag-plan.md` 改為指向 brief 的 tombstone，消除並存的互斥發布素材（不再引用已否定的內部素材）。

## Test Plan

- [x] 執行 `python3 -m pytest -q tests/` — **920 passed / 14 skipped / 0 failed**（無新失敗；先前已知的 `test_five_agents_three_rounds_no_conflict` 本次亦通過）
- [x] 執行 `python3 -m policy_check --repo .` — 通過

## Policy Checklist (R-11)

- [x] 分支不是 `main`
- [x] 變更已記錄：`CHANGELOG.md` `[Unreleased]` bullet + `changelog.d/59-clean-legacy-skill.md` fragment（#59 code 變更）
- [x] `VERSION` 已更新 — N/A（無版本號變動）
- [x] `python3 -m pytest -q tests/` 通過（無新失敗）
- [x] `python3 -m policy_check --repo .` 通過
- [x] 四份 agent 檔案已同步（已修改 `CLAUDE.md` 語言政策；`AGENTS.md`／`GEMINI.md`／`.github/copilot-instructions.md` 為 symlink，自動同步）
- [x] 已標記適用 label — N/A（無需豁免 label）

## Issue Reference

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)