### PR TITLE
fix(windows): suspend 期間連入的 console 不再誤授 raw ownership

### DIFF
--- a/changelog.d/134-console-suspend-ownership.md
+++ b/changelog.d/134-console-suspend-ownership.md
@@ -1,0 +1,6 @@
+---
+type: fix
+issue: 134
+scope: windows
+---
+修復 Windows TCP console 於 agent 命令執行期間（suspend）連入時被誤授 raw interactive ownership 的問題（自 #84 PORT-2 起存在）：`suspend_interactive()` 會把 `_interactive_owner` 暫存為 None，新連入的 console 因此被誤判為「首個 console」直接取得 raw ownership——鍵擊繞過 deferred buffer 直寫 UART、汙染 agent 命令輸出，且 `resume_interactive()` 以暫存值蓋回後該 console 永久卡在 line-buffer 模式。修正授予條件為 suspend-aware：suspend 中且原無 owner 時改記到 `_suspended_owner`，期間輸入走既有 deferred 分支累積、resume 時無縫接手 raw ownership 並 flush；suspend 前已有 owner 者維持第二 console 的 line-buffer 行為。POSIX（PTY／lease 路徑）不經此程式碼、行為不變。

--- a/sw_core/uart_io.py
+++ b/sw_core/uart_io.py
@@ -471,6 +471,15 @@ class UARTBridge:
                 self._primary_client_id = next_client.client_id if next_client is not None else None
             if self._interactive_owner == f"human:{client_id}":
                 self._interactive_owner = None
+            if self._suspended_owner == f"human:{client_id}":
+                # suspend 期間斷線的（未來）owner（#136 review）：讓位 _suspended_owner，
+                # 否則 resume 會把 ownership 還原成已不存在的 client，之後任何新連線都
+                # 拿不到 raw ownership。刻意**不**比照 detach_console 歸零 _agent_active/
+                # _suspend_depth——suspend 簿記由 agent 命令路徑持有，命令仍在跑，歸零會
+                # 讓後續新連線立即取得 raw、重演 #134 的直寫汙染；讓位後新連線走 #134
+                # 的 elif 接手 _suspended_owner，於 resume 時取得 ownership。
+                self._suspended_owner = None
+            self._deferred_buffers.pop(client_id, None)
         self._close_console_client(client)
 
     def reap_stale_consoles(self, *, held_slave_paths: set[str] | None = None) -> list[ConsoleClient]:

--- a/sw_core/uart_io.py
+++ b/sw_core/uart_io.py
@@ -360,8 +360,15 @@ class UARTBridge:
             # 首個 human console 自動取得 raw interactive ownership（對齊 Linux console-attach；
             # Windows 無 session_manager 代為授予，故於 bridge 層授予，使方向鍵/Tab 即時透傳，
             # 且 agent 命令時走 suspend/resume coexistence、連線不中斷）。
-            if self._interactive_owner is None:
+            # #134：suspend 期間（agent 命令執行中）_interactive_owner 被暫存為 None，
+            # 不得誤判為「首個 console」即時授予——owner 路徑會繞過 deferred buffer
+            # 直寫 UART、汙染 agent 命令輸出。改記到 _suspended_owner（原本為 None
+            # 時），期間輸入走既有 deferred 分支累積，resume 時無縫接手 raw 並 flush；
+            # suspend 前已有 owner 者維持第二 console 的 line-buffer 行為。
+            if self._interactive_owner is None and self._suspend_depth == 0:
                 self._interactive_owner = f"human:{client_id}"
+            elif self._suspend_depth > 0 and self._suspended_owner is None:
+                self._suspended_owner = f"human:{client_id}"
 
     def _console_loop(self) -> None:
         listener = self._console_listener

--- a/tests/test_serial_port.py
+++ b/tests/test_serial_port.py
@@ -820,9 +820,9 @@ class TestUARTBridgeTcpConsole(unittest.TestCase):
             finally:
                 s.close()
         finally:
