### PR TITLE
fix(windows): _save_state 並發 os.replace 序列化 + PermissionError 退避重試

### DIFF
--- a/changelog.d/133-save-state-replace-race.md
+++ b/changelog.d/133-save-state-replace-race.md
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 133
+scope: windows
+---
+修復 Windows 上 `_save_state` 並發 `os.replace` 撞 `WinError 5`（存取被拒）導致 attach 執行緒靜默死亡、`state.json` 更新遺失：I/O 段以 instance 級 `_state_io_lock` 序列化（消除行程內並發 replace；仍為 last-writer-wins），並新增 `_replace_state_file()` 於 Windows 對 `PermissionError` 短退避重試（外部讀者／防毒瞬時 handle），重試耗盡才上拋。POSIX `rename()` 語意不受影響（不重試、行為不變）。原 flaky 的 `test_session_bind::test_multi_device_auto_bind_order`（clean main 2/4 重現）修復後 6/6 通過。

--- a/sw_core/session_manager.py
+++ b/sw_core/session_manager.py
@@ -42,6 +42,31 @@ from .wal import WalWriter
 _ATTACHED_CONSOLE_LEASE_TIMEOUT_S = 86400.0
 
 
+def _replace_state_file(tmp_path: str, dst_path: str, *, retry: bool | None = None) -> None:
+    """``os.replace`` 包裝（#133）：Windows 上對 ``PermissionError`` 短退避重試。
+
+    Windows 的 ``MoveFileEx(REPLACE_EXISTING)`` 在目的檔被讀者（``_load_state``、
+    測試、防毒）短暫持有 handle 時會 ``WinError 5``；POSIX ``rename()`` 無此限制，
+    故 ``retry`` 預設依 ``os.name``（nt → 重試、其餘 → 裸 replace、行為不變）。
+    重試耗盡上拋，讓持續性失敗（ACL 壞掉等）可見而非靜默吞掉。
+    """
+    if retry is None:
+        retry = os.name == "nt"
+    if not retry:
+        os.replace(tmp_path, dst_path)
+        return
+    delay_s = 0.01
+    for attempt in range(6):
+        try:
+            os.replace(tmp_path, dst_path)
+            return
+        except PermissionError:
+            if attempt == 5:
+                raise
+            time.sleep(delay_s)
+            delay_s *= 2
+
+
 def device_sort_key(by_id: str, by_path: str | None) -> tuple[str, str]:
     """COM rank 排序鍵（#100）：以 by-id 路徑字串為主、by-path 為輔。
 
@@ -366,6 +391,9 @@ class SessionManager:
         self._on_detached = on_detached
         self._on_console_line = on_console_line
         self._lock = threading.RLock()
+        # state.json 寫入序列化（#133）：多 attach 執行緒並發 os.replace 同一目的檔在
+        # Windows 會 WinError 5；獨立於 self._lock（snapshot 用），I/O 段專用、不巢狀他鎖。
+        self._state_io_lock = threading.Lock()
         self._rx_observers: list[Callable[[str, bytes, int], None]] = []
         self._sessions: dict[str, SessionRuntime] = {}
         self._aliases = AliasRegistry()
@@ -518,29 +546,36 @@ class SessionManager:
         # 在「直接覆寫 state.json」中途失敗留下截斷檔，致 _load_state 解析失敗而靜默全棄（含 RELEASED
         # 交接狀態）→ 重啟後 daemon 重新 attach 已交給 flasher/人類的 tty 形成 two-reader（#82）。
         # 每次取唯一 temp 名（mkstemp）：_save_state 可能由多執行緒並發呼叫（device 自動綁定／attach），
-        # 固定 temp 名會在並發 os.replace 時互踩（FileNotFoundError）。唯一名 → 並發安全、last-writer-wins。
-        fd, tmp_path = tempfile.mkstemp(dir=state_dir, prefix="state.json.tmp.")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as fp:
-                fp.write(payload)
-                fp.flush()
-                os.fsync(fp.fileno())
-            os.replace(tmp_path, self._state_path)
-            # 目錄 fsync：確保 state.json 的目錄 entry 持久化（POSIX 語意）。
-            # Windows（nt）：os.O_RDONLY 開目錄會拋 Permission Denied；NTFS 自行管理一致性，跳過即可（#84 PORT-4）。
-            if sys.platform != "win32":
-                dir_fd = os.open(state_dir, os.O_RDONLY)
-                try:
-                    os.fsync(dir_fd)
-                finally:
-                    os.close(dir_fd)
-        finally:
-            # os.replace 成功後 tmp 已不存在；中途失敗時清掉半寫 temp，且絕不動到原 state.json。
+        # 固定 temp 名會在並發 os.replace 時互踩（FileNotFoundError）。
+        # I/O 段以 _state_io_lock 序列化（#133）：唯一 temp 名只保證 temp 不互踩，
+        # 並發 os.replace 到同一目的檔在 Windows 仍會 WinError 5（MoveFileEx 對被
+        # 開啟的目的檔 access denied）；序列化後仍為 last-writer-wins（snapshot 在
+        # self._lock 內建立，後進鎖者持較新快照）。鎖序 self._lock → _state_io_lock
+        # 單向，I/O 段內不取其他鎖，無倒置。
+        with self._state_io_lock:
+            fd, tmp_path = tempfile.mkstemp(dir=state_dir, prefix="state.json.tmp.")
             try:
-                if os.path.exists(tmp_path):
-                    os.remove(tmp_path)
-            except OSError:
-                pass
+                with os.fdopen(fd, "w", encoding="utf-8") as fp:
+                    fp.write(payload)
+                    fp.flush()
+                    os.fsync(fp.fileno())
+                # Windows 對外部讀者的瞬時 handle 另以退避重試兜底（#133）。
+                _replace_state_file(tmp_path, self._state_path)
+                # 目錄 fsync：確保 state.json 的目錄 entry 持久化（POSIX 語意）。
+                # Windows（nt）：os.O_RDONLY 開目錄會拋 Permission Denied；NTFS 自行管理一致性，跳過即可（#84 PORT-4）。
+                if sys.platform != "win32":
+                    dir_fd = os.open(state_dir, os.O_RDONLY)
+                    try:
+                        os.fsync(dir_fd)
+                    finally:
+                        os.close(dir_fd)
+            finally:
+                # os.replace 成功後 tmp 已不存在；中途失敗時清掉半寫 temp，且絕不動到原 state.json。
+                try:
+                    if os.path.exists(tmp_path):
+                        os.remove(tmp_path)
+                except OSError:
+                    pass
 
     def _next_dynamic_com(self) -> str:
         """分配下一個可用的 COM 編號（須在 self._lock 內呼叫）。