-            # 對稱性保險：測試中途失敗時不留下懸掛 suspend
-            while self._bridge.snapshot().get("suspend_depth", 0):
-                self._bridge.resume_interactive()
+            # 對稱性保險（Copilot review：snapshot 無 suspend_depth 鍵，改無條件 resume——
+            # 本測試僅 suspend 一次，depth 歸 0 後重複 resume 為 no-op）
+            self._bridge.resume_interactive()
 
     def test_console_during_suspend_with_prior_owner_stays_secondary(self) -> None:
         """suspend 前已有 owner：期間連入的第二個 console 維持 line-buffer，
@@ -833,10 +833,17 @@ class TestUARTBridgeTcpConsole(unittest.TestCase):
             owner_before = self._bridge.snapshot()["interactive_owner"]
             self.assertTrue(owner_before and owner_before.startswith("human:"))
             self._bridge.suspend_interactive()
-            b = self._connect()
             try:
-                _drain_sock(b)
+                b = self._connect()
+                try:
+                    _drain_sock(b)
+                finally:
+                    pass
+            finally:
+                # 對稱性清理（Copilot review）：中途例外也不得遺留 suspend 影響後續測試；
+                # depth 歸 0 後重複 resume 為 no-op。
                 self._bridge.resume_interactive()
+            try:
                 self.assertEqual(
                     self._bridge.snapshot()["interactive_owner"], owner_before,
                     "resume 後 ownership 應還給原 owner，而非期間連入的第二個 console",
@@ -845,6 +852,37 @@ class TestUARTBridgeTcpConsole(unittest.TestCase):
                 b.close()
         finally:
             a.close()
+
+    def test_suspended_owner_disconnect_before_resume_cleans_bookkeeping(self) -> None:
+        """suspend 期間成為 _suspended_owner 的 console 於 resume 前斷線（#136 review）：
+        斷線路徑須讓位 _suspended_owner 並清 deferred——否則 resume 會把 ownership
+        還原成已不存在的 human:<id>，之後任何新連線都無法再取得 raw ownership。"""
+        self._bridge.suspend_interactive()
+        try:
+            a = self._connect()
+            _drain_sock(a)
+            a.sendall(b"orphan")  # 進 deferred buffer
+            time.sleep(0.2)
+            a.close()  # resume 前斷線
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline and self._bridge.snapshot()["consoles"]:
+                time.sleep(0.05)
+            self.assertEqual(self._bridge.snapshot()["consoles"], [], "斷線應被 console loop 收屍")
+        finally:
+            self._bridge.resume_interactive()
+        self.assertIsNone(
+            self._bridge.snapshot()["interactive_owner"],
+            "resume 不得把 ownership 還原成已斷線的 console",
+        )
+        self.assertNotIn(b"orphan", bytes(self._fake.written), "斷線 console 的 deferred 不得流入 UART")
+        # 後續新連線必須能正常取得 raw ownership（簿記未卡死）
+        b = self._connect()
+        try:
+            _drain_sock(b)
+            owner = self._bridge.snapshot()["interactive_owner"]
+            self.assertTrue(owner and owner.startswith("human:"), f"新連線應可取得 ownership，got {owner!r}")
+        finally:
+            b.close()
 
     # ───────── Telnet 相容模式（#131 點 5）─────────
 

--- a/tests/test_serial_port.py
+++ b/tests/test_serial_port.py
@@ -787,6 +787,65 @@ class TestUARTBridgeTcpConsole(unittest.TestCase):
             time.sleep(0.05)
         self.assertTrue(dropped)
 
+    # ───────── suspend 期間連入的 console 不得即時取得 raw ownership（#134）─────────
+
+    def test_console_connected_during_suspend_is_deferred_until_resume(self) -> None:
+        """agent 命令進行中（suspend）連入的首個 console：輸入須走 deferred（不直寫
+        UART 汙染命令），resume 時才接手 raw ownership 並 flush。"""
+        self._bridge.suspend_interactive()  # agent 命令開始（此時尚無任何 console）
+        try:
+            s = self._connect()
+            try:
+                _drain_sock(s)
+                self.assertIsNone(
+                    self._bridge.snapshot()["interactive_owner"],
+                    "suspend 期間不得即時授予 raw ownership",
+                )
+                s.sendall(b"pwn\r")
+                time.sleep(0.3)
+                self.assertNotIn(
+                    b"pwn", bytes(self._fake.written),
+                    "suspend 期間 console 輸入不得直寫 UART（須 deferred）",
+                )
+                self._bridge.resume_interactive()
+                deadline = time.monotonic() + 2.0
+                while time.monotonic() < deadline and b"pwn\r" not in bytes(self._fake.written):
+                    time.sleep(0.02)
+                self.assertIn(b"pwn\r", bytes(self._fake.written), "resume 須 flush deferred")
+                owner = self._bridge.snapshot()["interactive_owner"]
+                self.assertTrue(
+                    owner and owner.startswith("human:"),
+                    f"resume 後新 console 應接手 raw ownership，got {owner!r}",
+                )
+            finally:
+                s.close()
+        finally:
+            # 對稱性保險：測試中途失敗時不留下懸掛 suspend
+            while self._bridge.snapshot().get("suspend_depth", 0):
+                self._bridge.resume_interactive()
+
+    def test_console_during_suspend_with_prior_owner_stays_secondary(self) -> None:
+        """suspend 前已有 owner：期間連入的第二個 console 維持 line-buffer，
+        resume 後 ownership 還給原 owner。"""
+        a = self._connect()
+        try:
+            _drain_sock(a)
+            owner_before = self._bridge.snapshot()["interactive_owner"]
+            self.assertTrue(owner_before and owner_before.startswith("human:"))
+            self._bridge.suspend_interactive()
+            b = self._connect()
+            try:
+                _drain_sock(b)
+                self._bridge.resume_interactive()
+                self.assertEqual(
+                    self._bridge.snapshot()["interactive_owner"], owner_before,
+                    "resume 後 ownership 應還給原 owner，而非期間連入的第二個 console",
+                )
+            finally:
+                b.close()
+        finally:
+            a.close()
+
     # ───────── Telnet 相容模式（#131 點 5）─────────
 
     def test_greeting_sent_on_accept(self) -> None:


### PR DESCRIPTION
## Summary

修復 Windows TCP console 於 agent 命令執行期間連入時被誤授 raw interactive ownership 的問題（自 #84 PORT-2 起存在，C2 級——單 UART 單寫入者仲裁被繞過）：

`suspend_interactive()` 會把 `_interactive_owner` 暫存到 `_suspended_owner` 後設為 **None**，`_accept_console_conn()` 的授予條件只看 `_interactive_owner is None` → agent 命令進行中新連入的 console 被誤判為「首個 console」即時取得 raw ownership。後果：(1) 其鍵擊經 owner 分支 `send_bytes()` **直寫 UART**（先於 deferred 分支命中），與 agent 命令交錯、汙染擷取結果；(2) `resume_interactive()` 以暫存值蓋回，該 console **永久卡 line-buffer 模式**（方向鍵/Tab 失效）需斷線重連。

**修法**（`sw_core/uart_io.py::_accept_console_conn`，授予條件改 suspend-aware）：
- `_interactive_owner is None` **且** `_suspend_depth == 0` → 照舊即時授予；
- suspend 中且 `_suspended_owner is None` → 改記到 `_suspended_owner`：期間輸入自然走既有 deferred 分支（`suspended == human:<id>`）累積，`resume_interactive()` 時無縫接手 raw ownership 並 flush deferred；
- suspend 前已有 owner → 維持第二 console 的 line-buffer 行為（resume 還給原 owner）。

POSIX（PTY／session_manager lease 路徑）不經此程式碼，行為不變。

> **Stacked PR**（R-12 `wt/<parent>/<subtask>` 慣例）：base 為 `feature/131-windows-native-fixes`，merge 進 feature 分支後由 #132 一併帶進 main。注意：merge 進非預設分支**不會**自動關 issue——#132 body 屆時補 `Closes #134`（或 merge 後手動關）。

## Test Plan

- [x] 執行 `python3 -m pytest -q tests/` — 無新增失敗
- [x] 執行 `python3 -m policy_check --repo .` — 通過（WSL）

- 新增 2 個 bridge 級測試（`tests/test_serial_port.py`，Linux CI 可跑的 loopback fake + 真 socket）：
  - suspend 期間連入 → 不授 owner、輸入不進 UART（deferred）→ resume 後 flush 且接手 raw ownership（修復前此測試以 `'human:...' is not None` 失敗，重現 bug）；
  - suspend 前已有 owner → 期間連入的第二 console 維持 line-buffer、resume 還給原 owner（回歸 pin）。
- 全套件零回歸：原生 Windows 與 WSL Linux 均對 base 分支嚴格 diff 失敗集合 = 零新增。

## Policy Checklist (R-11)

- [x] 分支不是 `main`（不可直接 commit 到 main）
- [x] 變更已記錄：新增 `changelog.d/<issue>-<slug>.md` fragment（code 變更必備，R-09；純文件／release PR 可改動 `CHANGELOG.md` 或免記）
- [x] `VERSION` 已更新（若有版本號變動）
- [x] `python3 -m pytest -q tests/` 通過（無新失敗）
- [x] `python3 -m policy_check --repo .` 通過（release PR 在 tag 建立前改用 `--pr-labels release:<version>`）
- [x] 四份 agent 檔案已同步（若有修改 `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` / `.github/copilot-instructions.md`）
- [x] 已標記適用 label（release PR 使用 `release:<version>`；豁免白名單見 `CLAUDE.md`）

## Issue Reference

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Me4RVotSBVaym1AeLp2B4