--- a/tests/test_state_save_race.py
+++ b/tests/test_state_save_race.py
@@ -135,6 +135,11 @@ class TestSaveStateSerialized(_Base):
             for t in threads:
                 t.join(10.0)
 
+        # join(timeout) 不保證結束（Copilot review）：顯式斷言無 worker 卡死，
+        # 確實涵蓋「並發 _save_state 不會 deadlock」。
+        self.assertFalse(
+            any(t.is_alive() for t in threads), "worker 逾時仍存活（疑似 _save_state 卡死）"
+        )
         self.assertEqual(errors, [])
         self.assertEqual(max_active, 1, "os.replace 必須被 _state_io_lock 序列化")
         with open(sm_mod.STATE_PATH, encoding="utf-8") as fh:

--- a/tests/test_state_save_race.py
+++ b/tests/test_state_save_race.py
@@ -1,0 +1,145 @@
+"""#133：Windows 上 `_save_state` 並發 `os.replace` 撞 WinError 5 的修復。
+
+多條 attach 執行緒（#100 並行 attach）同時對 `state.json` 做 unique-temp +
+`os.replace`；Windows 的 `MoveFileEx(REPLACE_EXISTING)` 對「目的檔正被另一個
+replace／讀者持有 handle」會 `PermissionError: [WinError 5]`，POSIX `rename()`
+無此限制——「唯一 temp 名 → 並發安全、last-writer-wins」只在 POSIX 成立。
+
+修復：instance 級 `_state_io_lock` 序列化 I/O 段（消除行程內並發 replace）＋
+`_replace_state_file()` 於 Windows 對 PermissionError 短退避重試（外部讀者／
+防毒的瞬時 handle），重試耗盡才上拋；POSIX 路徑不重試、行為不變。
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import sw_core.session_manager as sm_mod
+from sw_core.config import SessionProfile, UartProfile
+from sw_core.session_manager import SessionManager
+from sw_core.wal import WalWriter
+
+
+def _make_profile(com: str = "COM0", by_id: str = "/dev/serial/by-id/dev0") -> SessionProfile:
+    return SessionProfile(
+        profile_name="p", com=com, act_no=1, alias=None,
+        device_by_id=by_id, platform="prpl", uart=UartProfile(),
+    )
+
+
+class _Base(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._old_state_path = sm_mod.STATE_PATH
+        sm_mod.STATE_PATH = str(Path(self._tmp.name) / "state.json")
+        self.addCleanup(lambda: setattr(sm_mod, "STATE_PATH", self._old_state_path))
+        self.mgr = SessionManager(
+            [_make_profile()], WalWriter(wal_dir=self._tmp.name),
+            on_ready=lambda _: None, on_detached=lambda _: None,
+        )
+
+
+class TestReplaceStateFileRetry(_Base):
+    def test_retries_on_permissionerror_when_forced(self) -> None:
+        """瞬時 PermissionError（外部讀者/防毒短暫持有 handle）→ 退避重試後成功。"""
+        calls: list[int] = []
+
+        def flaky(src: str, dst: str) -> None:
+            calls.append(1)
+            if len(calls) <= 2:
+                raise PermissionError(5, "存取被拒")
+            # 第三次視為成功（不真的動檔案系統）
+
+        with (
+            mock.patch.object(sm_mod.os, "replace", side_effect=flaky),
+            mock.patch.object(sm_mod.time, "sleep"),  # 退避不真睡
+        ):
+            sm_mod._replace_state_file("ignored-src", "ignored-dst", retry=True)
+        self.assertEqual(len(calls), 3)
+
+    def test_exhausted_retries_reraise(self) -> None:
+        with (
+            mock.patch.object(
+                sm_mod.os, "replace", side_effect=PermissionError(5, "存取被拒")
+            ) as rep,
+            mock.patch.object(sm_mod.time, "sleep"),
+            self.assertRaises(PermissionError),
+        ):
+            sm_mod._replace_state_file("src", "dst", retry=True)
+        self.assertGreater(rep.call_count, 1)  # 有重試而非首錯即拋
+
+    def test_no_retry_on_posix_semantics(self) -> None:
+        """retry=False（POSIX 預設）：行為與裸 os.replace 相同，首錯即拋。"""
+        with (
+            mock.patch.object(
+                sm_mod.os, "replace", side_effect=PermissionError(5, "存取被拒")
+            ) as rep,
+            self.assertRaises(PermissionError),
+        ):
+            sm_mod._replace_state_file("src", "dst", retry=False)
+        self.assertEqual(rep.call_count, 1)
+
+    def test_default_follows_platform(self) -> None:
+        """retry 預設依 os.name（nt → 重試；posix → 不重試）。"""
+        with (
+            mock.patch.object(
+                sm_mod.os, "replace", side_effect=PermissionError(5, "存取被拒")
+            ) as rep,
+            mock.patch.object(sm_mod.time, "sleep"),
+            self.assertRaises(PermissionError),
+        ):
+            sm_mod._replace_state_file("src", "dst")
+        if os.name == "nt":
+            self.assertGreater(rep.call_count, 1)
+        else:
+            self.assertEqual(rep.call_count, 1)
+
+
+class TestSaveStateSerialized(_Base):
+    def test_concurrent_save_state_serialized_and_no_exception(self) -> None:
+        """行程內並發 _save_state：I/O 段序列化 → 不互踩、不拋例外、檔案恆為完整 JSON。"""
+        errors: list[BaseException] = []
+        active = 0
+        max_active = 0
+        gate = threading.Lock()
+        real_replace = os.replace
+
+        def counting_replace(src: str, dst: str) -> None:
+            nonlocal active, max_active
+            with gate:
+                active += 1
+                max_active = max(max_active, active)
+            try:
+                real_replace(src, dst)
+            finally:
+                with gate:
+                    active -= 1
+
+        def worker() -> None:
+            try:
+                for _ in range(20):
+                    self.mgr._save_state()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        with mock.patch.object(sm_mod.os, "replace", side_effect=counting_replace):
+            threads = [threading.Thread(target=worker) for _ in range(6)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(10.0)
+
+        self.assertEqual(errors, [])
+        self.assertEqual(max_active, 1, "os.replace 必須被 _state_io_lock 序列化")
+        with open(sm_mod.STATE_PATH, encoding="utf-8") as fh:
+            json.load(fh)  # 完整 JSON
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

修復 Windows 上 `_save_state` 並發 `os.replace` 撞 `WinError 5`（存取被拒）的 race：多條 attach 執行緒（#100 並行 attach）同時 replace 同一個 `state.json`、或外部讀者（`_load_state`／測試／防毒）瞬時持有目的檔 handle 時，`MoveFileEx(REPLACE_EXISTING)` 失敗 → attach 執行緒未捕捉例外死亡、session 卡住、state 更新（含 RELEASED 交接狀態）遺失。「唯一 temp 名 → 並發安全」的既有設計只在 POSIX `rename()` 語意下成立。

**修法**（`sw_core/session_manager.py`）：
- I/O 段（mkstemp → write → fsync → replace）以 instance 級 `_state_io_lock` 序列化——消除行程內並發 replace；snapshot 仍在 `self._lock` 內建立，後進鎖者持較新快照，維持 last-writer-wins。鎖序 `self._lock → _state_io_lock` 單向、I/O 段內不取其他鎖，無倒置。
- 新增模組層 `_replace_state_file()`：`os.name == "nt"` 時對 `PermissionError` 以 10ms 起倍增退避重試至多 6 次（外部讀者瞬時 handle 兜底），耗盡上拋讓持續性失敗可見；**POSIX 不重試、行為逐位元組不變**。

> **Stacked PR**（R-12 `wt/<parent>/<subtask>` 慣例）：base 為 `feature/131-windows-native-fixes`，merge 進 feature 分支後由 #132 一併帶進 main。注意：merge 進非預設分支**不會**自動關 issue——#132 body 屆時補 `Closes #133`（或 merge 後手動關）。

## Test Plan

- [x] 執行 `python3 -m pytest -q tests/` — 無新增失敗
- [x] 執行 `python3 -m policy_check --repo .` — 通過（WSL）

- 新增 `tests/test_state_save_race.py`：重試（瞬時／耗盡／POSIX 不重試／平台預設）＋ 6 執行緒 ×20 次並發 `_save_state` 序列化斷言（`max_active == 1`）與檔案完整性。
- **實證**：原 flaky 組合 `pytest tests/test_serial_port.py tests/test_session_bind.py`（clean main **2/4 失敗**）修復後原生 Windows **6/6 通過**。
- 全套件零回歸：原生 Windows 與 WSL Linux 均對 base 分支嚴格 diff 失敗集合 = 零新增。

## Policy Checklist (R-11)

- [x] 分支不是 `main`（不可直接 commit 到 main）
- [x] 變更已記錄：新增 `changelog.d/<issue>-<slug>.md` fragment（code 變更必備，R-09；純文件／release PR 可改動 `CHANGELOG.md` 或免記）
- [x] `VERSION` 已更新（若有版本號變動）
- [x] `python3 -m pytest -q tests/` 通過（無新失敗）
- [x] `python3 -m policy_check --repo .` 通過（release PR 在 tag 建立前改用 `--pr-labels release:<version>`）
- [x] 四份 agent 檔案已同步（若有修改 `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` / `.github/copilot-instructions.md`）
- [x] 已標記適用 label（release PR 使用 `release:<version>`；豁免白名單見 `CLAUDE.md`）

## Issue Reference

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Me4RVotSBVaym1AeLp2B4
