### PR TITLE
feat(remote): serialwrap remote — ssh 反向隧道便利 CLI（-R expose／-L connect，daemon 零改動）

### DIFF
--- a/.paul-project.yml
+++ b/.paul-project.yml
@@ -2,6 +2,14 @@ policy_profile: flat
 policy_version: "1.0.10"
 # 內容分類（R-21）：serialwrap 為通用序列工具、無雇主機密 → 維持 public
 tier: shareable
+secret_scan:
+  # R-21 結構偵測器（比對「斜線 home 斜線 使用者名稱 斜線」樣式）誤判：以下檔案內含
+  # docker 測試映像內建的 tester 帳號 home 目錄路徑（tools/docker/remote_tunnel_test.sh
+  # 三拓樸驗收用），該帳號僅存在於一次性測試容器內，非任何真人開發者的本機個人路徑，允許放行。
+  allow:
+    - "Dockerfile"
+    - "tools/docker/remote_tunnel_test.sh"
+    - "tools/docker/uart_harness.py"
 code_paths:
   - "sw_core/**"
   - "tools/**"

--- a/.paul-project.yml
+++ b/.paul-project.yml
@@ -28,3 +28,7 @@ cli:
     help_args: ["--help"]
     reflected_in: "README.md"
     marker: "serialwrap-device-help"
+  - command: "./serialwrap remote"
+    help_args: ["--help"]
+    reflected_in: "README.md"
+    marker: "serialwrap-remote-help"

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,15 @@ RUN useradd -m -s /bin/bash tester \
     && ssh-keygen -A
 
 # ssh client：測試容器間互連免 host-key 確認（僅此測試映像；passwordless key 已限定用途，
-# 不對外流通）。置於 ssh_config 最前段——OpenSSH 對同鍵取第一個設定值，故本段權威。
-RUN { printf 'Host *\n    StrictHostKeyChecking no\n    UserKnownHostsFile /dev/null\n    LogLevel ERROR\n\n'; cat /etc/ssh/ssh_config; } > /etc/ssh/ssh_config.new \
-    && mv /etc/ssh/ssh_config.new /etc/ssh/ssh_config
+# 不對外流通）。**僅**寫入 `tester`（唯一會執行 `serialwrap remote`／因而 spawn ssh 的帳號，
+# 見 tools/docker/remote_tunnel_test.sh 全數 `docker exec -u tester ... serialwrap remote`）
+# 的 per-user `~/.ssh/config`，不動全域 `/etc/ssh/ssh_config`——避免弱化映像內其他使用者／
+# 行程（如 otheruser、root）的 host-key 驗證基準。OpenSSH 依序讀 command-line → per-user
+# config → 系統 config，同鍵取第一個設定值，故 per-user config 已足夠權威、無需碰系統檔。
+RUN printf 'Host *\n    StrictHostKeyChecking no\n    UserKnownHostsFile /dev/null\n    LogLevel ERROR\n' \
+      > /home/tester/.ssh/config \
+    && chown tester:tester /home/tester/.ssh/config \
+    && chmod 600 /home/tester/.ssh/config
 
 # sshd 預設：GatewayPorts no（loopback-only remote bind，R2 finding 2 的安全基準）。
 RUN sed -i \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN apt-get update \
         jq \
         minicom \
         socat \
+        openssh-server \
+        openssh-client \
+        autossh \
+        iproute2 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/serialwrap
@@ -18,5 +22,42 @@ COPY . /opt/serialwrap
 
 # pyproject.toml 帶入 PyYAML 依賴；console_scripts 自動放到 PATH。
 RUN pip install --no-cache-dir .
+
+# ── tools/docker/remote_tunnel_test.sh（docker 三拓樸驗收）用 sshd／使用者／金鑰預燒 ──
+# `tester`：容器間 passwordless ssh 帳號（uart -> agent/relay，皆用同一把 baked key，
+#   因每個角色容器都是同一 image）。`otheruser`：斷言⑥「relay 上第二個本機使用者」
+#   trust-boundary 案例用，無 ssh key、僅供 `docker exec -u otheruser` 本機驗證。
+RUN useradd -m -s /bin/bash tester \
+    && useradd -m -s /bin/bash otheruser \
+    && passwd -d tester \
+    && passwd -d otheruser \
+    && mkdir -p /home/tester/.ssh /home/tester/.sw-relay \
+    && ssh-keygen -q -t ed25519 -N "" -f /home/tester/.ssh/id_ed25519 -C serialwrap-remote-tunnel-test \
+    && cp /home/tester/.ssh/id_ed25519.pub /home/tester/.ssh/authorized_keys \
+    && chmod 700 /home/tester/.ssh /home/tester/.sw-relay \
+    && chmod 600 /home/tester/.ssh/authorized_keys /home/tester/.ssh/id_ed25519 \
+    && chmod 644 /home/tester/.ssh/id_ed25519.pub \
+    && chown -R tester:tester /home/tester \
+    && ssh-keygen -A
+
+# ssh client：測試容器間互連免 host-key 確認（僅此測試映像；passwordless key 已限定用途，
+# 不對外流通）。置於 ssh_config 最前段——OpenSSH 對同鍵取第一個設定值，故本段權威。
+RUN { printf 'Host *\n    StrictHostKeyChecking no\n    UserKnownHostsFile /dev/null\n    LogLevel ERROR\n\n'; cat /etc/ssh/ssh_config; } > /etc/ssh/ssh_config.new \
+    && mv /etc/ssh/ssh_config.new /etc/ssh/ssh_config
+
+# sshd 預設：GatewayPorts no（loopback-only remote bind，R2 finding 2 的安全基準）。
+RUN sed -i \
+      -e 's/^#\?GatewayPorts.*/GatewayPorts no/' \
+      -e 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' \
+      -e 's/^#\?PermitRootLogin.*/PermitRootLogin no/' \
+      -e 's/^#\?PubkeyAuthentication.*/PubkeyAuthentication yes/' \
+      -e 's/^#\?AllowTcpForwarding.*/AllowTcpForwarding yes/' \
+      /etc/ssh/sshd_config \
+    && grep -q '^GatewayPorts' /etc/ssh/sshd_config || echo 'GatewayPorts no' >> /etc/ssh/sshd_config \
+    && grep -q '^PubkeyAuthentication' /etc/ssh/sshd_config || echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config \
+    && grep -q '^AllowTcpForwarding' /etc/ssh/sshd_config || echo 'AllowTcpForwarding yes' >> /etc/ssh/sshd_config \
+    && grep -q '^UsePAM' /etc/ssh/sshd_config && sed -i 's/^UsePAM.*/UsePAM no/' /etc/ssh/sshd_config || echo 'UsePAM no' >> /etc/ssh/sshd_config \
+    # 另備 GatewayPorts yes 版本（唯一差異），供 R2 finding 2 fail-closed 斷言（#141 §11.2 斷言⑧）。
+    && sed 's/^GatewayPorts no/GatewayPorts yes/' /etc/ssh/sshd_config > /etc/ssh/sshd_config.gwyes
 
 CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -474,23 +474,163 @@ Linux `/dev/ttyMCU` PTY bridge model is not used.
 
 ### Remote Support
 
-Remote operation is normally done through an SSH tunnel. The remote FAE host
-exposes the daemon Unix socket to loopback TCP with `socat`, and the RD host
-forwards that port through SSH:
+When an FAE engineer overseas (a US/EU telecom customer site) uses serialwrap
+to reach a DUT, RD in Taiwan can use `serialwrap remote` to let an agent issue
+commands to the remote daemon: a pure CLI convenience layer that shells out to
+the system `ssh` to build an `-R` (reverse/expose, default) or `-L`
+(forward/connect, relay/double-NAT) tunnel, running detached in the
+background. **The daemon itself is unchanged**, and no separate `socat` is
+needed — `ssh -R` can forward a remote TCP port directly to a local AF_UNIX
+socket (OpenSSH >= 6.7).
+
+#### Architecture overview (direct)
+
+```
+[FAE site, running serialwrapd]                       [Taiwan RD / agent host]
+serialwrap remote tester@AGENT_HOST:7777  --ssh -R-->  tcp://127.0.0.1:7777
+(-R: reverse-push the local daemon socket to the peer)  serialwrap --endpoint tcp://127.0.0.1:7777
+```
+
+When the agent and the UART host can't reach each other directly (double NAT
+/ relay), the agent side instead runs `serialwrap remote -L` (below).
+
+#### UART host side: open the tunnel (one line)
 
 ```bash
-# On the FAE host — the daemon socket is <run-dir>/serialwrapd.sock
-# (default $XDG_RUNTIME_DIR/serialwrap; override with SERIALWRAP_SOCKET).
-socat TCP-LISTEN:7777,bind=127.0.0.1,reuseaddr,fork \
-      UNIX-CONNECT:"$XDG_RUNTIME_DIR/serialwrap/serialwrapd.sock" &
+# -R is the default: reverse-push the local daemon to 127.0.0.1:7777 on tester@AGENT_OR_RELAY
+serialwrap remote tester@AGENT_OR_RELAY:7777
+```
 
-# On the RD host
-ssh -N -L 127.0.0.1:7777:127.0.0.1:7777 fae_user@fae_host
+`serialwrap remote` (`sw_core/remote_tunnel.py`) behavior:
+
+- **Background daemonization**: `ssh` / `--autossh` runs in its own process
+  group in the background; the command returns immediately.
+- **flock registry**: state lives under `<run-dir>/remote/` (`<port>.json` +
+  a `cm-<port>` ssh control socket), serialized with an flock so concurrent
+  `remote` / `remote close` calls don't race.
+- **Readiness confirmation**: returns `status`: `active` = verified and
+  ready; `starting` = timed out (default 10s, tunable via `--ready-timeout`)
+  but the process is still alive and not yet confirmed — query
+  `serialwrap remote` again or retry.
+- **Idempotency / conflict detection**: re-running against the same port with
+  the same identity (a hash of role/target/port/local/remote_socket/via/
+  ssh-opt, etc.) is an `already_running` no-op; a different identity is
+  rejected with `TUNNEL_CONFLICT` (so you can't accidentally hijack someone
+  else's tunnel or collide on a port).
+
+#### Agent-side connection
+
+- **Direct** (the agent host is the ssh peer above):
+  ```bash
+  serialwrap --endpoint tcp://127.0.0.1:7777 session list
+  serialwrap --endpoint tcp://127.0.0.1:7777 cmd submit --selector COM0 --cmd "uname -a"
+  ```
+- **Relay / double NAT** (agent and UART host can't reach each other; both
+  dial out to a relay): the agent side first runs
+  ```bash
+  serialwrap remote -L tester@RELAY:7777   # connect: pull relay's 7777 back to local loopback
+  ```
+  and uses the returned `endpoint` (`tcp://127.0.0.1:7777` by default, or
+  whatever port `--local` specified) as `--endpoint`.
+
+#### Tunnel management
+
+```bash
+serialwrap remote                   # list all current tunnels (status)
+serialwrap remote close 7777        # tear down a single tunnel
+serialwrap remote close all         # tear down everything
+```
+
+#### `--remote-socket` hardening (recommended for shared relays)
+
+By default `-R` opens a `127.0.0.1:<port>` TCP loopback bind on the peer; if
+the relay is a **multi-tenant shared host**, other local users could in
+principle still reach that loopback port. Adding `--remote-socket
+/path/to.sock` instead creates a **unix socket** on the peer, gated by file
+permissions (extending the local daemon socket's 0660 semantics to the
+relay). Both `-R` and `-L` must point at the same path:
+
+```bash
+# UART host (-R)
+serialwrap remote --remote-socket /tmp/sw-relay.sock tester@RELAY:7777
+# agent host (-L, paired)
+serialwrap remote -L --remote-socket /tmp/sw-relay.sock tester@RELAY:7777
+```
+
+#### Security and trust boundary
+
+- The tunnel gives the peer **full control over the DUT**
+  (`command.submit`, `file.push`, `daemon.stop` are all reachable; the
+  daemon adds no token auth — trust is delegated entirely to ssh). **Use
+  only single-tenant / trusted relays**; shared relays must pair with
+  `--remote-socket` above.
+- In `-R` tcp-loopback mode (without `--remote-socket`), readiness reuses
+  the ssh master connection to run `ss` on the peer and verify the remote
+  bind is **loopback only**; if it can't be verified, the check fails, or a
+  non-loopback bind is detected (e.g. the peer's sshd has `GatewayPorts`
+  exposing the port to `0.0.0.0`), it **fails closed** and returns
+  `REMOTE_BIND_UNVERIFIED`, tearing down the already-spawned ssh process so
+  no unverified, exposed tunnel is left behind.
+
+#### Limitations and caveats
+
+- `daemon start` does **not support** `--endpoint` (the daemon can only be
+  started locally; it returns `REMOTE_NOT_SUPPORTED`).
+- **`file.push` / `file.pull`'s `local_path` is a path on the daemon side
+  (UART host)**, not on the agent's local machine; to transfer a local file,
+  first scp/rsync it to the UART host, then have the daemon do the file
+  transfer. WAL and mirror-log paths returned by the RPC are likewise
+  UART-host paths.
+- **Native Windows does not support `serialwrap remote` in this release**:
+  running it returns `REMOTE_NOT_SUPPORTED` (see the manual equivalent
+  below).
+- For an isolated two-container check, run `./tools/docker/remote_smoke.sh`
+  directly; the full flow is documented in
+  [`func-test/README.md`](./func-test/README.md) under the **Remote Support
+  Docker test flow**.
+
+#### Manual `ssh -R` / `-L` equivalent (without `serialwrap remote`)
+
+If you'd rather not use the convenience layer, you can still run ssh by hand
+(this is exactly what `serialwrap remote` generates internally):
+
+```bash
+# -R equivalent (expose, run on the UART host; no socat needed — ssh -R
+# forwards straight to a local unix socket)
+# the socket path is <run-dir>/serialwrapd.sock (RUN_DIR defaults to
+# $XDG_RUNTIME_DIR/serialwrap; override with SERIALWRAP_SOCKET)
+ssh -N -R 127.0.0.1:7777:"$XDG_RUNTIME_DIR/serialwrap/serialwrapd.sock" tester@AGENT_OR_RELAY
+
+# -L equivalent (connect, relay scenario, run on the agent host)
+ssh -N -L 127.0.0.1:7777:127.0.0.1:7777 tester@RELAY
+
+# agent side unchanged
 serialwrap --endpoint tcp://127.0.0.1:7777 session list
 ```
 
-Never expose the TCP bridge on a non-loopback interface; serialwrap RPC can
-submit commands, transfer files, and control the daemon.
+Native Windows (daemon listens on TCP loopback `48700`) manual reverse
+tunnel:
+
+```powershell
+ssh -N -R 7777:127.0.0.1:48700 user@AGENT_OR_RELAY
+```
+
+#### Docker smoke test
+
+To quickly verify the current repo's remote-support works across
+containers, run:
+
+```bash
+./tools/docker/remote_smoke.sh
+```
+
+This script:
+
+1. builds `serialwrap:remote-smoke`
+2. creates an isolated bridge network (no fixed IP, no MAC pinning)
+3. starts a remote daemon container (fake target + `serialwrapd` + `socat`)
+4. starts a client container and verifies `daemon status` / `session list` /
+   `cmd submit` / `cmd status`
 
 ### Event Trigger Engine
 
@@ -1629,90 +1769,107 @@ CLI（`bind` 只改 device、`recover`/`clear` 沿用舊 profile）。在 produc
 > `Offline`（DCD 未拉起），不影響輸入轉送。(3) `log tail-raw` 預設為 latest 模式（最新 N 筆，#124），
 > 直接 `serialwrap log tail-raw --selector COMx --limit 50` 即可驗證最新輸出；要從特定 seq 增量讀取才帶 `--from-seq`。
 
-## Remote Support（ssh-tunnel 遠端連線）
+## Remote Support（serialwrap remote 隧道）
 
-當 FAE 在海外（美國 / 歐洲電信客戶端）用 serialwrap 連接 DUT，台灣 RD 可透過 **ssh-tunnel** 讓 agent 對遠端 daemon 下命令，無需修改 daemon 端程式。
+當 FAE 在海外（美國／歐洲電信客戶端）用 serialwrap 連接 DUT，台灣 RD 可用 `serialwrap remote` 讓 agent 對遠端 daemon 下命令：純 CLI 便利層，外包系統 `ssh` 建立 `-R`（reverse／expose，預設）或 `-L`（forward／connect，relay／雙 NAT 情境）隧道，background 常駐；**daemon 端零改動**，也不需要另跑 `socat`——`ssh -R` 可直接把遠端 TCP port 轉發到本機的 AF_UNIX socket（OpenSSH ≥ 6.7）。
 
-### 架構概覽
+### 架構概覽（direct）
 
 ```
-[台灣 RD]                              [FAE 現場]
- agent (CLI)                           serialwrapd
-   |                                        |
-   | tcp://127.0.0.1:7777                   |
-   +--> ssh tunnel (ssh -L) -->--> socat <--> Unix socket
+[FAE 現場，跑 serialwrapd]                          [台灣 RD / agent host]
+serialwrap remote tester@AGENT_HOST:7777  --ssh -R-->  tcp://127.0.0.1:7777
+（-R：本機 daemon socket 反向推到對端）                serialwrap --endpoint tcp://127.0.0.1:7777
 ```
 
-### FAE 端設定（一次性）
+agent 與 UART host 互不可達（雙 NAT／relay）時，改由 agent 端另跑 `serialwrap remote -L`（見下）。
 
-**步驟 1**：以 `socat` 將 Unix socket 暴露成 TCP（**只 bind loopback，不可對外**）：
+### UART host 端：起隧道（一行）
 
 ```bash
-# socket 為 <run-dir>/serialwrapd.sock（RUN_DIR 預設 $XDG_RUNTIME_DIR/serialwrap，可 SERIALWRAP_SOCKET 覆寫）
-socat TCP-LISTEN:7777,bind=127.0.0.1,reuseaddr,fork \
-      UNIX-CONNECT:"$XDG_RUNTIME_DIR/serialwrap/serialwrapd.sock" &
+# -R 為預設：把本機 daemon 反向推到 tester@AGENT_OR_RELAY 的 127.0.0.1:7777
+serialwrap remote tester@AGENT_OR_RELAY:7777
 ```
 
-> ⚠️ **安全注意**：
-> - 必須 `bind=127.0.0.1`，絕對不能省略，否則 port 會暴露在 0.0.0.0
-> - serialwrap RPC 包含 `command.submit`、`file.push`、`daemon.stop`，**任何可連到此 port 的機器都能完全遠端操控 DUT**
-> - 永遠只透過 ssh-tunnel 使用，不可直接對網路開放
+`serialwrap remote`（`sw_core/remote_tunnel.py`）行為：
 
-**步驟 2**：在 FAE 的 sshd 確認允許 `AllowTcpForwarding yes`（預設通常已開）。
+- **background 常駐**：`ssh`／`--autossh` 以獨立 process group 背景執行，指令立即回傳。
+- **flock registry**：狀態落在 `<run-dir>/remote/`（`<port>.json` + `cm-<port>` ssh control socket），以 flock 序列化並發的 `remote` / `remote close` 操作。
+- **readiness 確認**：回傳 `status`：`active`＝已驗證就緒可用；`starting`＝逾時（預設 10s，`--ready-timeout` 可調）但行程仍存活、尚未確認，需再 `serialwrap remote` 查或重試。
+- **冪等 / 衝突偵測**：同 port 重複執行且 identity（role/target/port/local/remote_socket/via/ssh-opt 等雜湊）相同 → `already_running` no-op；identity 不同 → 拒絕並回 `TUNNEL_CONFLICT`（避免竊佔他人隧道或造成埠位混用）。
 
-### 台灣 RD 端設定
+### Agent 端連線
 
-**建立 ssh-tunnel**：
+- **direct**（agent host 就是上面 ssh 的對端）：
+  ```bash
+  serialwrap --endpoint tcp://127.0.0.1:7777 session list
+  serialwrap --endpoint tcp://127.0.0.1:7777 cmd submit --selector COM0 --cmd "uname -a"
+  ```
+- **relay / 雙 NAT**（agent 與 UART host 互不可達，各自對 relay 撥出）：agent 端先
+  ```bash
+  serialwrap remote -L tester@RELAY:7777   # connect：把 relay 上的 7777 拉回本機 loopback
+  ```
+  回傳的 `endpoint`（預設 `tcp://127.0.0.1:7777`，或 `--local` 指定的 port）即為 agent 該用的 `--endpoint`。
 
-```bash
-ssh -N -L 127.0.0.1:7777:127.0.0.1:7777 fae_user@fae_host
-```
-
-| 參數 | 說明 |
-|---|---|
-| `-N` | 不開 shell，只轉發 port |
-| `-L 127.0.0.1:7777:127.0.0.1:7777` | 本機 7777 → FAE host 127.0.0.1:7777 |
-
-若要保持常駐，可加 `-f` 或用 autossh：
-
-```bash
-autossh -M 0 -N -L 127.0.0.1:7777:127.0.0.1:7777 fae_user@fae_host
-```
-
-**確認 tunnel 通**：
-
-```bash
-serialwrap --endpoint tcp://127.0.0.1:7777 daemon status
-```
-
-### `--endpoint` 參數
-
-CLI 支援 `--endpoint`，優先於 `--socket`：
-
-```bash
-# CLI 遠端查詢 session 列表
-serialwrap --endpoint tcp://127.0.0.1:7777 session list
-
-# CLI 遠端提交命令
-serialwrap --endpoint tcp://127.0.0.1:7777 cmd submit \
-    --selector COM0 --cmd "uname -a"
-```
-
-支援的 endpoint 格式：
+支援的 `--endpoint` 格式：
 
 | 格式 | 用途 |
 |---|---|
 | `<run-dir>/serialwrapd.sock` | 本機 Unix socket（預設；RUN_DIR 預設 `$XDG_RUNTIME_DIR/serialwrap`，可 `SERIALWRAP_SOCKET` 覆寫） |
 | `unix://<run-dir>/serialwrapd.sock` | 本機 Unix socket（顯式 `unix://` 前綴） |
-| `tcp://127.0.0.1:7777` | 透過 ssh-tunnel 連接遠端 daemon |
+| `tcp://127.0.0.1:7777` | 透過隧道連接遠端 daemon（`serialwrap remote` 或手動 ssh 皆可） |
+
+### 隧道管理
+
+```bash
+serialwrap remote                   # 列目前所有隧道（status）
+serialwrap remote close 7777        # 拆除單一隧道
+serialwrap remote close all         # 拆除全部
+```
+
+### `--remote-socket` 硬化（共享 relay 建議必開）
+
+預設 `-R` 在對端開 `127.0.0.1:<port>` 的 TCP loopback bind；relay 若為**多租戶共享主機**，同機其他使用者理論上仍可能連到該 loopback port。加 `--remote-socket /path/to.sock` 後改在對端建 **unix socket**，以檔案權限把關（等同把本機 daemon socket 的 0660 語意延伸到 relay）；`-R`／`-L` 兩端須成對指定同一路徑：
+
+```bash
+# UART host（-R）
+serialwrap remote --remote-socket /tmp/sw-relay.sock tester@RELAY:7777
+# agent host（-L，成對）
+serialwrap remote -L --remote-socket /tmp/sw-relay.sock tester@RELAY:7777
+```
+
+### 安全性與信任邊界
+
+- 隧道讓對端**全權操控 DUT**（`command.submit`、`file.push`、`daemon.stop` 皆可達；daemon 不加 token 驗證，認證完全委由 ssh）。**只用於單租戶／可信 relay**；共享 relay 務必搭配上面的 `--remote-socket`。
+- `-R` 的 tcp loopback 模式（未帶 `--remote-socket`）readiness 會借用 ssh master 連線在對端跑 `ss` 驗證遠端 bind 是否**僅 loopback**；查不到、查失敗、或偵測到非 loopback bind（例如對端 sshd 開了 `GatewayPorts` 把 port 暴露到 `0.0.0.0`）一律 **fail-closed** 拒絕並回 `REMOTE_BIND_UNVERIFIED`，同時 teardown 已 spawn 的 ssh 行程，不留下未驗證安全性的暴露隧道。
 
 ### 限制與注意事項
 
-- `daemon start` **不支援** `--endpoint`（daemon 只能在本機啟動，會回 `REMOTE_NOT_SUPPORTED`）
-- **`file.push / file.pull` 的 `local_path` 是 FAE host（daemon 端）的路徑**，不是 RD 本機路徑。若 RD 要傳輸本機檔案，需先透過 scp/rsync 傳到 FAE host，再由 daemon 執行 file transfer
-- WAL 路徑、mirror log 路徑等回傳值也都是 FAE host 上的路徑
-- 認證完全委由 ssh 本身，daemon 不加 token 驗證
-- 若要做隔離式雙 container 驗證，可直接執行 `./tools/docker/remote_smoke.sh`；完整流程說明在 [`func-test/README.md`](./func-test/README.md) 的 **Remote Support Docker test flow**
+- `daemon start` **不支援** `--endpoint`（daemon 只能在本機啟動，會回 `REMOTE_NOT_SUPPORTED`）。
+- **`file.push` / `file.pull` 的 `local_path` 是 daemon 端（UART host）的路徑**，不是 agent 本機路徑；agent 若要傳輸本機檔案，需先透過 scp/rsync 傳到 UART host，再由 daemon 執行 file transfer。WAL、mirror log 等路徑回傳值同理。
+- **native Windows 本期不支援** `serialwrap remote`：執行會回 `REMOTE_NOT_SUPPORTED`（見下方手動等價）。
+- 若要做隔離式雙 container 驗證，可直接執行 `./tools/docker/remote_smoke.sh`；完整流程說明在 [`func-test/README.md`](./func-test/README.md) 的 **Remote Support Docker test flow**。
+
+### 手動 `ssh -R` / `-L` 等價（不透過 `serialwrap remote`）
+
+不想用便利層時，也可以照舊手動下 ssh（`serialwrap remote` 內部即產生等價 argv）：
+
+```bash
+# -R 等價（expose，於 UART host 執行；免 socat，ssh -R 直接轉發到本機 unix socket）
+# socket 路徑為 <run-dir>/serialwrapd.sock（RUN_DIR 預設 $XDG_RUNTIME_DIR/serialwrap，可 SERIALWRAP_SOCKET 覆寫）
+ssh -N -R 127.0.0.1:7777:"$XDG_RUNTIME_DIR/serialwrap/serialwrapd.sock" tester@AGENT_OR_RELAY
+
+# -L 等價（connect，relay 情境於 agent host 執行）
+ssh -N -L 127.0.0.1:7777:127.0.0.1:7777 tester@RELAY
+
+# agent 端照舊
+serialwrap --endpoint tcp://127.0.0.1:7777 session list
+```
+
+native Windows（daemon 走 TCP loopback `48700`）手動反向隧道：
+
+```powershell
+ssh -N -R 7777:127.0.0.1:48700 user@AGENT_OR_RELAY
+```
 
 ### Docker smoke test
 
@@ -1835,6 +1992,7 @@ command groups:
     file               透過 UART 推送／拉取檔案
     wal                write-ahead log 匯出／重設／seq 查詢
     mcu                MCU flash pattern 查詢與 flash 端點狀態
+    remote             按需開關 ssh 反向隧道，讓遠端 agent 連本機 daemon（-R 預設 expose）
     event              event-trigger 規則註冊與 matcher 控制
     supervision-mode   顯示有效的監管模式（on-demand、systemd-user 或 systemd-system）
     service            透過 systemctl 管理 serialwrap systemd service（systemd 監管模式適用）
@@ -1922,6 +2080,36 @@ options:
   -h, --help  show this help message and exit
 <!-- END: cli-help marker="serialwrap-device-help" -->
 
+`serialwrap remote --help`：
+
+<!-- BEGIN: cli-help marker="serialwrap-remote-help" -->
+usage: serialwrap remote [-h] [-R] [-L] [--autossh] [--local LOCAL]
+                         [--remote-socket REMOTE_SOCKET]
+                         [--ready-timeout READY_TIMEOUT] [--ssh-opt SSH_OPT]
+                         [words ...]
+
+serialwrap remote：外包系統 ssh 建立 -R（expose，把本機 daemon 推到對端）／-L（connect，relay 情境把對端 port 拉回本機 loopback）隧道，background 常駐。
+  serialwrap remote user@host:7777        # -R 預設：expose 本機 daemon
+  serialwrap remote -L user@relay:7777    # connect（relay/雙 NAT）
+  serialwrap remote                        # 列目前隧道（status）
+  serialwrap remote close 7777|all         # 拆除
+安全：只透過 ssh-tunnel、單租戶/可信 relay 或 --remote-socket；不可對網路直接開放。
+
+positional arguments:
+  words                 [user@]host:port ｜ status ｜ close <port|all>
+
+options:
+  -h, --help            show this help message and exit
+  -R                    reverse/expose（預設）
+  -L                    forward/connect（relay）
+  --autossh             以 autossh 斷線自動重連
+  --local LOCAL         -L 本機 loopback port（預設=對端 port）
+  --remote-socket REMOTE_SOCKET
+                        硬化：-R 建遠端 unix socket／-L 連該 socket（共享 relay 建議）
+  --ready-timeout READY_TIMEOUT
+                        readiness 確認上限秒數（逾時回 starting）
+  --ssh-opt SSH_OPT     透傳額外 ssh 參數（可重複），如 --ssh-opt=-p --ssh-opt=2222
+<!-- END: cli-help marker="serialwrap-remote-help" -->
 
 ```bash
 # 啟動 daemon（on-demand 模式手動啟動；systemd 模式下此命令會自動 route 到 service start）

--- a/changelog.d/remote-tunnel-attacker-isolation.md
+++ b/changelog.d/remote-tunnel-attacker-isolation.md
@@ -1,0 +1,5 @@
+---
+type: fix
+scope: remote
+---
+docker 三拓樸驗收 harness（`tools/docker/remote_tunnel_test.sh`）補 review 發現的攻擊者隔離覆蓋缺口：`topology_nat_host`（net_a）與 `topology_dual_nat`（net_a／net_b 雙 NAT）先前僅以 `ss -ltn` 檢查 relay 綁 loopback，未實際驗證「同網段的獨立攻擊者容器」真的連不到——現在兩個拓樸都在 tcp 模式 `-R` 隧道存活期間，另起一個獨立 `attacker` 容器（與 relay 同網段），以 relay 的**非 loopback 容器位址**（`tcp://<relay-container>:7777`，而非合法路徑用的 relay 自身 `127.0.0.1`）嘗試 `daemon status`，斷言真連線失敗（`ok:false` + `SOCKET_ERROR`）；`topology_dual_nat` 額外驗證 net_b 上的 agent 若繞過自身 `-L` 轉發直連 relay 容器位址同樣失敗，證明合法路徑必須經過 relay 自身 loopback。另外 `topology_gatewayports_failclosed` 的 `--remote-socket` 成功案例先前只有 tcp fail-closed 分支有 teardown 收尾複查，現補上同樣的 `assert_default_off`／pid 不變複查，避免該路徑的 teardown 迴歸漏測。攻擊者容器已納入既有 `teardown_now` 回收流程，不留殘留資源。

--- a/changelog.d/remote-tunnel-cli.md
+++ b/changelog.d/remote-tunnel-cli.md
@@ -1,0 +1,5 @@
+---
+type: feat
+scope: remote
+---
+`serialwrap remote`：按需開關 SSH 反向隧道（`-R` expose 預設／`-L` connect），讓遠端 agent 取得本機 serialwrap 操作；background 常駐、flock registry、readiness 確認、`--remote-socket` 硬化、fail-closed 遠端 bind 驗證。daemon 零改動、不做預設、僅 POSIX（native Windows 回 `REMOTE_NOT_SUPPORTED`）。

--- a/changelog.d/remote-tunnel-copilot-fixes.md
+++ b/changelog.d/remote-tunnel-copilot-fixes.md
@@ -1,0 +1,5 @@
+---
+type: fix
+scope: remote
+---
+`serialwrap remote`：收斂 Copilot PR review 三項發現。① `--local` 新增範圍／角色驗證——搭 `-R`／預設（expose）帶入視為誤用，早擋 `INVALID_ARGS`；搭 `-L` 但超出 `1..65535` 範圍同樣早擋，不再交給 ssh 晚爆成非 `INVALID_ARGS` 錯誤。② `Registry` 新增 `log_path()` 單一事實來源，`remove()`（`status` prune／`close` 皆走此路徑）與 `open_tunnel` 的 spawn log 皆改用此方法，`<port>.log` 隨 state／control socket 同生命週期清除，不再於重試／失敗後於 `<run_dir>/remote/` 累積孤兒 log 檔。③ docker 測試映像（`Dockerfile`）的 host-key-skip（`StrictHostKeyChecking no`／`UserKnownHostsFile /dev/null`）改由全域 `/etc/ssh/ssh_config` 收斂至僅 `tester`（唯一會執行 `serialwrap remote`／spawn ssh 的帳號）的 `~/.ssh/config`，不再弱化映像內其他使用者（`otheruser`／`root`）的 host-key 驗證基準；已以獨立 throwaway 容器驗證 `tester` 免 host-key 提示連線成功，`root`／`otheruser` 仍正常觸發 host-key 驗證失敗。

--- a/changelog.d/remote-tunnel-windows-guard-hoist.md
+++ b/changelog.d/remote-tunnel-windows-guard-hoist.md
@@ -1,0 +1,5 @@
+---
+type: fix
+scope: remote
+---
+`serialwrap remote`：修全分支複查發現的 merge-blocker——native Windows 下 `_run_remote` 在 `guard_platform()` 之前就先 `from . import remote_tunnel`（該模組頂層 `import fcntl`，POSIX-only），導致 `ModuleNotFoundError` 穿越 CLI 邊界變成原始 traceback（而非 `REMOTE_NOT_SUPPORTED`）；且該 import 發生於 `try:` 外，`status`／`close` 兩條路徑更是完全沒呼叫 `guard_platform()`。改為在 `_run_remote` 最頂端、`import remote_tunnel` 之前先攔截 `os.name == "nt"`，一律回 JSON `REMOTE_NOT_SUPPORTED`，涵蓋 `status`／`close`／open 三條路徑。另補一個 catch-all `except Exception`，讓非 `TunnelError` 的非預期例外（如 `SERIALWRAP_RUN_DIR` 父路徑非目錄觸發的 `NotADirectoryError`）同樣轉為 JSON `INTERNAL_ERROR`，不穿越 CLI 邊界。

--- a/docs/superpowers/plans/2026-07-19-remote-tunnel-cli.md
+++ b/docs/superpowers/plans/2026-07-19-remote-tunnel-cli.md
@@ -1,0 +1,1622 @@
+# serialwrap `remote` 隧道便利 CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增 `serialwrap remote` 子命令群，用極簡 `host:port` 語法在 runtime 按需拉起／關閉 SSH 反向隧道，讓遠端 agent 取得本機 serialwrap 操作，serialwrapd 零改動、不重啟、不做預設。
+
+**Architecture:** 純 CLI 便利層——新模組 `sw_core/remote_tunnel.py` 外包給系統 `ssh`（`-R` expose／`-L` connect），background 常駐 + flock registry + readiness 確認 + robust close；`sw_core/cli.py` 加平面 `remote` 分派。daemon／RPC／arbiter 完全不動。
+
+**Tech Stack:** Python 3.10+、stdlib（`subprocess`／`fcntl`／`socket`／`hashlib`／`argparse`）、系統 `ssh`/`autossh`；測試 pytest + docker（真 sshd）。
+
+**Spec:** `docs/superpowers/specs/2026-07-19-remote-tunnel-cli-design.md`（含 2 輪 adversarial review 修訂）。
+
+## Global Constraints
+
+- **daemon 零改動**：不改 `sw_core/service.py`／`daemon.py`／`arbiter.py`／`session_manager.py`／RPC；serialwrapd 不重啟、不新增 listener。
+- **不做預設**：`remote` 永不自動啟動，只在顯式執行時開。
+- **僅 POSIX（Linux/WSL）**：native Windows（`os.name == "nt"`）執行 `remote` → 回 `REMOTE_NOT_SUPPORTED`；lifecycle 用 POSIX primitive（`start_new_session`／`fcntl.flock`／`os.killpg`／`/proc` start-ticks）。
+- **auth 全交 ssh**：不碰金鑰、不引入 paramiko；預設 `-o BatchMode=yes`。
+- **loopback bind 不變量**：`-L`／`-R` 顯式綁 `127.0.0.1:`；`-R` tcp 模式 active 前必以 `ss` 實測遠端 bind，非 loopback／無法驗證即拆除 + `REMOTE_BIND_UNVERIFIED`。
+- **JSON 輸出**：一律經 `sw_core/cli.py::_print`（`json.dumps(..., ensure_ascii=False, sort_keys=True, separators=(",",":"))`）；失敗回 `{"ok":false,"error_code":...}`，例外不穿越。
+- **語言**：所有 code comment／docstring／文件繁體中文（README 中英雙語並存）。
+- **測試政策**：`python3 -m pytest -q tests/` 無新失敗；`python3 -m policy_check --repo .` 通過。既有已知失敗 `tests/test_multiagent_e2e.py::...::test_five_agents_three_rounds_no_conflict` 不計。
+- **分支**：`feature/remote-tunnel-cli`（已建立，禁止 commit 到 main）。
+- **每個 code 變更前**：新增／更新 `changelog.d/remote-tunnel-cli.md`（本計畫 Task 11 一次備妥）。
+- **commit trailer**：每個 commit 附 `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`。
+
+---
+
+### Task 1: 模組骨架 + target 解析 + identity
+
+**Files:**
+- Create: `sw_core/remote_tunnel.py`
+- Test: `tests/test_remote_tunnel.py`
+
+**Interfaces:**
+- Produces:
+  - `class TunnelError(Exception)`：`__init__(self, code: str, message: str | None = None)`，屬性 `.code`、`.message`。
+  - `@dataclass(frozen=True) class TunnelSpec`：欄位 `role: str`（`"expose"|"connect"`）、`ssh_target: str`、`port: int`、`local: int | None = None`、`forward_src: str | None = None`、`remote_socket: str | None = None`、`via: str = "ssh"`、`ssh_opts: tuple[str, ...] = ()`、`ready_timeout: float = 10.0`。
+  - `def parse_target(target: str) -> tuple[str, int]`：回 `(ssh_target, port)`；不符 `[user@]host:port` → `raise TunnelError("INVALID_TARGET", ...)`。
+  - `def compute_identity(spec: TunnelSpec) -> str`：canonical effective forward spec 的 `sha256` hex。
+
+- [ ] **Step 1: 寫 failing test**
+
+```python
+# tests/test_remote_tunnel.py
+from __future__ import annotations
+
+import pytest
+
+from sw_core import remote_tunnel as rt
+
+
+def test_parse_target_user_host_port():
+    assert rt.parse_target("tester@relay:7777") == ("tester@relay", 7777)
+
+
+def test_parse_target_alias_only():
+    assert rt.parse_target("myrelay:22000") == ("myrelay", 22000)
+
+
+@pytest.mark.parametrize("bad", ["nohost", "host:", "host:abc", "host:-1", "", "a@b@c:1"])
+def test_parse_target_rejects_bad(bad):
+    with pytest.raises(rt.TunnelError) as ei:
+        rt.parse_target(bad)
+    assert ei.value.code == "INVALID_TARGET"
+
+
+def test_identity_stable_and_distinguishes_remote_socket():
+    a = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/run/s.sock")
+    b = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/run/s.sock")
+    c = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/run/s.sock",
+                      remote_socket="/relay/b.sock")
+    assert rt.compute_identity(a) == rt.compute_identity(b)
+    assert rt.compute_identity(a) != rt.compute_identity(c)
+
+
+def test_identity_distinguishes_via_and_ssh_opts():
+    base = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/run/s.sock")
+    assert rt.compute_identity(base) != rt.compute_identity(
+        rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/run/s.sock", via="autossh"))
+    assert rt.compute_identity(base) != rt.compute_identity(
+        rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/run/s.sock",
+                      ssh_opts=("-p", "2222")))
+```
+
+- [ ] **Step 2: 跑 test 確認 fail**
+
+Run: `python3 -m pytest tests/test_remote_tunnel.py -q`
+Expected: FAIL（`ModuleNotFoundError` 或 `AttributeError: parse_target`）。
+
+- [ ] **Step 3: 寫最小實作**
+
+```python
+# sw_core/remote_tunnel.py
+"""serialwrap `remote` 隧道便利層（純 CLI，daemon 零改動）。
+
+外包給系統 ssh 建立 `-R`（expose）／`-L`（connect）隧道，background 常駐、
+flock registry 管理、readiness 確認。設計見
+docs/superpowers/specs/2026-07-19-remote-tunnel-cli-design.md。
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+
+# `[user@]host:port`——host 允許 ssh_config alias（不含 '@'/':' 的一段）。
+_TARGET_RE = re.compile(r"^(?:(?P<user>[^@:]+)@)?(?P<host>[^@:]+):(?P<port>\d+)$")
+
+
+class TunnelError(Exception):
+    """攜帶 error_code 的隧道錯誤；不讓例外穿越 CLI 邊界。"""
+
+    def __init__(self, code: str, message: str | None = None) -> None:
+        super().__init__(message or code)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class TunnelSpec:
+    role: str  # "expose" | "connect"
+    ssh_target: str
+    port: int
+    local: int | None = None
+    forward_src: str | None = None
+    remote_socket: str | None = None
+    via: str = "ssh"  # "ssh" | "autossh"
+    ssh_opts: tuple[str, ...] = ()
+    ready_timeout: float = 10.0
+
+
+def parse_target(target: str) -> tuple[str, int]:
+    m = _TARGET_RE.match(target or "")
+    if not m:
+        raise TunnelError("INVALID_TARGET", f"target 需為 [user@]host:port，取得 {target!r}")
+    port = int(m.group("port"))
+    if not (1 <= port <= 65535):
+        raise TunnelError("INVALID_TARGET", f"port 超出範圍：{port}")
+    user = m.group("user")
+    host = m.group("host")
+    ssh_target = f"{user}@{host}" if user else host
+    return ssh_target, port
+
+
+def compute_identity(spec: TunnelSpec) -> str:
+    # canonical effective forward spec：涵蓋所有會改變入口／目的地的欄位。
+    canonical = "|".join(
+        str(x)
+        for x in (
+            spec.role,
+            spec.ssh_target,
+            spec.port,
+            spec.local,
+            spec.forward_src,
+            spec.remote_socket,
+            spec.via,
+            ";".join(spec.ssh_opts),
+        )
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+```
+
+- [ ] **Step 4: 跑 test 確認 pass**
+
+Run: `python3 -m pytest tests/test_remote_tunnel.py -q`
+Expected: PASS（5 passed）。
+
+- [ ] **Step 5: commit**
+
+```bash
+git add sw_core/remote_tunnel.py tests/test_remote_tunnel.py
+git commit -m "feat(remote): remote_tunnel 模組骨架與 target 解析／identity" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 2: `build_argv`（ssh/autossh argv 組裝）
+
+**Files:**
+- Modify: `sw_core/remote_tunnel.py`
+- Test: `tests/test_remote_tunnel.py`
+
+**Interfaces:**
+- Consumes: `TunnelSpec`（Task 1）。
+- Produces:
+  - `def default_ssh_opts(control_path: str) -> list[str]`：回預設 `-o` 清單。
+  - `def build_argv(spec: TunnelSpec, control_path: str) -> list[str]`：完整 `ssh`/`autossh` argv（含方向 `-R`/`-L`、預設 `-o`、`--ssh-opt` 透傳、target）。
+
+- [ ] **Step 1: 寫 failing test**
+
+```python
+# tests/test_remote_tunnel.py（append）
+def _cp():
+    return "/run/user/1000/serialwrap/remote/cm-abc"
+
+
+def test_build_argv_expose_unix_socket_loopback_bind():
+    spec = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777,
+                         forward_src="/run/serialwrapd.sock")
+    argv = rt.build_argv(spec, _cp())
+    assert argv[0] == "ssh"
+    assert "-N" in argv and "-T" in argv
+    assert "-R" in argv
+    assert argv[argv.index("-R") + 1] == "127.0.0.1:7777:/run/serialwrapd.sock"
+    joined = " ".join(argv)
+    assert "BatchMode=yes" in joined
+    assert "ExitOnForwardFailure=yes" in joined
+    assert "ControlMaster=auto" in joined
+    assert f"ControlPath={_cp()}" in joined
+    assert argv[-1] == "u@h"
+
+
+def test_build_argv_expose_remote_socket_hardened():
+    spec = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777,
+                         forward_src="/run/serialwrapd.sock", remote_socket="/relay/x.sock")
+    argv = rt.build_argv(spec, _cp())
+    assert argv[argv.index("-R") + 1] == "/relay/x.sock:/run/serialwrapd.sock"
+
+
+def test_build_argv_expose_tcp_forward_src():
+    spec = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777,
+                         forward_src="127.0.0.1:48700")
+    argv = rt.build_argv(spec, _cp())
+    assert argv[argv.index("-R") + 1] == "127.0.0.1:7777:127.0.0.1:48700"
+
+
+def test_build_argv_connect_tcp_loopback():
+    spec = rt.TunnelSpec(role="connect", ssh_target="u@relay", port=7777, local=7777)
+    argv = rt.build_argv(spec, _cp())
+    assert argv[argv.index("-L") + 1] == "127.0.0.1:7777:localhost:7777"
+
+
+def test_build_argv_connect_remote_socket():
+    spec = rt.TunnelSpec(role="connect", ssh_target="u@relay", port=7777, local=7788,
+                         remote_socket="/relay/x.sock")
+    argv = rt.build_argv(spec, _cp())
+    assert argv[argv.index("-L") + 1] == "127.0.0.1:7788:/relay/x.sock"
+
+
+def test_build_argv_autossh_and_ssh_opts_passthrough():
+    spec = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777,
+                         forward_src="/s.sock", via="autossh", ssh_opts=("-p", "2222"))
+    argv = rt.build_argv(spec, _cp())
+    assert argv[0] == "autossh"
+    assert argv[1:3] == ["-M", "0"]
+    assert "-p" in argv and argv[argv.index("-p") + 1] == "2222"
+```
+
+- [ ] **Step 2: 跑 test 確認 fail**
+
+Run: `python3 -m pytest tests/test_remote_tunnel.py -q`
+Expected: FAIL（`AttributeError: build_argv`）。
+
+- [ ] **Step 3: 寫實作**
+
+```python
+# sw_core/remote_tunnel.py（append）
+def default_ssh_opts(control_path: str) -> list[str]:
+    """readiness／安全預設 -o（可被使用者 --ssh-opt 覆寫，故置於其前）。"""
+    return [
+        "-o", "BatchMode=yes",            # 禁互動認證，失敗即退出不卡死
+        "-o", "ExitOnForwardFailure=yes",  # forward 建不起即退出，供 readiness 判死
+        "-o", "ControlMaster=auto",
+        "-o", f"ControlPath={control_path}",
+        "-o", "ControlPersist=no",
+        "-o", "ServerAliveInterval=30",
+        "-o", "ServerAliveCountMax=3",
+    ]
+
+
+def _direction_args(spec: TunnelSpec) -> list[str]:
+    if spec.role == "expose":
+        if spec.remote_socket:
+            bind = spec.remote_socket                      # 遠端 unix socket（硬化）
+        else:
+            bind = f"127.0.0.1:{spec.port}"                # 顯式遠端 loopback bind
+        return ["-R", f"{bind}:{spec.forward_src}"]
+    # connect：顯式本機 loopback bind
+    local = spec.local if spec.local is not None else spec.port
+    dest = spec.remote_socket if spec.remote_socket else f"localhost:{spec.port}"
+    return ["-L", f"127.0.0.1:{local}:{dest}"]
+
+
+def build_argv(spec: TunnelSpec, control_path: str) -> list[str]:
+    base = ["autossh", "-M", "0"] if spec.via == "autossh" else ["ssh"]
+    argv = [*base, "-N", "-T", *default_ssh_opts(control_path), *spec.ssh_opts]
+    argv += _direction_args(spec)
+    argv.append(spec.ssh_target)
+    return argv
+```
+
+- [ ] **Step 4: 跑 test 確認 pass**
+
+Run: `python3 -m pytest tests/test_remote_tunnel.py -q`
+Expected: PASS。
+
+- [ ] **Step 5: commit**
+
+```bash
+git add sw_core/remote_tunnel.py tests/test_remote_tunnel.py
+git commit -m "feat(remote): build_argv 組裝 ssh/autossh -R/-L 與安全預設 -o" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 3: state registry（flock + durable state + pid_start_ticks 存活 + prune）
+
+**Files:**
+- Modify: `sw_core/remote_tunnel.py`
+- Test: `tests/test_remote_tunnel.py`
+
+**Interfaces:**
+- Consumes: `TunnelSpec`、`compute_identity`（Tasks 1）。
+- Produces:
+  - `def read_pid_start_ticks(pid: int) -> int | None`：讀 `/proc/<pid>/stat` 第 22 欄；讀不到回 `None`。
+  - `def pid_alive(pid: int, start_ticks: int | None) -> bool`：`os.kill(pid,0)` + start-ticks 一致性（防 PID reuse）。
+  - `class Registry`：`__init__(self, run_dir: str)`；`remote_dir`（`<run_dir>/remote`）、`lock()`（contextmanager，flock LOCK_EX）、`control_path(listen_port: int) -> str`、`state_path(listen_port: int) -> str`、`write(state: dict) -> None`（atomic `os.replace`）、`read(listen_port: int) -> dict | None`、`read_all() -> list[dict]`、`remove(listen_port: int) -> None`。
+
+- [ ] **Step 1: 寫 failing test**
+
+```python
+# tests/test_remote_tunnel.py（append）
+import json
+import os
+import subprocess
+
+
+def test_registry_write_read_remove_atomic(tmp_path):
+    reg = rt.Registry(str(tmp_path))
+    with reg.lock():
+        reg.write({"listen_port": 7777, "status": "active", "role": "expose"})
+    assert reg.read(7777)["status"] == "active"
+    assert [s["listen_port"] for s in reg.read_all()] == [7777]
+    with reg.lock():
+        reg.remove(7777)
+    assert reg.read(7777) is None
+
+
+def test_pid_alive_true_for_running_and_reuse_guard(tmp_path):
+    proc = subprocess.Popen(["sleep", "30"])
+    try:
+        ticks = rt.read_pid_start_ticks(proc.pid)
+        assert ticks is not None
+        assert rt.pid_alive(proc.pid, ticks) is True
+        # start-ticks 不符 → 視為非我方（PID reuse 防護）
+        assert rt.pid_alive(proc.pid, ticks + 999999) is False
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+def test_pid_alive_false_for_dead(tmp_path):
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    assert rt.pid_alive(proc.pid, 12345) is False
+
+
+def test_lock_is_exclusive_serialized(tmp_path):
+    # 兩次 lock 不會同時持有（LOCK_EX）；此處驗證可重入取得、釋放後再取。
+    reg = rt.Registry(str(tmp_path))
+    with reg.lock():
+        pass
+    with reg.lock():
+        reg.write({"listen_port": 1, "status": "spawning", "role": "connect"})
+    assert reg.read(1)["status"] == "spawning"
+```
+
+- [ ] **Step 2: 跑 test 確認 fail**
+
+Run: `python3 -m pytest tests/test_remote_tunnel.py -k "registry or pid_alive or lock" -q`
+Expected: FAIL（`AttributeError: Registry`）。
+
+- [ ] **Step 3: 寫實作**
+
+```python
+# sw_core/remote_tunnel.py（append）
+import contextlib
+import fcntl
+import json
+import os
+
+
+def read_pid_start_ticks(pid: int) -> int | None:
+    """Linux /proc/<pid>/stat 第 22 欄（starttime，clock ticks）。非 Linux／不存在回 None。"""
+    try:
+        with open(f"/proc/{pid}/stat", "rb") as fh:
+            data = fh.read()
+    except OSError:
+        return None
+    # comm 欄可能含空白/括號，故從最後一個 ')' 之後切。
+    rparen = data.rfind(b")")
+    if rparen < 0:
+        return None
+    fields = data[rparen + 2:].split()
+    # 切點後的 fields[0] 為 state(第3欄)，starttime 為第22欄 → index 22-3 = 19。
+    if len(fields) <= 19:
+        return None
+    try:
+        return int(fields[19])
+    except ValueError:
+        return None
+
+
+def pid_alive(pid: int, start_ticks: int | None) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    if start_ticks is None:
+        return True  # 無 /proc（非 Linux）→ best-effort pid-only
+    current = read_pid_start_ticks(pid)
+    if current is None:
+        return True
+    return current == start_ticks
+
+
+class Registry:
+    """`<run_dir>/remote/` 下的 per-tunnel state JSON + flock 序列化。"""
+
+    def __init__(self, run_dir: str) -> None:
+        self.run_dir = run_dir
+        self.remote_dir = os.path.join(run_dir, "remote")
+
+    def _ensure_dir(self) -> None:
+        os.makedirs(self.remote_dir, exist_ok=True)
+
+    @contextlib.contextmanager
+    def lock(self):
+        self._ensure_dir()
+        lock_path = os.path.join(self.remote_dir, ".registry.lock")
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            yield
+        finally:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+
+    def control_path(self, listen_port: int) -> str:
+        return os.path.join(self.remote_dir, f"cm-{listen_port}")
+
+    def state_path(self, listen_port: int) -> str:
+        return os.path.join(self.remote_dir, f"{listen_port}.json")
+
+    def write(self, state: dict) -> None:
+        self._ensure_dir()
+        path = self.state_path(int(state["listen_port"]))
+        tmp = f"{path}.tmp.{os.getpid()}"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(state, fh, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        os.replace(tmp, path)  # atomic
+
+    def read(self, listen_port: int) -> dict | None:
+        try:
+            with open(self.state_path(listen_port), "r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            return None
+
+    def read_all(self) -> list[dict]:
+        out: list[dict] = []
+        try:
+            names = os.listdir(self.remote_dir)
+        except OSError:
+            return out
+        for name in sorted(names):
+            if name.endswith(".json"):
+                try:
+                    with open(os.path.join(self.remote_dir, name), "r", encoding="utf-8") as fh:
+                        out.append(json.load(fh))
+                except (OSError, json.JSONDecodeError):
+                    continue
+        return out
+
+    def remove(self, listen_port: int) -> None:
+        for p in (self.state_path(listen_port), self.control_path(listen_port)):
+            with contextlib.suppress(OSError):
+                os.unlink(p)
+```
+
+- [ ] **Step 4: 跑 test 確認 pass**
+
+Run: `python3 -m pytest tests/test_remote_tunnel.py -k "registry or pid_alive or lock" -q`
+Expected: PASS。
+
+- [ ] **Step 5: commit**
+
+```bash
+git add sw_core/remote_tunnel.py tests/test_remote_tunnel.py
+git commit -m "feat(remote): flock registry + durable state + pid_start_ticks 存活驗證" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 4: readiness（注入式 probe：ssh -O check / ss 遠端 bind / health.ping）
+
+**Files:**
+- Modify: `sw_core/remote_tunnel.py`
+- Test: `tests/test_remote_tunnel.py`
+
+**Interfaces:**
+- Consumes: `TunnelSpec`（Task 1）。
+- Produces:
+  - `def wait_ready(spec, pid, start_ticks, *, ssh_check, role_probe, sleep, monotonic) -> str`：回 `"active"` | `"starting"`；行程死亡 → `raise TunnelError("TUNNEL_SPAWN_FAILED", <stderr尾>)`。`ssh_check() -> bool`（master 是否已連線＋forward 建立）、`role_probe() -> bool`（`-R`：遠端 bind loopback 驗證；`-L`：`health.ping`）皆為注入 callable；`sleep`／`monotonic` 注入時鐘。遠端 bind 驗到 wildcard 時 `role_probe` 內部 `raise TunnelError("REMOTE_BIND_UNVERIFIED")`。
+
+- [ ] **Step 1: 寫 failing test**
+
+```python
+# tests/test_remote_tunnel.py（append）
+class _Clock:
+    def __init__(self):
+        self.t = 0.0
+    def monotonic(self):
+        return self.t
+    def sleep(self, dt):
+        self.t += dt
+
+
+def _spec_R():
+    return rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock",
+                         ready_timeout=5.0)
+
+
+def test_wait_ready_active_when_check_and_probe_ok():
+    clk = _Clock()
+    st = rt.wait_ready(_spec_R(), pid=1, start_ticks=1,
+                       ssh_check=lambda: True, role_probe=lambda: True,
+                       sleep=clk.sleep, monotonic=clk.monotonic,
+                       alive=lambda: True, stderr_tail=lambda: "")
+    assert st == "active"
+
+
+def test_wait_ready_starting_on_timeout_process_alive():
+    clk = _Clock()
+    st = rt.wait_ready(_spec_R(), pid=1, start_ticks=1,
+                       ssh_check=lambda: False, role_probe=lambda: False,
+                       sleep=clk.sleep, monotonic=clk.monotonic,
+                       alive=lambda: True, stderr_tail=lambda: "")
+    assert st == "starting"
+
+
+def test_wait_ready_spawn_failed_when_process_dies():
+    clk = _Clock()
+    with pytest.raises(rt.TunnelError) as ei:
+        rt.wait_ready(_spec_R(), pid=1, start_ticks=1,
+                      ssh_check=lambda: False, role_probe=lambda: False,
+                      sleep=clk.sleep, monotonic=clk.monotonic,
+                      alive=lambda: False, stderr_tail=lambda: "Permission denied (publickey).")
+    assert ei.value.code == "TUNNEL_SPAWN_FAILED"
+    assert "publickey" in (ei.value.message or "")
+
+
+def test_wait_ready_remote_bind_unverified_propagates():
+    clk = _Clock()
+    def probe():
+        raise rt.TunnelError("REMOTE_BIND_UNVERIFIED", "0.0.0.0:7777")
+    with pytest.raises(rt.TunnelError) as ei:
+        rt.wait_ready(_spec_R(), pid=1, start_ticks=1,
+                      ssh_check=lambda: True, role_probe=probe,
+                      sleep=clk.sleep, monotonic=clk.monotonic,
+                      alive=lambda: True, stderr_tail=lambda: "")
+    assert ei.value.code == "REMOTE_BIND_UNVERIFIED"
+```
+
+- [ ] **Step 2: 跑 test 確認 fail**
+
+Run: `python3 -m pytest tests/test_remote_tunnel.py -k wait_ready -q`
+Expected: FAIL（`AttributeError: wait_ready`）。
+
+- [ ] **Step 3: 寫實作**
+
+```python
+# sw_core/remote_tunnel.py（append）
+_POLL_INTERVAL_S = 0.2
+
+
+def wait_ready(
+    spec: TunnelSpec,
+    pid: int,
+    start_ticks: int | None,
+    *,
+    ssh_check,          # () -> bool：master 連線＋forward 建立
+    role_probe,         # () -> bool：-R 遠端 bind loopback；-L health.ping。可 raise TunnelError
+    sleep,              # (float) -> None
+    monotonic,          # () -> float
+    alive,              # () -> bool：行程是否仍活
+    stderr_tail,        # () -> str：spawn log 的 stderr 尾（供 TUNNEL_SPAWN_FAILED）
+) -> str:
+    """回 'active'（就緒）或 'starting'（逾時但行程仍活）；行程死亡 → TUNNEL_SPAWN_FAILED。"""
+    deadline = monotonic() + spec.ready_timeout
+    while True:
+        if not alive():
+            raise TunnelError("TUNNEL_SPAWN_FAILED", (stderr_tail() or "").strip()[-500:])
+        if ssh_check() and role_probe():   # role_probe 可 raise（REMOTE_BIND_UNVERIFIED）
+            return "active"
+        if monotonic() >= deadline:
+            return "starting"
+        sleep(_POLL_INTERVAL_S)
+```
+
+- [ ] **Step 4: 跑 test 確認 pass**
+
+Run: `python3 -m pytest tests/test_remote_tunnel.py -k wait_ready -q`
+Expected: PASS。
+
+- [ ] **Step 5: commit**
+
+```bash
+git add sw_core/remote_tunnel.py tests/test_remote_tunnel.py
+git commit -m "feat(remote): wait_ready readiness 狀態機（注入式 probe，active/starting/spawn-failed）" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 5: probe 具體實作（ssh -O check / ss 遠端 bind / health.ping）
+
+**Files:**
+- Modify: `sw_core/remote_tunnel.py`
+- Test: `tests/test_remote_tunnel.py`
+
+**Interfaces:**
+- Consumes: `TunnelSpec`、`build_argv` 的 control_path 慣例。
+- Produces（皆接受注入 `runner`／`ping` 以利測試）：
+  - `def make_ssh_check(spec, control_path, *, runner) -> callable`：回 `() -> bool`，內部跑 `ssh -O check -o ControlPath=... <target>`（`runner(argv) -> (rc, stderr)`）。
+  - `def make_role_probe(spec, control_path, endpoint, *, runner, ping) -> callable`：`-R` tcp → 在 relay 跑 `ss` 驗遠端 bind（wildcard → `raise TunnelError("REMOTE_BIND_UNVERIFIED", bind)`）；`-R` unix（`remote_socket`）→ 直接回 `True`；`-L` → `ping(endpoint) -> bool`。
+  - `def endpoint_for(spec) -> str`：`-L`／direct 回 `tcp://127.0.0.1:<local>`。
+
+- [ ] **Step 1: 寫 failing test**
+
+```python
+# tests/test_remote_tunnel.py（append）
+def test_ssh_check_true_on_rc0():
+    calls = []
+    def runner(argv):
+        calls.append(argv)
+        return (0, "")
+    chk = rt.make_ssh_check(rt.TunnelSpec(role="expose", ssh_target="u@h", port=1),
+                            "/cp", runner=runner)
+    assert chk() is True
+    assert "-O" in calls[0] and "check" in calls[0]
+
+
+def test_role_probe_expose_tcp_rejects_wildcard():
+    def runner(argv):
+        return (0, "LISTEN 0 128 0.0.0.0:7777 0.0.0.0:*")
+    probe = rt.make_role_probe(
+        rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock"),
+        "/cp", "tcp://127.0.0.1:7777", runner=runner, ping=lambda ep: True)
+    with pytest.raises(rt.TunnelError) as ei:
+        probe()
+    assert ei.value.code == "REMOTE_BIND_UNVERIFIED"
+
+
+def test_role_probe_expose_tcp_accepts_loopback():
+    def runner(argv):
+        return (0, "LISTEN 0 128 127.0.0.1:7777 0.0.0.0:*")
+    probe = rt.make_role_probe(
+        rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock"),
+        "/cp", "tcp://127.0.0.1:7777", runner=runner, ping=lambda ep: True)
+    assert probe() is True
+
+
+def test_role_probe_expose_remote_socket_skips_bind_check():
+    def runner(argv):
+        raise AssertionError("unix 模式不應跑 ss")
+    probe = rt.make_role_probe(
+        rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock",
+                      remote_socket="/relay/x.sock"),
+        "/cp", "", runner=runner, ping=lambda ep: True)
+    assert probe() is True
+
+
+def test_role_probe_connect_uses_health_ping():
+    seen = {}
+    probe = rt.make_role_probe(
+        rt.TunnelSpec(role="connect", ssh_target="u@relay", port=7777, local=7777),
+        "/cp", "tcp://127.0.0.1:7777",
+        runner=lambda argv: (0, ""), ping=lambda ep: seen.setdefault("ep", ep) or True)
+    assert probe() is True
+    assert seen["ep"] == "tcp://127.0.0.1:7777"
+```
+
+- [ ] **Step 2: 跑 test 確認 fail**
+
+Run: `python3 -m pytest tests/test_remote_tunnel.py -k "ssh_check or role_probe" -q`
+Expected: FAIL。
+
+- [ ] **Step 3: 寫實作**
+
+```python
+# sw_core/remote_tunnel.py（append）
+import re as _re
+
+_WILDCARD_RE = _re.compile(r"(?:^|\s)(0\.0\.0\.0|\[?::\]?|\*):%d\b")
+
+
+def endpoint_for(spec: TunnelSpec) -> str:
+    local = spec.local if spec.local is not None else spec.port
+    return f"tcp://127.0.0.1:{local}"
+
+
+def make_ssh_check(spec: TunnelSpec, control_path: str, *, runner):
+    def _check() -> bool:
+        rc, _ = runner(["ssh", "-O", "check", "-o", f"ControlPath={control_path}", spec.ssh_target])
+        return rc == 0
+    return _check
+
+
+def make_role_probe(spec: TunnelSpec, control_path: str, endpoint: str, *, runner, ping):
+    def _probe() -> bool:
+        if spec.role == "connect":
+            return bool(ping(endpoint))
+        # expose：unix socket 模式天然 fail-closed，免 ss 驗證
+        if spec.remote_socket:
+            return True
+        # tcp 模式：以 master 連線在 relay 跑 ss，驗遠端 bind 為 loopback（fail-closed）
+        rc, out = runner([
+            "ssh", "-o", f"ControlPath={control_path}", spec.ssh_target,
+            "ss", "-ltnH", f"sport = :{spec.port}",
+        ])
+        if rc != 0 or not out.strip():
+            raise TunnelError("REMOTE_BIND_UNVERIFIED", "無法在 relay 驗證遠端 bind")
+        if _WILDCARD_RE.search(out.replace("%d", str(spec.port))) or _bind_has_wildcard(out, spec.port):
+            raise TunnelError("REMOTE_BIND_UNVERIFIED", out.strip()[:200])
+        return True
+    return _probe
+
+
+def _bind_has_wildcard(ss_out: str, port: int) -> bool:
+    """ss 輸出中該 port 是否綁在非 loopback 位址（0.0.0.0 / :: / *）。"""
+    for line in ss_out.splitlines():
+        if f":{port}" not in line:
+            continue
+        for tok in line.split():
+            if tok.endswith(f":{port}"):
+                addr = tok.rsplit(":", 1)[0].strip("[]")
+                if addr in ("0.0.0.0", "::", "*", ""):
+                    return True
+    return False
+```
+
+> 註：`_WILDCARD_RE` 為保險；主判定走 `_bind_has_wildcard`（逐 token 比對位址）。實作者可擇一，測試以 `_bind_has_wildcard` 行為為準。
+
+- [ ] **Step 4: 跑 test 確認 pass**
+
+Run: `python3 -m pytest tests/test_remote_tunnel.py -k "ssh_check or role_probe" -q`
+Expected: PASS。
+
+- [ ] **Step 5: commit**
+
+```bash
+git add sw_core/remote_tunnel.py tests/test_remote_tunnel.py
+git commit -m "feat(remote): probe 實作（ssh -O check、ss 遠端 bind fail-closed、health.ping）" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 6: `open_tunnel` 編排（spawn → durable state → readiness → active/starting，conflict + fail-closed teardown）
+
+**Files:**
+- Modify: `sw_core/remote_tunnel.py`
+- Test: `tests/test_remote_tunnel.py`
+
+**Interfaces:**
+- Consumes: 全部 Task 1-5。
+- Produces:
+  - `def open_tunnel(spec, run_dir, *, spawner, ssh_check_factory=make_ssh_check, role_probe_factory=make_role_probe, runner=..., ping=..., clock=...) -> dict`。`spawner(argv, control_path, log_path) -> (pid, pgid, start_ticks, stderr_tail_fn)`。回 `{"ok":true,"status":...,"role":...,"pid":...,"listen_port":...,...}` 或 `raise TunnelError`。
+  - 流程（持 `Registry.lock()`）：identity 衝突檢查 → spawn → **立即寫 `status="spawning"` durable state** → 釋放鎖跑 readiness → 依結果 `os.replace` 成 `active`/`starting`；readiness raise（含 `REMOTE_BIND_UNVERIFIED`/`TUNNEL_SPAWN_FAILED`）→ **拆除隧道 + remove state** 後 re-raise。
+
+- [ ] **Step 1: 寫 failing test**
+
+```python
+# tests/test_remote_tunnel.py（append）
+class _FakeProc:
+    def __init__(self, pid): self.pid = pid
+    def poll(self): return None
+
+
+def _fake_spawner(alive=True, stderr=""):
+    procs = {}
+    def spawn(argv, control_path, log_path):
+        proc = subprocess.Popen(["sleep", "30"]) if alive else subprocess.Popen(["true"])
+        if not alive:
+            proc.wait()
+        procs["p"] = proc
+        return proc.pid, os.getpgid(proc.pid) if alive else proc.pid, \
+               rt.read_pid_start_ticks(proc.pid), (lambda: stderr)
+    spawn.procs = procs
+    return spawn
+
+
+def test_open_tunnel_expose_active(tmp_path):
+    spec = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock")
+    spawn = _fake_spawner(alive=True)
+    try:
+        res = rt.open_tunnel(spec, str(tmp_path), spawner=spawn,
+                             runner=lambda a: (0, "LISTEN 0 128 127.0.0.1:7777 *:*"),
+                             ping=lambda ep: True)
+        assert res["ok"] and res["status"] == "active" and res["role"] == "expose"
+        reg = rt.Registry(str(tmp_path))
+        assert reg.read(7777)["status"] == "active"
+    finally:
+        spawn.procs["p"].terminate(); spawn.procs["p"].wait()
+
+
+def test_open_tunnel_conflict_same_port_diff_identity(tmp_path):
+    reg = rt.Registry(str(tmp_path))
+    with reg.lock():
+        reg.write({"listen_port": 7777, "status": "active", "role": "expose",
+                   "identity": "OTHER", "pid": os.getpid(),
+                   "pid_start_ticks": rt.read_pid_start_ticks(os.getpid())})
+    spec = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock")
+    with pytest.raises(rt.TunnelError) as ei:
+        rt.open_tunnel(spec, str(tmp_path), spawner=_fake_spawner(),
+                       runner=lambda a: (0, ""), ping=lambda ep: True)
+    assert ei.value.code == "TUNNEL_CONFLICT"
+
+
+def test_open_tunnel_fail_closed_removes_state_on_bind_unverified(tmp_path):
+    spec = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock")
+    spawn = _fake_spawner(alive=True)
+    try:
+        with pytest.raises(rt.TunnelError) as ei:
+            rt.open_tunnel(spec, str(tmp_path), spawner=spawn,
+                           runner=lambda a: (0, "LISTEN 0 128 0.0.0.0:7777 *:*"),  # wildcard
+                           ping=lambda ep: True)
+        assert ei.value.code == "REMOTE_BIND_UNVERIFIED"
+        assert rt.Registry(str(tmp_path)).read(7777) is None  # 拆除、不留暴露隧道
+    finally:
+        with contextlib.suppress(Exception):
+            spawn.procs["p"].wait(timeout=2)
+```
+
+- [ ] **Step 2: 跑 test 確認 fail**
+
+Run: `python3 -m pytest tests/test_remote_tunnel.py -k open_tunnel -q`
+Expected: FAIL。
+
+- [ ] **Step 3: 寫實作**
+
+```python
+# sw_core/remote_tunnel.py（append）
+import signal
+import time
+
+
+def _terminate_pgid(pgid: int, *, timeout: float = 5.0, sleep=time.sleep) -> None:
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(pgid, signal.SIGTERM)
+    waited = 0.0
+    while waited < timeout:
+        try:
+            os.killpg(pgid, 0)
+        except ProcessLookupError:
+            return
+        sleep(0.1)
+        waited += 0.1
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(pgid, signal.SIGKILL)
+
+
+def open_tunnel(
+    spec: TunnelSpec,
+    run_dir: str,
+    *,
+    spawner,
+    runner,
+    ping,
+    ssh_check_factory=make_ssh_check,
+    role_probe_factory=make_role_probe,
+    clock=None,
+) -> dict:
+    reg = Registry(run_dir)
+    listen_port = spec.local if (spec.role == "connect" and spec.local is not None) else spec.port
+    identity = compute_identity(spec)
+    control_path = reg.control_path(listen_port)
+
+    # ── check → spawn → durable state（持鎖）──
+    with reg.lock():
+        existing = reg.read(listen_port)
+        if existing:
+            alive = pid_alive(int(existing.get("pid", -1)), existing.get("pid_start_ticks"))
+            if alive and existing.get("identity") == identity:
+                return {"ok": True, "already_running": True, **_public(existing)}
+            if alive and existing.get("identity") != identity:
+                raise TunnelError("TUNNEL_CONFLICT",
+                                  f"port {listen_port} 已有不同 identity 的隧道，請先 remote close {listen_port}")
+            reg.remove(listen_port)  # 死 state → 覆寫
+        log_path = os.path.join(reg.remote_dir, f"{listen_port}.log")
+        pid, pgid, start_ticks, stderr_tail = spawner(build_argv(spec, control_path), control_path, log_path)
+        state = {
+            "identity": identity, "status": "spawning", "role": spec.role,
+            "pid": pid, "pgid": pgid, "pid_start_ticks": start_ticks,
+            "target": spec.ssh_target, "listen_port": listen_port,
+            "remote_bind": spec.remote_socket or f"127.0.0.1:{spec.port}",
+            "forward_target": spec.forward_src, "via": spec.via,
+            "control_path": control_path, "endpoint": endpoint_for(spec),
+        }
+        reg.write(state)
+
+    # ── readiness（不持鎖，避免阻塞其他操作）──
+    import time as _t
+    monotonic = (clock or _t).monotonic
+    sleep = (clock or _t).sleep
+    endpoint = endpoint_for(spec)
+    ssh_check = ssh_check_factory(spec, control_path, runner=runner)
+    role_probe = role_probe_factory(spec, control_path, endpoint, runner=runner, ping=ping)
+
+    try:
+        status = wait_ready(
+            spec, pid, start_ticks,
+            ssh_check=ssh_check, role_probe=role_probe,
+            sleep=sleep, monotonic=monotonic,
+            alive=lambda: pid_alive(pid, start_ticks),
+            stderr_tail=stderr_tail,
+        )
+    except TunnelError:
+        _terminate_pgid(pgid, sleep=sleep)
+        with reg.lock():
+            reg.remove(listen_port)
+        raise
+
+    with reg.lock():
+        state["status"] = status
+        reg.write(state)
+    return {"ok": True, **_public(state)}
+
+
+def _public(state: dict) -> dict:
+    """對外可見欄位（去掉 argv 等內部細節）。"""
+    keys = ("status", "role", "pid", "listen_port", "target", "remote_bind",
+            "forward_target", "via", "endpoint", "identity")
+    out = {k: state[k] for k in keys if k in state}
+    if state.get("role") == "expose":
+        out["remote_hint"] = f"agent 端用 serialwrap --endpoint {state.get('endpoint','tcp://127.0.0.1:%d' % state['listen_port'])}"
+    return out
+```
+
+- [ ] **Step 4: 跑 test 確認 pass**
+
+Run: `python3 -m pytest tests/test_remote_tunnel.py -k open_tunnel -q`
+Expected: PASS。
+
+- [ ] **Step 5: commit**
+
+```bash
+git add sw_core/remote_tunnel.py tests/test_remote_tunnel.py
+git commit -m "feat(remote): open_tunnel 編排（durable state、conflict、fail-closed teardown）" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 7: `status` + `close`（killpg 整組 + verify + orphan scan）
+
+**Files:**
+- Modify: `sw_core/remote_tunnel.py`
+- Test: `tests/test_remote_tunnel.py`
+
+**Interfaces:**
+- Consumes: `Registry`、`pid_alive`、`_terminate_pgid`。
+- Produces:
+  - `def status(run_dir) -> dict`：`{"ok":true,"tunnels":[...]}`；prune 死 state、orphan scan（`cm-*` 對應 ssh 活著卻無 state → 標 `orphan`）。
+  - `def close(run_dir, selector) -> dict`：`selector` 為 port（str/int）或 `"all"`；驗 pid+start-ticks → `killpg` 整組 → wait → remove；失敗保留 `status="error"`。回 `{"ok":true,"closed":[...]}`。
+
+- [ ] **Step 1: 寫 failing test**
+
+```python
+# tests/test_remote_tunnel.py（append）
+def test_status_prunes_dead_and_lists_alive(tmp_path):
+    reg = rt.Registry(str(tmp_path))
+    live = subprocess.Popen(["sleep", "30"])
+    try:
+        with reg.lock():
+            reg.write({"listen_port": 7777, "status": "active", "role": "expose",
+                       "pid": live.pid, "pgid": os.getpgid(live.pid),
+                       "pid_start_ticks": rt.read_pid_start_ticks(live.pid),
+                       "target": "u@h"})
+            reg.write({"listen_port": 7778, "status": "active", "role": "connect",
+                       "pid": 999999, "pgid": 999999, "pid_start_ticks": 1, "target": "u@r"})
+        res = rt.status(str(tmp_path))
+        ports = {t["listen_port"] for t in res["tunnels"]}
+        assert 7777 in ports and 7778 not in ports  # 死的被 prune
+    finally:
+        live.terminate(); live.wait()
+
+
+def test_close_terminates_and_removes(tmp_path):
+    reg = rt.Registry(str(tmp_path))
+    live = subprocess.Popen(["sleep", "30"])
+    with reg.lock():
+        reg.write({"listen_port": 7777, "status": "active", "role": "expose",
+                   "pid": live.pid, "pgid": os.getpgid(live.pid),
+                   "pid_start_ticks": rt.read_pid_start_ticks(live.pid), "target": "u@h"})
+    res = rt.close(str(tmp_path), 7777)
+    assert 7777 in res["closed"]
+    assert reg.read(7777) is None
+    assert live.poll() is not None  # 已被終止
+
+
+def test_close_missing_is_idempotent(tmp_path):
+    assert rt.close(str(tmp_path), 12345) == {"ok": True, "closed": []}
+```
+
+- [ ] **Step 2: 跑 test 確認 fail**
+
+Run: `python3 -m pytest tests/test_remote_tunnel.py -k "status_prunes or close_" -q`
+Expected: FAIL。
+
+- [ ] **Step 3: 寫實作**
+
+```python
+# sw_core/remote_tunnel.py（append）
+def status(run_dir: str) -> dict:
+    reg = Registry(run_dir)
+    tunnels: list[dict] = []
+    with reg.lock():
+        for st in reg.read_all():
+            pid = int(st.get("pid", -1))
+            if pid_alive(pid, st.get("pid_start_ticks")):
+                out = _public(st)
+                out["alive"] = True
+                tunnels.append(out)
+            else:
+                reg.remove(int(st["listen_port"]))  # prune 死 state
+        # orphan scan：cm-* control socket 活著卻無 state
+        try:
+            for name in sorted(os.listdir(reg.remote_dir)):
+                if name.startswith("cm-") and not reg.read(_port_of_cm(name)):
+                    tunnels.append({"status": "orphan", "control_path":
+                                    os.path.join(reg.remote_dir, name), "alive": True})
+        except OSError:
+            pass
+    return {"ok": True, "tunnels": tunnels}
+
+
+def _port_of_cm(name: str) -> int:
+    try:
+        return int(name[len("cm-"):])
+    except ValueError:
+        return -1
+
+
+def close(run_dir: str, selector, *, sleep=time.sleep) -> dict:
+    reg = Registry(run_dir)
+    closed: list[int] = []
+    with reg.lock():
+        targets = reg.read_all()
+        if str(selector) != "all":
+            targets = [s for s in targets if str(s.get("listen_port")) == str(selector)]
+        for st in targets:
+            port = int(st["listen_port"])
+            pid, pgid = int(st.get("pid", -1)), int(st.get("pgid", st.get("pid", -1)))
+            if pid_alive(pid, st.get("pid_start_ticks")):
+                try:
+                    _terminate_pgid(pgid, sleep=sleep)
+                except Exception:  # noqa: BLE001
+                    st["status"] = "error"
+                    reg.write(st)
+                    continue
+            reg.remove(port)
+            closed.append(port)
+    return {"ok": True, "closed": closed}
+```
+
+- [ ] **Step 4: 跑 test 確認 pass**
+
+Run: `python3 -m pytest tests/test_remote_tunnel.py -k "status_prunes or close_" -q`
+Expected: PASS。
+
+- [ ] **Step 5: commit**
+
+```bash
+git add sw_core/remote_tunnel.py tests/test_remote_tunnel.py
+git commit -m "feat(remote): status prune/orphan-scan 與 close killpg-verify-error-state" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 8: real spawner + ssh 探索 + platform guard
+
+**Files:**
+- Modify: `sw_core/remote_tunnel.py`
+- Test: `tests/test_remote_tunnel.py`
+
+**Interfaces:**
+- Produces:
+  - `def resolve_ssh_bin(via: str) -> str`：`shutil.which("ssh"/"autossh")`；缺 → `raise TunnelError("SSH_NOT_FOUND")`。
+  - `def real_spawner(argv, control_path, log_path) -> (pid, pgid, start_ticks, stderr_tail_fn)`：`subprocess.Popen(argv, start_new_session=True, stdin=DEVNULL, stdout/stderr→log)`；`stderr_tail_fn` 讀 log 尾。
+  - `def make_runner() -> callable`：`(argv) -> (rc, stdout+stderr)`，real `subprocess.run`（供 probe）。
+  - `def real_ping(endpoint) -> bool`：呼叫 `sw_core.client.rpc_call(endpoint, "health.ping", {}, timeout_s=2.0).get("ok")`。
+  - `def guard_platform() -> None`：`os.name == "nt"` → `raise TunnelError("REMOTE_NOT_SUPPORTED")`。
+
+- [ ] **Step 1: 寫 failing test**
+
+```python
+# tests/test_remote_tunnel.py（append）
+def test_resolve_ssh_bin_missing(monkeypatch):
+    monkeypatch.setattr(rt.shutil, "which", lambda name: None)
+    with pytest.raises(rt.TunnelError) as ei:
+        rt.resolve_ssh_bin("ssh")
+    assert ei.value.code == "SSH_NOT_FOUND"
+
+
+def test_guard_platform_rejects_windows(monkeypatch):
+    monkeypatch.setattr(rt.os, "name", "nt")
+    with pytest.raises(rt.TunnelError) as ei:
+        rt.guard_platform()
+    assert ei.value.code == "REMOTE_NOT_SUPPORTED"
+
+
+def test_real_ping_uses_client(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(rt, "_rpc_call", lambda ep, m, p, timeout_s: seen.setdefault("ep", ep) or {"ok": True})
+    assert rt.real_ping("tcp://127.0.0.1:7777") is True
+    assert seen["ep"] == "tcp://127.0.0.1:7777"
+```
+
+- [ ] **Step 2: 跑 test 確認 fail**
+
+Run: `python3 -m pytest tests/test_remote_tunnel.py -k "resolve_ssh or guard_platform or real_ping" -q`
+Expected: FAIL。
+
+- [ ] **Step 3: 寫實作**
+
+```python
+# sw_core/remote_tunnel.py（append）
+import shutil
+import subprocess
+
+from .client import rpc_call as _rpc_call
+
+
+def guard_platform() -> None:
+    if os.name == "nt":
+        raise TunnelError("REMOTE_NOT_SUPPORTED",
+                          "native Windows 本期不支援 serialwrap remote；請手動 ssh -R（見 SKILL_WINDOWS.md）")
+
+
+def resolve_ssh_bin(via: str) -> str:
+    name = "autossh" if via == "autossh" else "ssh"
+    path = shutil.which(name)
+    if not path:
+        raise TunnelError("SSH_NOT_FOUND", f"PATH 找不到 {name}")
+    return path
+
+
+def real_spawner(argv, control_path, log_path):
+    os.makedirs(os.path.dirname(control_path), exist_ok=True)
+    log = open(log_path, "ab", buffering=0)  # noqa: SIM115（stderr_tail 需持續讀）
+    proc = subprocess.Popen(
+        argv, stdin=subprocess.DEVNULL, stdout=log, stderr=log,
+        start_new_session=True, close_fds=True,
+    )
+    pgid = os.getpgid(proc.pid)
+    start_ticks = read_pid_start_ticks(proc.pid)
+
+    def _stderr_tail() -> str:
+        try:
+            with open(log_path, "rb") as fh:
+                return fh.read()[-500:].decode("utf-8", "replace")
+        except OSError:
+            return ""
+
+    return proc.pid, pgid, start_ticks, _stderr_tail
+
+
+def make_runner():
+    def _run(argv):
+        proc = subprocess.run(argv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                              text=True, timeout=10.0, check=False)
+        return proc.returncode, proc.stdout or ""
+    return _run
+
+
+def real_ping(endpoint: str) -> bool:
+    try:
+        return bool(_rpc_call(endpoint, "health.ping", {}, timeout_s=2.0).get("ok"))
+    except Exception:  # noqa: BLE001
+        return False
+```
+
+- [ ] **Step 4: 跑 test 確認 pass**
+
+Run: `python3 -m pytest tests/test_remote_tunnel.py -q`
+Expected: PASS（全模組 unit 綠）。
+
+- [ ] **Step 5: commit**
+
+```bash
+git add sw_core/remote_tunnel.py tests/test_remote_tunnel.py
+git commit -m "feat(remote): real spawner／ssh 探索／platform guard／health.ping runner" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 9: CLI `remote` subparser + 分派
+
+**Files:**
+- Modify: `sw_core/cli.py`
+- Test: `tests/test_remote_cli.py`（Create）
+
+**Interfaces:**
+- Consumes: `sw_core.remote_tunnel`（全部）、`sw_core.cli._print`、`_resolve_endpoint`。
+- Produces:
+  - subparser：`remote`，positional `words`（`nargs="*"`）、`-R`/`-L`（互斥 store_true）、`--autossh`、`--local`（int）、`--socket`、`--remote-socket`、`--ready-timeout`（float，預設 10.0）、`--ssh-opt`（append）。
+  - `def _run_remote(args) -> int`：解讀 `words`（`[]`/`status` → status；`close [port|all]` → close；否則 target → open）。open 前 `guard_platform()`、`resolve_ssh_bin`；`-R`/`-L` 互斥檢查（→ `INVALID_ARGS`）；`-R` 預設。以 `_resolve_endpoint(args)`（unix path 或 tcp）推 `forward_src`。組 `TunnelSpec`，呼 `open_tunnel(..., spawner=real_spawner, runner=make_runner(), ping=real_ping)`。全程 `try/except TunnelError` → `_print({"ok":False,"error_code":e.code,...})`、`return 1`。
+  - `main()` 加 `if args.cmd == "remote": return _run_remote(args)`。
+
+- [ ] **Step 1: 寫 failing test**
+
+```python
+# tests/test_remote_cli.py
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from sw_core import cli
+from sw_core import remote_tunnel as rt
+
+
+def _run(argv, capsys):
+    rc = cli.main(argv)
+    out = capsys.readouterr().out
+    return rc, json.loads(out) if out.strip() else None
+
+
+def test_remote_bare_is_status(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(tmp_path))
+    rc, obj = _run(["remote"], capsys)
+    assert rc == 0 and obj["ok"] and obj["tunnels"] == []
+
+
+def test_remote_mutually_exclusive_R_L(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(tmp_path))
+    rc, obj = _run(["remote", "-R", "-L", "u@h:7777"], capsys)
+    assert rc == 1 and obj["error_code"] == "INVALID_ARGS"
+
+
+def test_remote_invalid_target(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(tmp_path))
+    rc, obj = _run(["remote", "nohost"], capsys)
+    assert rc == 1 and obj["error_code"] == "INVALID_TARGET"
+
+
+def test_remote_open_dispatches_to_open_tunnel(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(tmp_path))
+    captured = {}
+    def fake_open(spec, run_dir, **kw):
+        captured["spec"] = spec
+        return {"ok": True, "status": "active", "role": "expose", "listen_port": spec.port}
+    monkeypatch.setattr(rt, "open_tunnel", fake_open)
+    monkeypatch.setattr(rt, "resolve_ssh_bin", lambda via: "/usr/bin/ssh")
+    rc, obj = _run(["remote", "tester@relay:7777"], capsys)
+    assert rc == 0 and obj["status"] == "active"
+    assert captured["spec"].role == "expose"  # -R 預設
+    assert captured["spec"].ssh_target == "tester@relay"
+```
+
+- [ ] **Step 2: 跑 test 確認 fail**
+
+Run: `python3 -m pytest tests/test_remote_cli.py -q`
+Expected: FAIL（`remote` subparser 不存在 / `INVALID_ARGS` 未實作）。
+
+- [ ] **Step 3: 寫實作**
+
+在 `build_parser()` 內（與其他 `sub.add_parser` 並列）新增：
+
+```python
+    # sw_core/cli.py（build_parser 內）
+    p_remote = sub.add_parser(
+        "remote",
+        help="按需開關 ssh 反向隧道，讓遠端 agent 連本機 daemon（-R 預設 expose）",
+        description=(
+            "serialwrap remote：外包系統 ssh 建立 -R（expose，把本機 daemon 推到對端）／"
+            "-L（connect，relay 情境把對端 port 拉回本機 loopback）隧道，background 常駐。\n"
+            "  serialwrap remote user@host:7777        # -R 預設：expose 本機 daemon\n"
+            "  serialwrap remote -L user@relay:7777    # connect（relay/雙 NAT）\n"
+            "  serialwrap remote                        # 列目前隧道（status）\n"
+            "  serialwrap remote close 7777|all         # 拆除\n"
+            "安全：只透過 ssh-tunnel、單租戶/可信 relay 或 --remote-socket；不可對網路直接開放。"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p_remote.add_argument("words", nargs="*", help="[user@]host:port ｜ status ｜ close <port|all>")
+    _dir = p_remote.add_mutually_exclusive_group()
+    _dir.add_argument("-R", dest="reverse", action="store_true", help="reverse/expose（預設）")
+    _dir.add_argument("-L", dest="forward", action="store_true", help="forward/connect（relay）")
+    p_remote.add_argument("--autossh", action="store_true", help="以 autossh 斷線自動重連")
+    p_remote.add_argument("--local", type=int, default=None, help="-L 本機 loopback port（預設=對端 port）")
+    p_remote.add_argument("--remote-socket", dest="remote_socket", default=None,
+                          help="硬化：-R 建遠端 unix socket／-L 連該 socket（共享 relay 建議）")
+    p_remote.add_argument("--ready-timeout", dest="ready_timeout", type=float, default=10.0,
+                          help="readiness 確認上限秒數（逾時回 starting）")
+    p_remote.add_argument("--ssh-opt", dest="ssh_opt", action="append", default=[],
+                          help="透傳額外 ssh 參數（可重複），如 --ssh-opt=-p --ssh-opt=2222")
+    # 註：--socket / --endpoint / --timeout 為既有全域參數，_resolve_endpoint 會取用。
+```
+
+新增 handler：
+
+```python
+# sw_core/cli.py（新 handler，靠近 _run_skill）
+def _run_remote(args: argparse.Namespace) -> int:
+    """serialwrap remote 分派：words → status / close / open。"""
+    from . import remote_tunnel as rt
+
+    run_dir = _remote_run_dir()
+    words = list(getattr(args, "words", []) or [])
+    try:
+        if not words or words[0] == "status":
+            _print(rt.status(run_dir))
+            return 0
+        if words[0] == "close":
+            selector = words[1] if len(words) > 1 else "all"
+            _print(rt.close(run_dir, selector))
+            return 0
+
+        rt.guard_platform()
+        if args.reverse and args.forward:
+            raise rt.TunnelError("INVALID_ARGS", "-R 與 -L 不可同時指定")
+        role = "connect" if args.forward else "expose"  # -R 預設
+        ssh_target, port = rt.parse_target(words[0])
+        rt.resolve_ssh_bin("autossh" if args.autossh else "ssh")
+
+        forward_src = None
+        if role == "expose":
+            forward_src = _forward_src_from_endpoint(_resolve_endpoint(args))
+
+        spec = rt.TunnelSpec(
+            role=role, ssh_target=ssh_target, port=port,
+            local=args.local, forward_src=forward_src,
+            remote_socket=args.remote_socket,
+            via="autossh" if args.autossh else "ssh",
+            ssh_opts=tuple(args.ssh_opt), ready_timeout=args.ready_timeout,
+        )
+        res = rt.open_tunnel(
+            spec, run_dir,
+            spawner=rt.real_spawner, runner=rt.make_runner(), ping=rt.real_ping,
+        )
+        _print(res)
+        return 0
+    except rt.TunnelError as exc:
+        _print({"ok": False, "error_code": exc.code, "message": exc.message or exc.code})
+        return 1
+
+
+def _forward_src_from_endpoint(endpoint: str) -> str:
+    """把 _resolve_endpoint 結果轉成 ssh -R 的本機轉發源。"""
+    from .client import _parse_endpoint
+    transport, address = _parse_endpoint(endpoint)
+    if transport == "unix":
+        return address  # AF_UNIX 路徑
+    host, tcp_port = address
+    return f"127.0.0.1:{tcp_port}"
+
+
+def _remote_run_dir() -> str:
+    """remote state 落在 <run_dir>/remote/。**於呼叫時讀 env**（不可用 import-time
+    constants.SOCKET_PATH——測試/隔離以 SERIALWRAP_RUN_DIR 於 import 後覆寫需即時生效）。"""
+    run = os.environ.get("SERIALWRAP_RUN_DIR")
+    if run and run.strip():
+        return os.path.expanduser(run)
+    from . import constants
+    return constants.RUN_DIR
+```
+
+在 `main()` 加分派（與其他 `if args.cmd == ...` 並列）：
+
+```python
+    # sw_core/cli.py（main 內）
+    if args.cmd == "remote":
+        return _run_remote(args)
+```
+
+- [ ] **Step 4: 跑 test 確認 pass**
+
+Run: `python3 -m pytest tests/test_remote_cli.py -q`
+Expected: PASS。
+
+- [ ] **Step 5: 驗 help 可產生（供 R-16）**
+
+Run: `./serialwrap remote --help`
+Expected: 印出 remote 用法，`exit 0`；`./serialwrap --help` 的子命令列表含 `remote`。
+
+- [ ] **Step 6: commit**
+
+```bash
+git add sw_core/cli.py tests/test_remote_cli.py
+git commit -m "feat(remote): serialwrap remote subparser 與分派（-R 預設、status/close、fail 回 error_code）" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 10: agent 文件（SKILL.md / SKILL_WINDOWS.md）改寫
+
+**Files:**
+- Modify: `sw_core/assets/skill/SKILL.md`（「Remote Support 用法（ssh-tunnel）」段，約 line 92-112）
+- Modify: `sw_core/assets/skill/SKILL_WINDOWS.md`（新增精簡 remote 段）
+
+**Interfaces:** 無 code interface；內容須與 §3/§4/§8 一致。
+
+- [ ] **Step 1: 改寫 `SKILL.md` 的 Remote Support 段**
+
+把現有教 `ssh -L`（inbound）的段落整段換成（繁中）：
+
+````markdown
+## Remote Support 用法（serialwrap remote，ssh-tunnel）
+
+Agent 要從遠端操作本機 UART 時：**在 UART host（daemon 所在機）** 跑一行反向隧道，agent 端照舊用 `--endpoint`。daemon 不重啟、不做預設。
+
+```bash
+# UART host（有 serialwrapd）：把本機 daemon 反向推到對端（-R 為預設）
+serialwrap remote tester@AGENT_OR_RELAY:7777
+```
+
+Agent 端連線（依拓樸擇一）：
+
+- **direct**（agent host 就是上面 ssh 的對端）：直接
+  `serialwrap --endpoint tcp://127.0.0.1:7777 session list`
+- **relay / 雙 NAT**（agent 與 UART host 互不可達，各自對 relay 撥出）：agent 端先
+  `serialwrap remote -L tester@RELAY:7777`（回傳 `endpoint`），再用該 endpoint。
+
+管理：`serialwrap remote`（列隧道）、`serialwrap remote close 7777|all`（拆除）。
+回傳 `status`：`active`＝就緒可用；`starting`＝尚未確認（慢速認證／上游未就緒），需再 `remote status` 或重試。
+
+安全：隧道讓對端全權操控 DUT。**只用單租戶／可信 relay**；共享 relay 加 `--remote-socket /path`（遠端改建檔案權限把關的 unix socket）。`-R` tcp 模式若偵測遠端被 `GatewayPorts` 綁到對外，會拒絕（`REMOTE_BIND_UNVERIFIED`）。
+````
+
+- [ ] **Step 2: 於 `SKILL_WINDOWS.md` 新增 remote 段**
+
+````markdown
+## Remote Support（native Windows：本期不支援 serialwrap remote）
+
+native Windows 執行 `serialwrap remote` 回 `REMOTE_NOT_SUPPORTED`。需遠端存取時**手動**建反向隧道：
+
+```powershell
+ssh -N -R 7777:127.0.0.1:48700 user@AGENT_OR_RELAY
+```
+
+（Windows daemon 為 TCP loopback `48700`。）agent 端照舊 `serialwrap --endpoint tcp://127.0.0.1:7777`。
+````
+
+- [ ] **Step 3: 驗證輸出**
+
+Run: `./serialwrap skill | grep -A2 "serialwrap remote"` 與 `./serialwrap skill --platform windows | grep REMOTE_NOT_SUPPORTED`
+Expected: 皆有對應內容。
+
+- [ ] **Step 4: commit**
+
+```bash
+git add sw_core/assets/skill/SKILL.md sw_core/assets/skill/SKILL_WINDOWS.md
+git commit -m "docs(skill): 改寫 Remote Support 為 serialwrap remote，含 direct/relay/安全/Windows 排除" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 11: README（中英雙語）+ cli-help markers + `.paul-project.yml` + changelog
+
+**Files:**
+- Modify: `README.md`（「Remote Support（ssh-tunnel 遠端連線）」段 + cli-help marker 區塊）
+- Modify: `.paul-project.yml`（`cli:` 新增 remote 條目）
+- Create: `changelog.d/remote-tunnel-cli.md`
+
+**Interfaces:** 無 code；R-16／R-18 對齊。
+
+- [ ] **Step 1: 改寫 README 的「Remote Support」段（繁中 + English 兩份，內容一致）**
+
+以 `serialwrap remote` 為主軸，保留 `ssh -R`/`-L` 手動等價；涵蓋 direct/relay、`--remote-socket` 硬化、單租戶 relay 警語、`status`/`close`、`starting` 語意、`REMOTE_BIND_UNVERIFIED`／`REMOTE_NOT_SUPPORTED`。英文段為繁中段對照翻譯（依語言政策雙語並存）。
+
+- [ ] **Step 2: `.paul-project.yml` 新增 cli 條目**
+
+```yaml
+  - command: "./serialwrap remote"
+    help_args: ["--help"]
+    reflected_in: "README.md"
+    marker: "serialwrap-remote-help"
+```
+
+- [ ] **Step 3: README 插入／再生 cli-help marker 區塊**
+
+新增：
+```markdown
+<!-- BEGIN: cli-help marker="serialwrap-remote-help" -->
+```
+（貼上 `LC_ALL=C ./serialwrap remote --help` 的輸出）
+```markdown
+<!-- END: cli-help marker="serialwrap-remote-help" -->
+```
+並**再生** `serialwrap-help` 區塊（`remote` 已入子命令列表）：把 `LC_ALL=C ./serialwrap --help` 輸出貼回既有 `serialwrap-help` marker 之間。
+
+Run（取得權威 help 文字）：
+```bash
+LC_ALL=C ./serialwrap --help
+LC_ALL=C ./serialwrap remote --help
+```
+
+- [ ] **Step 4: 新增 changelog fragment**
+
+```bash
+cat > changelog.d/remote-tunnel-cli.md <<'MD'
+### Added
+- `serialwrap remote`：按需開關 SSH 反向隧道（`-R` expose 預設／`-L` connect），讓遠端 agent 取得本機 serialwrap 操作；background 常駐、flock registry、readiness 確認、`--remote-socket` 硬化、fail-closed 遠端 bind 驗證。daemon 零改動、不做預設、僅 POSIX（native Windows 回 `REMOTE_NOT_SUPPORTED`）。
+MD
+```
+
+- [ ] **Step 5: 驗 R-16 對齊**
+
+Run: `python3 -m policy_check --repo . 2>&1 | grep -Ei "R-16|remote-help" || echo "R-16 ok"`
+Expected: R-16 PASS（marker 與 `--help` 輸出一致）。
+
+- [ ] **Step 6: commit**
+
+```bash
+git add README.md .paul-project.yml changelog.d/remote-tunnel-cli.md
+git commit -m "docs(readme): Remote Support 改寫為 serialwrap remote（雙語）+ R-16 cli-help + changelog" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 12: docker 三拓樸驗收 harness
+
+**Files:**
+- Create: `tools/docker/remote_tunnel_test.sh`
+- Modify: `Dockerfile`（或 `tools/docker/` 內既有 build 定義）——測試映像加 `openssh-server`／`openssh-client`／`autossh`／`iproute2` + 預燒 keypair
+- Reference: `tools/docker/remote_smoke.sh`（既有模式）、`tools/docker/remote_lab.py`
+
+**Interfaces:** 產出可執行的 acceptance gate；退出碼 0＝全拓樸通過。
+
+- [ ] **Step 1: 擴充測試映像**
+
+於 build 的套件安裝加 `openssh-server openssh-client autossh iproute2`；生成一組測試 keypair 並寫入 `authorized_keys`（passwordless），relay/agent sshd 設定 `GatewayPorts no`（另備一個 `GatewayPorts yes` 的 sshd 設定供 fail-closed 案例）。
+
+- [ ] **Step 2: 寫 `remote_tunnel_test.sh`（骨架，逐拓樸驗收）**
+
+腳本須做（對照 spec §11.2）：
+1. build 映像、建 docker networks（`net_direct`、`net_a`、`net_b`）。
+2. **拓樸 1 direct**：起 `uart`（serialwrapd）、`agent`（sshd）同 `net_direct`。斷言①預設不啟用（`remote status` 空、無 state、attacker 連 `uart` 之外的 endpoint 失敗）；`uart` 跑 `serialwrap remote tester@agent:7777`；`agent` 用 `--endpoint tcp://127.0.0.1:7777` 跑 `session list`＋`cmd submit`→`done`；斷言③ daemon pid 不變；④ `close all` 後復歸。
+3. **拓樸 2 NAT→host**：`uart`＋`relay` 同 `net_a`；`uart` `remote -R tester@relay:7777`；relay 上 agent CLI 用 loopback；同斷言。
+4. **拓樸 3 NAT←client**：`net_a`=`uart`+`relay`、`net_b`=`agent`+`relay`；tcp 模式與 `--remote-socket` 硬化模式各跑一次端到端；同斷言。
+5. **斷言⑤ loopback 不變量**：relay 上 `ss -ltn` 該 port 綁 `127.0.0.1`；獨立 attacker 容器連 `relay:7777` 失敗。
+6. **斷言⑧ GatewayPorts fail-closed**：對 `GatewayPorts yes` 的 relay，`-R` tcp 模式回 `REMOTE_BIND_UNVERIFIED` 且無殘留（`remote status` 空、無 ssh 行程）；同情境 `--remote-socket` 仍成功。
+7. **斷言⑨ -L 端到端**：relay 無對應 `-R` 時 `remote -L` 回 `starting`（非 active）。
+8. `trap cleanup EXIT` 移除容器與 networks。任何斷言失敗即 `exit 1`。
+
+（可沿用 `remote_smoke.sh` 的 `docker run`／`json_extract` 輔助結構。）
+
+- [ ] **Step 3: 本機執行驗收（需 docker）**
+
+Run: `./tools/docker/remote_tunnel_test.sh`
+Expected: 三拓樸全過，最後印 `[serialwrap] remote-tunnel acceptance: PASS`，`exit 0`。
+（docker 不可用環境：腳本開頭偵測 `docker` 不存在 → 印原因並 `exit 0`（SKIP，不靜默略過），CI 對應標記。）
+
+- [ ] **Step 4: commit**
+
+```bash
+git add tools/docker/remote_tunnel_test.sh Dockerfile
+git commit -m "test(remote): docker 三拓樸驗收（direct/NAT→host/NAT←client）含預設不啟用/fail-closed/端到端" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 13: 全面驗證 + 收尾
+
+**Files:** 無新增；跑政策與測試。
+
+- [ ] **Step 1: 全測試**
+
+Run: `python3 -m pytest -q tests/`
+Expected: 無新失敗（僅既有已知 `test_five_agents_three_rounds_no_conflict` 可能失敗）。
+
+- [ ] **Step 2: policy check**
+
+Run: `python3 -m policy_check --repo .`
+Expected: PASS（R-09 fragment、R-16 cli-help、R-18 docs 對齊、R-13/R-14 symlink）。
+
+- [ ] **Step 3: docker 驗收（若環境可用）**
+
+Run: `./tools/docker/remote_tunnel_test.sh`
+Expected: PASS 或明確 SKIP（docker 不可用）。
+
+- [ ] **Step 4: 收尾**
+
+依 `superpowers:finishing-a-development-branch` 決定 merge/PR；PR body 填 `.github/pull_request_template.md` 的 Policy Checklist，附 `🤖 Generated with [Claude Code]` 與 session 連結。無對應 issue，故不寫 closing-keyword（或視需要上 `policy-exempt:issue-link`）。
+
+---
+
+## Self-Review（計畫對 spec 覆蓋）
+
+- §3 介面（`-R` 預設/`-L`/status/close/旗標）→ Task 9。
+- §4.0 identity＋readiness → Tasks 1、4、5、6。
+- §4.1 expose（forward_src、conflict、fail-closed bind 驗證）→ Tasks 2、5、6。
+- §4.2 connect（remote-socket 配對、health.ping readiness）→ Tasks 2、5、6。
+- §4.4/§4.5 status/close（pgid、verify、orphan、error-state）→ Task 7。
+- §5 argv（BatchMode/ControlMaster/loopback bind/autossh）→ Task 2。
+- §6 registry（flock、durable、pid_start_ticks）→ Tasks 3、6。
+- §7 `_resolve_endpoint` 重用 → Task 9（`_forward_src_from_endpoint`）。
+- §8 安全（trust boundary、GatewayPorts fail-closed、BatchMode）→ Tasks 2、5、文件 10/11。
+- §9 error codes（含 `REMOTE_BIND_UNVERIFIED`／`REMOTE_NOT_SUPPORTED`／`TUNNEL_CONFLICT`）→ Tasks 5-9。
+- §10 改動表面 → Tasks 9（cli）、1-8（module）、10-11（docs）。
+- §11 測試（unit + docker 三拓樸 + 斷言 1-9）→ Tasks 1-8（unit）、12（docker）。
+- §12 相依（ssh/OpenSSH、/proc）→ Tasks 3、8。
+- Windows 排除（§2/§5/§13）→ Task 8（guard）、9（分派）、10（SKILL_WINDOWS）。
+
+型別一致性：`TunnelSpec`／`TunnelError`／`Registry`／`compute_identity`／`build_argv`／`wait_ready`／`open_tunnel`／`status`／`close` 跨 Task 命名一致。

--- a/docs/superpowers/specs/2026-07-19-remote-tunnel-cli-design.md
+++ b/docs/superpowers/specs/2026-07-19-remote-tunnel-cli-design.md
@@ -56,6 +56,7 @@ agent/RD 端  ── ssh -L 7777:127.0.0.1:7777 ──►  UART host（FAE）─
 - 不自製 SSH（不引入 paramiko）；auth 全數委由系統 `ssh`。
 - 不做 relay 伺服器、不做隧道健康自動修復以外的 orchestration。
 - 不改變既有 `--endpoint` 語意；agent 端 direct 情境仍用既有 `--endpoint tcp://…`。
+- **native Windows UART host 本期不支援**（R2 finding 4）：lifecycle 全用 POSIX primitive，Windows 無等價；native Windows 執行 `remote` 回 `REMOTE_NOT_SUPPORTED`，defer 至 §13（Windows 現行仍可手動 `ssh -R`）。
 
 ## 3. 使用者介面（CLI surface）
 
@@ -84,19 +85,20 @@ serialwrap remote close all                  # 拆除全部
   - `--autossh`：以 `autossh -M 0` 取代 `ssh`，斷線自動重連。
   - `--local N`：`-L` 時本機 loopback port（預設 = target port）。
   - `--socket EP`：`-R` 時要暴露的本機 daemon endpoint（預設 = `_resolve_endpoint` 解析結果）。
-  - `--remote-socket PATH`（**硬化模式**，adversarial review finding 1）：`-R` 時遠端改建 **unix socket** 而非 tcp loopback port，用檔案權限把關存取（agent 端改用 `--endpoint unix://PATH`）。**共享／多租戶 relay 建議必開**。省略則預設 tcp loopback（便利但受 §8 殘留風險）。
+  - `--remote-socket PATH`（**硬化模式**，R1 finding 1／R2 finding 1）：`-R` 時遠端改建 **unix socket** 而非 tcp loopback port，用檔案權限把關；**成對地** `-L` 亦以 `--remote-socket PATH` 指定要連的 relay-side unix socket（雙 NAT 全鏈需兩側配對，見 §4.2）。agent 端仍用回傳的 `tcp://127.0.0.1:<local>`。**共享／多租戶 relay 建議必開**；省略則預設 tcp loopback（便利但受 §8 殘留風險）。
   - `--ready-timeout S`：readiness 確認上限（預設 10s）；逾時仍未確認 forward 建立 → 回 `starting`（見 §4）。
   - `--ssh-opt "..."`：透傳額外 ssh 參數（可重複），例如 `-o ServerAliveInterval=30`、`-p 2222`。
 - 所有子動作輸出緊湊 JSON（`ensure_ascii=False, separators=(",",":")`，含 `ok`），對齊 CLI 慣例。
 
 ## 4. 行為規格
 
-### 4.0 共同：tunnel identity 與 readiness（adversarial review findings 3/5）
+### 4.0 共同：tunnel identity 與 readiness（adversarial review R1 findings 3/5、R2 findings 2/5/6）
 
-- **tunnel identity** = `(role, ssh_target, listen_port, forward_target)`。作為 registry 邏輯主鍵（**非只 port**）。listen_port（`-R`＝遠端 bind port、`-L`＝本機 local port）供顯示與 `close` 選取。
-- **readiness 協定**：spawn 後**不以「行程還活著」當成功**。附 `-o BatchMode=yes`（禁互動、不卡密碼提示）+ ControlMaster（`-o ControlMaster=auto -o ControlPath=<run>/remote/cm-<id>`），以 `ssh -O check` 輪詢至主連線確認「認證完成且 forward 已建立」（`ExitOnForwardFailure=yes` 保證 forward 失敗即 ssh 退出），或子行程提前死亡，或 `--ready-timeout` 到期：
-  - 確認就緒 → 寫 `status="active"`，回 `{"ok":true,"status":"active",...}`。
-  - 逾時但行程仍在 → 寫 `status="starting"`，回 `{"ok":true,"status":"starting",...}`（**非** silent success；agent 應再以 `remote status` 或探測 endpoint 確認）。
+- **tunnel identity**（R2 finding 6）= **canonical effective forward spec** 的雜湊，須涵蓋所有會改變「入口位置／目的地」的欄位，**至少**：`role`、`ssh_target`、遠端 bind 類型與位址（tcp `127.0.0.1:<port>` 或 unix `PATH`）、`local`（-L）、`forward_src`／`forward_target`、`via`（ssh／autossh）、以及目的地相關 `--ssh-opt`（`-p`／`ProxyJump` 等）。避免「改 `--remote-socket /a→/b`、換 port／ProxyJump 卻被誤判 already_running、舊入口續暴露」。listen_port（`-R`＝遠端 bind port、`-L`＝本機 local port）僅供顯示與 `close` 選取。
+- **readiness 協定（骨架）**：spawn 後**不以「行程還活著」當成功**。附 `-o BatchMode=yes`（禁互動、不卡密碼提示）+ ControlMaster（`-o ControlMaster=auto -o ControlPath=<run>/remote/cm-<id>`），以 `ssh -O check` 輪詢至主連線確認「認證完成且 forward 已建立」（`ExitOnForwardFailure=yes` 保證 forward 失敗即 ssh 退出），或子行程提前死亡，或 `--ready-timeout` 到期：
+  - **role 專屬補強（R2 findings 2/5）**：`ssh -O check` 只證明 master 存活＋本機 listener bind，**不證明端到端可用**。故 `active` 的最終判定另加：`-R` → 遠端 bind loopback 驗證（§4.1 step 4）；`-L` → 透過回傳 endpoint 打 serialwrap `health.ping` 成功（§4.2 step 4）。
+  - 確認就緒（含 role 補強）→ 寫 `status="active"`，回 `{"ok":true,"status":"active",...}`。
+  - 逾時但行程仍在 / role 補強尚未通過 → 寫 `status="starting"`，回 `{"ok":true,"status":"starting",...}`（**非** silent success；agent 應再 `remote status` 或探測 endpoint 確認）。
   - 行程已死 → `TUNNEL_SPAWN_FAILED`（附 stderr 尾），不留 active state。
 
 ### 4.1 `remote -R`（expose；跑在 UART host）
@@ -105,13 +107,17 @@ serialwrap remote close all                  # 拆除全部
 2. 決定 **forward_target**（`--socket` 或 `_resolve_endpoint(args)` 決定本機轉發源）：
    - `--remote-socket PATH` → 遠端 unix socket：`-R PATH:<本機轉發源>`（硬化模式）。
    - 否則 → 遠端 loopback tcp：`-R 127.0.0.1:<port>:<本機轉發源>`（**顯式綁 loopback**，見 §5/§8）。
-   - 本機轉發源：AF_UNIX 路徑（`ssh -R … :<sock>`，免 socat，需兩端 OpenSSH ≥ 6.7）；`tcp://127.0.0.1:<p>`（Windows）→ `127.0.0.1:<p>`。
+   - 本機轉發源：AF_UNIX 路徑（`ssh -R … :<sock>`，免 socat，需兩端 OpenSSH ≥ 6.7）；`tcp://127.0.0.1:<p>`（daemon endpoint 為 tcp 時，如 `SERIALWRAP_ENDPOINT` 覆寫）→ `127.0.0.1:<p>`。
    - 完全解析不到任何本機 endpoint → `NO_LOCAL_DAEMON`。解析到 unix 路徑但檔案暫不存在 → **僅 warn**（`ssh -R` 要等有連線進來才連 socket，daemon 稍後起即通）。
 3. **identity 衝突檢查（持 registry flock，見 §6）**：同 listen_port 已有 state──
    - identity 完全相同且 active/starting → `{"ok":true,"already_running":true,...}` no-op。
    - identity 不同（換 target/forward）→ `TUNNEL_CONFLICT`（要求先 `remote close <port>`）。
    - state 在但行程已死 → 視為可覆寫。
-4. 組 argv（§5），spawn detached，跑 readiness（§4.0），依結果寫 state（§6）並回：
+4. 組 argv（§5），spawn detached，跑 readiness（§4.0）。**遠端 bind loopback 驗證（R2 finding 2，fail-closed）**：tcp 模式下 master 建立後，透過同一 ControlMaster 連線在 relay 執行 `ss -ltnH 'sport = :<port>'`（或等價），確認實際 bind：
+   - 綁 `127.0.0.1`/`::1` → 續判 `active`。
+   - 偵測 wildcard（`0.0.0.0`/`::`，即 relay `GatewayPorts yes` 漂移）或**無法驗證** → **立即拆除隧道 + 回 `REMOTE_BIND_UNVERIFIED`**（絕不留暴露隧道）。
+   - `--remote-socket`（unix）模式免此驗證（不受 `GatewayPorts` 影響，天然 fail-closed）。
+   依結果寫 state（§6）並回：
    ```json
    {"ok":true,"status":"active","role":"expose","pid":12345,"listen_port":7777,
     "target":"user@host","forward_target":"unix:///run/.../serialwrapd.sock","via":"ssh",
@@ -122,13 +128,20 @@ serialwrap remote close all                  # 拆除全部
 
 1. 解析 target 與本機 `--local`（預設 = target port）。
 2. identity 衝突檢查同 §4.1 step 3（以 local_port 選取）。
-3. 組 `ssh -N -T -o BatchMode=yes -L 127.0.0.1:<local>:localhost:<port> <ssh_target>`（**顯式綁本機 loopback**，見 §8），spawn，跑 readiness（`-L` 可直接探測本機 `127.0.0.1:<local>` 可連性），寫 state，回：
+3. 決定 `-L` 遠端目的地（**R2 finding 1**，與 `-R` 硬化模式配對，否則雙 NAT 全鏈連不上）：
+   - `--remote-socket PATH` → `-L 127.0.0.1:<local>:PATH`（連 relay 上那個 unix socket；硬化模式的雙 NAT 全鏈唯一走得通的方式）。
+   - 否則 → `-L 127.0.0.1:<local>:localhost:<port>`（連 relay 的 tcp loopback port）。
+   兩者皆**顯式綁本機 loopback**（見 §8）。
+4. spawn，跑 readiness（§4.0）。**`-L` 端到端 readiness（R2 finding 5）**：本機 listener 能 bind、`ssh -O check` 通過，都不代表上游 `-R` 存在；故 `active` 須以回傳 endpoint 打 serialwrap `health.ping` 得有效回應為準：
+   - `health.ping` ok → `active`。
+   - listener 起但 ping 失敗（上游 `-R` 缺失／已斷／接受即斷）→ `starting`（未達 active）；`--ready-timeout` 內未 ok 維持 `starting`。
+   寫 state，回：
    ```json
    {"ok":true,"status":"active","role":"connect","pid":23456,"local_port":7777,
     "target":"user@relay","endpoint":"tcp://127.0.0.1:7777"}
    ```
    `endpoint` 即 agent 接著餵給 `--endpoint` 的值。
-4. 本機 `local` port 已被佔（非本工具的隧道）→ `PORT_IN_USE`。
+5. 本機 `local` port 已被佔（非本工具的隧道）→ `PORT_IN_USE`。
 
 ### 4.3 direct 情境（agent 端免 connect）
 
@@ -173,25 +186,27 @@ serialwrap --endpoint tcp://127.0.0.1:7777 session list
   - 否則 → `["-R", f"127.0.0.1:{port}:{forward_src}"]`（**顯式遠端 loopback bind**）。
   - `forward_src` = 本機 unix socket 路徑 或 `127.0.0.1:{tcpport}`。
   - **GatewayPorts 前提**（finding 2）：遠端 bind 是否真的只綁 loopback，最終受 **relay sshd 的 `GatewayPorts`** 決定——`GatewayPorts yes` 會強制 remote forward 綁 wildcard，client 無法覆寫。故本設計要求「relay `GatewayPorts no`（預設）」為前提，於 docker gate 以 `ss` 斷言實測（§11），文件明講此前提。
-- `-L`（connect）：`["-L", f"127.0.0.1:{local}:localhost:{port}"]`（**顯式本機 loopback bind**，不受 client `GatewayPorts` 影響——finding 2）。
-- `--autossh`：改用 `["autossh","-M","0", ...其後同 ssh...]`（pid 為 autossh；readiness／close 對 autossh 行程操作，其子 ssh 由 autossh 管）。
-- **Windows UART host**：無 AF_UNIX，daemon 為 TCP loopback，`forward_src` 自動為 `127.0.0.1:<tcpport>`；需系統有 `ssh`（Win10+ OpenSSH client）。次要平台，文件標注即可。
+- `-L`（connect）：`--remote-socket PATH` → `["-L", f"127.0.0.1:{local}:{PATH}"]`（連 relay unix socket）；否則 → `["-L", f"127.0.0.1:{local}:localhost:{port}"]`。皆**顯式本機 loopback bind**（不受 client `GatewayPorts` 影響——R1 finding 2）。
+- `--autossh`：改用 `["autossh","-M","0", ...其後同 ssh...]`（pid 為 autossh；readiness／close 對 autossh **process group** 操作，其子 ssh 由 autossh 管）。
+- **Windows UART host：本期不支援（R2 finding 4，defer §13）**——lifecycle 全用 POSIX primitive（`start_new_session`／`flock`／`os.killpg`／`/proc` start-ticks），native Windows 無等價（detach 需 `DETACHED_PROCESS|CREATE_NEW_PROCESS_GROUP`、無 flock/killpg//proc）。故 `remote` **僅 POSIX（Linux/WSL 生產路徑）**；native Windows 執行 `remote` → 回 `REMOTE_NOT_SUPPORTED`（明確拒絕，不半實作）。Windows 現行仍可手動 `ssh -R`。
 
 ## 6. 背景行程與 state registry
 
-- spawn：`subprocess.Popen(..., start_new_session=True, stdin=DEVNULL, stdout=log, stderr=log)`（setsid：脫離父行程與終端，並使子行程自成 process group，供 §4.5 `killpg`）。log 檔在 state 目錄下（供 `TUNNEL_SPAWN_FAILED` 撈 stderr 尾）。
+- spawn：`subprocess.Popen(..., start_new_session=True, stdin=DEVNULL, stdout=log, stderr=log)`（setsid：脫離父行程與終端，並使子行程自成 process group／pgid，供 §4.5 `killpg`）。log 檔在 state 目錄下（供 `TUNNEL_SPAWN_FAILED` 撈 stderr 尾）。
 - state 目錄：`$RUN_DIR/remote/`（`RUN_DIR` 預設 XDG runtime，與 socket／lock 同層；reboot 清掉剛好隧道也一併消失）。
-- **registry 鎖（finding 5）**：`$RUN_DIR/remote/.registry.lock` 的 flock，包住每次 `check → spawn → readiness → atomic replace`（`os.replace` 換檔）與 `close` 的 read-verify-remove，序列化並行 `remote` 操作，消除「兩個並行 start 同時通過檢查」競態。沿用 `sw_core/lock_posix.py` 既有 flock 慣例。
+- **registry 鎖（R1 finding 5）**：`$RUN_DIR/remote/.registry.lock` 的 flock，包住每次 `check → spawn → 立即寫 durable state → readiness → atomic replace`（`os.replace`）與 `close` 的 read-verify-remove，序列化並行 `remote` 操作，消除「兩個並行 start 同時通過檢查」競態。沿用 `sw_core/lock_posix.py` 既有 flock 慣例。
+- **crash-consistent 寫入順序（R2 finding 3）**：`Popen` 一返回即取 `pid`／`pgid`／`control_path`，**先** atomic 寫 `status="spawning"` 的 durable state，**才**跑 readiness；readiness 結果再 replace 成 `active`／`starting`／清除。如此 CLI 於 spawn 與 readiness 間被 SIGKILL／例外，ssh 雖脫離父行程續活，仍留有可被 `status`／`close` 找到的 state（指向 pgid）。**殘留窗**僅 `Popen` 返回到首次寫檔的次毫秒級；另以 **orphan scan** 兜底：`status`／`close` 掃 `$RUN_DIR/remote/cm-*` control socket 與對應 ssh 行程，活著卻無 state → 標為 orphan 列出（可 `close`）。
 - 每條隧道一檔 `$RUN_DIR/remote/<listen_port>.json`：
   ```json
-  {"identity":"<hash(role,target,listen_port,forward_target)>","status":"active|starting|error",
-   "role":"expose|connect","pid":12345,"pid_start_ticks":8837201,
-   "target":"user@host","listen_port":7777,"forward_target":"unix:///…","via":"ssh|autossh",
-   "control_path":"…/cm-<id>","argv":["ssh","-N",...],
-   "started_mono":123456.7,"started_wall":"2026-07-19T..."}
+  {"identity":"<hash(canonical effective forward spec：role,target,remote_bind,local,forward_src,via,dest-ssh-opts)>",
+   "status":"spawning|active|starting|error",
+   "role":"expose|connect","pid":12345,"pgid":12345,"pid_start_ticks":8837201,
+   "target":"user@host","listen_port":7777,"remote_bind":"127.0.0.1:7777|unix:/relay/x.sock",
+   "forward_target":"unix:///…","via":"ssh|autossh","control_path":"…/cm-<id>",
+   "argv":["ssh","-N",...],"started_mono":123456.7,"started_wall":"2026-07-19T..."}
   ```
   以 `sort_keys=True` 寫出（對齊 state.json 慣例）。
-- **存活與身分驗證（finding 4）**：`os.kill(pid,0)` 只判 pid 存在，無法分辨 **PID reuse**；故另存 `pid_start_ticks`（Linux `/proc/<pid>/stat` 第 22 欄行程啟動時刻），驗活時比對 pid 現行 start-ticks 是否一致——不一致即「該 pid 已非我方隧道」→ 不誤殺、prune 舊 state。非 Linux POSIX 無 `/proc` → 退化 pid-only（best-effort，文件標注）。`autossh` 情境 pid 為 autossh 本身。
+- **存活與身分驗證（R1 finding 4）**：`os.kill(pid,0)` 只判 pid 存在，無法分辨 **PID reuse**；故另存 `pid_start_ticks`（Linux `/proc/<pid>/stat` 第 22 欄），驗活時比對一致——不符即「該 pid 已非我方隧道」→ 不誤殺、prune 舊 state。`autossh` 情境 `pid`／`pgid` 為 autossh leader；status／close 驗證並操作**整個 pgid**（涵蓋其子 ssh），非只父 pid。非 Linux POSIX 無 `/proc` → 本期不支援（§5 Windows 排除；其餘非 Linux POSIX 退化 pid-only、best-effort、文件標注）。
 - idempotency／conflict／close 規則見 §4.1、§4.4、§4.5。
 - **與 serialwrapd 生命週期完全解耦**：daemon 死了隧道還在（連過去 EOF）；daemon 重啟不需重開隧道（AF_UNIX 路徑不變）。
 
@@ -199,7 +214,7 @@ serialwrap --endpoint tcp://127.0.0.1:7777 session list
 
 重用 `sw_core/cli.py::_resolve_endpoint(args)`（既有優先序：`--endpoint` > `--socket` > config.yaml > 平台預設）取得本機 daemon endpoint，再依 transport（unix／tcp）決定 `-R` 的 forward target。不新增解析邏輯、不改寫 config（維持 CLI 對 config.yaml 唯讀）。
 
-## 8. 安全（adversarial review findings 1/2）
+## 8. 安全（adversarial review R1+R2 findings 1/2）
 
 **信任邊界（trust boundary）**——SSH 只認證「誰建立隧道」，**不認證之後連入被轉發 endpoint 的 client**。RPC request 僅 `id/method/params`、無 token，daemon 不做 peer 認證（本期不改，見 §2 非目標）。故：
 
@@ -210,7 +225,7 @@ serialwrap --endpoint tcp://127.0.0.1:7777 session list
 
 **loopback bind 不變量**：
 - `-L` 顯式 `127.0.0.1:` bind，不受 client `GatewayPorts` 影響。
-- `-R` 顯式 `127.0.0.1:` bind，但**最終受 relay sshd `GatewayPorts` 決定**——`GatewayPorts yes` 會強制綁 wildcard 對外，client 無法覆寫。**前提：relay `GatewayPorts no`（預設）**；docker gate 以 `ss` 實測非 loopback 不可達（§11），文件明講。
+- `-R` 顯式 `127.0.0.1:` bind，但**最終受 relay sshd `GatewayPorts` 決定**——`GatewayPorts yes` 會強制綁 wildcard 對外、client 無法覆寫，且 forward 仍成功（`ExitOnForwardFailure`／`ssh -O check` 皆過），**光靠前提不夠**。**fail-closed（R2 finding 2）**：tcp 模式 active 前必以 master 連線在 relay `ss` 實測遠端 bind，非 loopback／無法驗證即**拆除＋`REMOTE_BIND_UNVERIFIED`**（§4.1 step 4）。硬化 `--remote-socket`（unix）不受 `GatewayPorts` 影響、天然 fail-closed，為多租戶安全預設；docker gate 另含 `GatewayPorts yes` 必須失敗案例（§11）。
 
 **其他**：
 - `BatchMode=yes` 禁互動認證，避免弱認證與卡死。
@@ -224,19 +239,21 @@ serialwrap --endpoint tcp://127.0.0.1:7777 session list
 | target 非 `[user@]host:port` | `INVALID_TARGET` |
 | 無 `ssh`（或 `--autossh` 但無 `autossh`）於 PATH | `SSH_NOT_FOUND` |
 | readiness 期間子行程死亡（認證／forward 失敗） | `TUNNEL_SPAWN_FAILED`（附 stderr 尾） |
+| `-R` tcp 模式遠端 bind 非 loopback（`GatewayPorts` 漂移）或無法驗證 | `REMOTE_BIND_UNVERIFIED`（已拆除隧道，R2 finding 2） |
 | 同 listen_port 已有**不同 identity** 的隧道 | `TUNNEL_CONFLICT` |
 | `-R` 完全解析不到任何本機 endpoint | `NO_LOCAL_DAEMON` |
 | `-L` 本機 port 已被佔（非本工具隧道） | `PORT_IN_USE` |
 | `-R` 與 `-L` 同時指定 | `INVALID_ARGS` |
+| native Windows 執行 `remote`（本期不支援，R2 finding 4） | `REMOTE_NOT_SUPPORTED` |
 
-- **`status` 非 error**：`active`／`starting`／`error` 為隧道生命週期狀態，隨 `{"ok":true,...}` 回傳（`starting`＝已 spawn、forward 尚未確認，readiness 逾時走此；`error`＝`close` 驗證／等待失敗保留的孤兒 state，見 §4.5）。
+- **`status` 非 error**：`spawning`／`active`／`starting`／`error` 為隧道生命週期狀態，隨 `{"ok":true,...}` 回傳（`spawning`＝已 Popen、durable state 已寫、readiness 未跑完；`starting`＝forward／端到端 readiness 尚未確認，逾時走此；`error`＝`close` 驗證／等待失敗保留的孤兒 state，見 §4.5）。
 
 ## 10. 改動表面（顯式同步多表面）
 
 ### Code
 
 - `sw_core/cli.py`：新增 `remote` subparser（positional target、`-R`/`-L`/`--autossh`/`--local`/`--socket`/`--remote-socket`/`--ready-timeout`/`--ssh-opt`、`status`/`close` 子動作）+ 平面 if/elif 分派。
-- 新模組 `sw_core/remote_tunnel.py`：target 解析、identity 計算、argv 組裝、spawn（注入式 spawner）、**readiness probe（注入式 `ssh -O check`）**、**flock registry**（state 讀寫／identity 衝突／atomic replace）、status prune（pid+start-ticks）、robust close（verify→killpg→wait→error-state）。純函式為主，副作用（Popen／flock／檔案）集中且可注入。
+- 新模組 `sw_core/remote_tunnel.py`：target 解析、canonical identity 計算、argv 組裝、spawn（注入式 spawner）、**readiness**（注入式 `ssh -O check` ＋ `-R` 遠端 bind `ss` 驗證 ＋ `-L` `health.ping`）、durable-intent 寫入 ＋ flock registry（state／identity 衝突／atomic replace／orphan scan）、status prune（pid+start-ticks、pgid）、robust close（verify→`killpg` 整組→wait→error-state）、native Windows 守衛回 `REMOTE_NOT_SUPPORTED`。純函式為主，副作用（Popen／flock／檔案／probe）集中且可注入。
 
 ### Docs / help / skill（本次硬需求：讓 agent 會用、會連）
 
@@ -244,7 +261,7 @@ serialwrap --endpoint tcp://127.0.0.1:7777 session list
   - UART host：`serialwrap remote user@host:7777`（`-R` 預設）。
   - agent 端連線 runbook：direct → `serialwrap --endpoint tcp://127.0.0.1:7777 …`；relay → 先 `serialwrap remote -L user@relay:7777` 再用回傳 endpoint。
   - 明確標示 direct vs relay 岔路、`remote status`/`close`、`starting` 狀態需再確認、以及信任邊界警語（**單租戶／可信 relay**，共享 relay 用 `--remote-socket` 硬化）。
-- `sw_core/assets/skill/SKILL_WINDOWS.md`：新增精簡 remote 段（Windows daemon 為 TCP loopback，`-R` 轉發 `127.0.0.1:48700`；需 OpenSSH client）。
+- `sw_core/assets/skill/SKILL_WINDOWS.md`：新增精簡 remote 段——native Windows **`serialwrap remote` 本期不支援**（回 `REMOTE_NOT_SUPPORTED`，R2 finding 4）；需遠端存取時**手動** `ssh -R 7777:127.0.0.1:48700 user@host`（Windows daemon 為 TCP loopback），agent 端照舊 `--endpoint tcp://127.0.0.1:7777`。
 - `README.md`：**改寫「Remote Support（ssh-tunnel 遠端連線）」（現 line 1632+）**，以 `serialwrap remote` 為主軸、保留 `ssh -R`/`-L` 手動等價、涵蓋 direct/relay。依語言政策 **README 中英雙語並存**，英文段與繁中段一致更新。
 - `README.md` cli-help markers（R-16）：新增 `serialwrap-remote-help` marker 區塊；因 `remote` 進入子命令列表，**一併再生 `serialwrap-help` 區塊**。
 - `.paul-project.yml`：`cli:` 新增 `{command:"./serialwrap remote", help_args:["--help"], reflected_in:"README.md", marker:"serialwrap-remote-help"}`。
@@ -256,12 +273,14 @@ serialwrap --endpoint tcp://127.0.0.1:7777 session list
 
 - target 解析（`user@host:port`／`alias:port`／缺 port／壞格式）。
 - argv 組裝：`-R` unix-socket／tcp／`--remote-socket` 三種 forward 形式、`-R` 顯式 `127.0.0.1:` bind、`-L` 顯式 `127.0.0.1:` bind、`--autossh`、`--ssh-opt` 透傳、預設 `-o`（`BatchMode`／`ExitOnForwardFailure`／`ControlMaster`／`ControlPath`）附加。
-- identity／衝突（finding 5）：同 port 同 identity→`already_running`；同 port 不同 identity→`TUNNEL_CONFLICT`；死 state→覆寫。
-- readiness 狀態機（finding 3；注入式 `ssh -O check` probe）：確認→`active`；逾時行程仍活→`starting`；行程即死→`TUNNEL_SPAWN_FAILED`。
-- `close`（finding 4）：pid+start-ticks 驗證（**PID reuse**：start-ticks 不符→不殺、prune）、`killpg`→wait→移檔；驗證／等待失敗→保留 `error` state。
-- flock 並行（finding 5）：barrier 式兩個並行 start 同 port → 只成一條、另一條 `TUNNEL_CONFLICT`／`already_running`；並行 start/close 不留孤兒。
-- error_code：`INVALID_TARGET`／`SSH_NOT_FOUND`（PATH monkeypatch）／`INVALID_ARGS`／`NO_LOCAL_DAEMON`／`PORT_IN_USE`／`TUNNEL_CONFLICT`。
-- 生命週期以**注入式 spawner + 假長命行程**（如 `sleep`）＋**注入式 readiness probe** 驗證，不真的起 ssh。
+- identity／衝突（R1 finding 5／R2 finding 6）：identity 涵蓋 role/target/remote_bind/local/forward_src/via/dest-ssh-opt；同 identity→`already_running`；任一欄不同（含 `--remote-socket /a→/b`、`ssh→autossh`、換 `-p`／`ProxyJump`）→`TUNNEL_CONFLICT`；死 state→覆寫。
+- readiness 狀態機（R1 finding 3／R2 findings 2/5；注入式 `ssh -O check`／`ss`／`health.ping` probe）：master+forward 確認且 role 補強通過→`active`；`-R` 遠端 bind 驗到 wildcard→`REMOTE_BIND_UNVERIFIED`+拆除；`-L` 上游缺失致 `health.ping` 失敗→`starting`；逾時行程仍活→`starting`；行程即死→`TUNNEL_SPAWN_FAILED`。
+- crash-consistency（R2 finding 3）：spawn 後、readiness 前殺掉 CLI → durable `spawning` state 仍在且 `close` 能循 pgid 拆除；autossh leader 死亡→status 循 pgid 驗整組。
+- `close`（R1 finding 4）：pid+start-ticks 驗證（**PID reuse**：start-ticks 不符→不殺、prune）、`killpg` 整組→wait→移檔；驗證／等待失敗→保留 `error` state。
+- flock 並行（R1 finding 5）：barrier 式兩並行 start 同 port → 只成一條、另一條 `TUNNEL_CONFLICT`／`already_running`；並行 start/close 不留孤兒。
+- 平台：模擬 native Windows（`os.name` monkeypatch）執行 `remote`→`REMOTE_NOT_SUPPORTED`。
+- error_code：`INVALID_TARGET`／`SSH_NOT_FOUND`（PATH monkeypatch）／`INVALID_ARGS`／`NO_LOCAL_DAEMON`／`PORT_IN_USE`／`TUNNEL_CONFLICT`／`REMOTE_BIND_UNVERIFIED`／`REMOTE_NOT_SUPPORTED`。
+- 生命週期以**注入式 spawner + 假長命行程**（`sleep`）＋**注入式 readiness probe**（`ssh -O check`／`ss`／`health.ping`）驗證，不真的起 ssh。
 
 ### 11.2 docker 拓樸驗收（acceptance gate；`tools/docker/remote_tunnel_test.sh`）
 
@@ -280,8 +299,8 @@ serialwrap --endpoint tcp://127.0.0.1:7777 session list
 
 **拓樸 3 — NAT ← client（雙 NAT relay 全鏈）**
 - `net_a`：`uart`＋`relay`；`net_b`：`agent`＋`relay`。`uart` 與 `agent` **無共網段**（互不可達）。
-- `uart`：`serialwrap remote -R tester@relay:7777`（把 daemon 推上 relay loopback:7777）。
-- `agent`：`serialwrap remote -L tester@relay:7777`（把 relay:7777 拉回本機 loopback）→ 再用回傳 `endpoint` 下命令。
+- tcp 模式：`uart` `remote -R tester@relay:7777`、`agent` `remote -L tester@relay:7777` → 用回傳 `endpoint` 下命令。
+- **硬化模式（R2 finding 1，須同樣端到端走得通）**：`uart` `remote -R tester@relay:7777 --remote-socket /run/relay-sw.sock`、`agent` `remote -L tester@relay:7777 --remote-socket /run/relay-sw.sock` → agent 端 endpoint 仍 `tcp://127.0.0.1:7777`，可下命令。
 
 **每個拓樸的斷言（缺一不可）**
 1. **預設不啟用**（跑 `remote` 前）：`serialwrap remote status` 回空 `tunnels`；`$RUN_DIR/remote/` 無 state 檔；無 serialwrap-spawn 的 `ssh`/`autossh` 行程；遠端 `--endpoint` 連線失敗（`SOCKET_ERROR`）。
@@ -290,7 +309,9 @@ serialwrap --endpoint tcp://127.0.0.1:7777 session list
 4. **teardown 乾淨**：`serialwrap remote close all` 後隧道行程消失、state 檔清空、`--endpoint` 復歸不可連。
 5. **loopback 不變量**（finding 2）：relay/agent 上 `ss -ltn` 斷言 forward listener 綁 `127.0.0.1`（非 `0.0.0.0`／`::`）；獨立 `attacker` 容器連 `relay:<port>` **必失敗**（證明非對外）。
 6. **信任邊界實測**（finding 1）：relay 內第二個本機使用者連 `127.0.0.1:<port>`——tcp loopback 模式**可連**（記錄為已知殘留風險）；`--remote-socket` 模式無檔案權限者**被拒**（證明硬化有效）。
-7. **readiness 誠實**（finding 3/4）：錯 key／未知 host key／`BatchMode` 擋互動時 `remote` 回 `starting`／錯誤而非假 `ok`；真 sshd 下 PID reuse 不誤殺、並行 start/close 不留孤兒。
+7. **readiness 誠實**（R1 finding 3/4）：錯 key／未知 host key／`BatchMode` 擋互動時 `remote` 回 `starting`／錯誤而非假 `ok`；真 sshd 下 PID reuse 不誤殺、並行 start/close 不留孤兒。
+8. **GatewayPorts fail-closed**（R2 finding 2）：另備一台 relay sshd 設 `GatewayPorts yes`，`-R` tcp 模式必回 `REMOTE_BIND_UNVERIFIED` 且**無殘留隧道**（state/行程/listener 皆已拆）；同情境 `--remote-socket` 模式仍成功（不受影響）。
+9. **`-L` 端到端誠實**（R2 finding 5）：relay sshd 正常但**無對應 `-R`**（上游缺 port／接受即斷）時，`remote -L` 回 `starting`（非 `active`），不誤報成功。
 
 **執行與 CI**：docker 可用時列為必跑驗收；docker 不可用的環境明確 SKIP 並印原因（不靜默略過）。單元測試（11.1）恆入 CI。
 
@@ -309,4 +330,5 @@ serialwrap --endpoint tcp://127.0.0.1:7777 session list
 
 - `remote` 隧道健康的主動探測／自動重連（超出 `--autossh` 的部分）。
 - 多 UART host → 單 agent host 的 endpoint 名錄／自動選號。
+- **native Windows `remote` expose lifecycle**（R2 finding 4）：Windows registry lock、process-tree／job-object teardown、creation-time identity、可用 readiness 與 native Windows 驗收；隨 #84 Windows daemon 面一併補。
 - Windows daemon 端 `device release`／remote 編排（對齊 #84 尚未完成的 Windows daemon 面）。

--- a/docs/superpowers/specs/2026-07-19-remote-tunnel-cli-design.md
+++ b/docs/superpowers/specs/2026-07-19-remote-tunnel-cli-design.md
@@ -2,7 +2,7 @@
 
 - 日期：2026-07-19
 - 分支：`feature/remote-tunnel-cli`
-- 狀態：設計待複審
+- 狀態：設計待複審（已納入 2026-07-19 Codex adversarial review 之安全／韌性修訂）
 
 ## 1. 背景與 root cause
 
@@ -32,6 +32,7 @@ agent/RD 端  ── ssh -L 7777:127.0.0.1:7777 ──►  UART host（FAE）─
 - **不做為預設**：永不自動啟動，只在使用者顯式執行時開啟。
 - direct（agent host 可被撥入）與 relay（雙方皆 NAT 後）**同一套指令都支援**。
 - **help 與所有面向 agent 的文件同步修正**，務必讓 agent 知道如何使用與連線。
+- **信任邊界誠實化**（adversarial review 修訂）：明確界定「誰能操控 DUT」的邊界，並在**不改 daemon**的前提下提供把關手段（遠端 unix socket 檔案權限、loopback bind 不變量、單租戶 relay 要求）。
 
 ### 驗收條件（acceptance gate）
 
@@ -45,10 +46,13 @@ agent/RD 端  ── ssh -L 7777:127.0.0.1:7777 ──►  UART host（FAE）─
 - **預設不啟用**：跑 `serialwrap remote …` 之前，無隧道行程、無 state 檔、遠端 endpoint 不可連。
 - **手動啟動後正常**：`serialwrap remote …` 後，agent 端可透過隧道 `session list` / `cmd submit` 並取得正確結果。
 - **serialwrapd 不重啟**：daemon pid 全程不變。
+- **loopback 不變量與信任邊界**（adversarial review）：轉發出的 listener 只綁 loopback（`ss` 斷言非 `0.0.0.0`／`::`）；第三方攻擊者容器行為符合 §8 界定——tcp loopback 模式下「同機可連＝已知殘留風險」被實測記錄，遠端 unix socket 模式下無檔案權限者不可連。
+- **readiness 誠實**：慢速／失敗認證時 `remote` 不得回假 `ok`（回 `starting`／錯誤，見 §4）。
 
 ### 非目標（本期不做）
 
 - 不在 daemon／RPC 層做任何改動（純 CLI 便利層）。
+- **不在 RPC 層加認證／peer-credential 檢查**（adversarial review finding 1）：完整解法需改 daemon，牴觸「daemon 零改動」。**殘留信任邊界**——凡能連上被轉發 endpoint 的主體即可全權操控 DUT（`command.submit`／`file.push`／`daemon.stop`，RPC request 僅 `id/method/params`、無 token；socket 本機權限為 0660 group）——**以 §8 的手段緩解而非消除**：優先 `-R` 到**遠端 unix socket**（用檔案權限把關，等同把本機 0660 語意延伸到 relay）、明列**單租戶／可信 relay** 要求、loopback bind 不變量。若 relay 為多租戶共享主機且未用遠端 unix socket，此殘留風險存在，文件須明講。
 - 不自製 SSH（不引入 paramiko）；auth 全數委由系統 `ssh`。
 - 不做 relay 伺服器、不做隧道健康自動修復以外的 orchestration。
 - 不改變既有 `--endpoint` 語意；agent 端 direct 情境仍用既有 `--endpoint tcp://…`。
@@ -80,36 +84,51 @@ serialwrap remote close all                  # 拆除全部
   - `--autossh`：以 `autossh -M 0` 取代 `ssh`，斷線自動重連。
   - `--local N`：`-L` 時本機 loopback port（預設 = target port）。
   - `--socket EP`：`-R` 時要暴露的本機 daemon endpoint（預設 = `_resolve_endpoint` 解析結果）。
+  - `--remote-socket PATH`（**硬化模式**，adversarial review finding 1）：`-R` 時遠端改建 **unix socket** 而非 tcp loopback port，用檔案權限把關存取（agent 端改用 `--endpoint unix://PATH`）。**共享／多租戶 relay 建議必開**。省略則預設 tcp loopback（便利但受 §8 殘留風險）。
+  - `--ready-timeout S`：readiness 確認上限（預設 10s）；逾時仍未確認 forward 建立 → 回 `starting`（見 §4）。
   - `--ssh-opt "..."`：透傳額外 ssh 參數（可重複），例如 `-o ServerAliveInterval=30`、`-p 2222`。
 - 所有子動作輸出緊湊 JSON（`ensure_ascii=False, separators=(",",":")`，含 `ok`），對齊 CLI 慣例。
 
 ## 4. 行為規格
 
+### 4.0 共同：tunnel identity 與 readiness（adversarial review findings 3/5）
+
+- **tunnel identity** = `(role, ssh_target, listen_port, forward_target)`。作為 registry 邏輯主鍵（**非只 port**）。listen_port（`-R`＝遠端 bind port、`-L`＝本機 local port）供顯示與 `close` 選取。
+- **readiness 協定**：spawn 後**不以「行程還活著」當成功**。附 `-o BatchMode=yes`（禁互動、不卡密碼提示）+ ControlMaster（`-o ControlMaster=auto -o ControlPath=<run>/remote/cm-<id>`），以 `ssh -O check` 輪詢至主連線確認「認證完成且 forward 已建立」（`ExitOnForwardFailure=yes` 保證 forward 失敗即 ssh 退出），或子行程提前死亡，或 `--ready-timeout` 到期：
+  - 確認就緒 → 寫 `status="active"`，回 `{"ok":true,"status":"active",...}`。
+  - 逾時但行程仍在 → 寫 `status="starting"`，回 `{"ok":true,"status":"starting",...}`（**非** silent success；agent 應再以 `remote status` 或探測 endpoint 確認）。
+  - 行程已死 → `TUNNEL_SPAWN_FAILED`（附 stderr 尾），不留 active state。
+
 ### 4.1 `remote -R`（expose；跑在 UART host）
 
-1. 解析 target 為 `(ssh_target, port)`；格式不符 → `{"ok":false,"error_code":"INVALID_TARGET"}`。
-2. 解析要暴露的本機 daemon endpoint（`--socket` 或 `_resolve_endpoint(args)`）：
-   - AF_UNIX 路徑 → 遠端轉發目標為該 socket 路徑（`ssh -R <port>:<sock>`，**免 socat**，需對端與本機 OpenSSH ≥ 6.7）。
-   - `tcp://127.0.0.1:<p>`（Windows daemon 或顯式覆寫）→ `ssh -R <port>:127.0.0.1:<p>`。
-   - 完全解析不到任何本機 endpoint → `NO_LOCAL_DAEMON`（提示先 `serialwrap daemon status`）。若解析到 unix 路徑但檔案暫不存在 → **僅 warn 不擋**：`ssh -R` 要等遠端有連線進來才連該 socket，daemon 稍後起來即通（隧道可先於 daemon 起）。
-3. 組 argv（見 §5），spawn detached 子行程，寫 state（見 §6），立即返回：
+1. 解析 target 為 `(ssh_target, port)`；格式不符 → `INVALID_TARGET`。
+2. 決定 **forward_target**（`--socket` 或 `_resolve_endpoint(args)` 決定本機轉發源）：
+   - `--remote-socket PATH` → 遠端 unix socket：`-R PATH:<本機轉發源>`（硬化模式）。
+   - 否則 → 遠端 loopback tcp：`-R 127.0.0.1:<port>:<本機轉發源>`（**顯式綁 loopback**，見 §5/§8）。
+   - 本機轉發源：AF_UNIX 路徑（`ssh -R … :<sock>`，免 socat，需兩端 OpenSSH ≥ 6.7）；`tcp://127.0.0.1:<p>`（Windows）→ `127.0.0.1:<p>`。
+   - 完全解析不到任何本機 endpoint → `NO_LOCAL_DAEMON`。解析到 unix 路徑但檔案暫不存在 → **僅 warn**（`ssh -R` 要等有連線進來才連 socket，daemon 稍後起即通）。
+3. **identity 衝突檢查（持 registry flock，見 §6）**：同 listen_port 已有 state──
+   - identity 完全相同且 active/starting → `{"ok":true,"already_running":true,...}` no-op。
+   - identity 不同（換 target/forward）→ `TUNNEL_CONFLICT`（要求先 `remote close <port>`）。
+   - state 在但行程已死 → 視為可覆寫。
+4. 組 argv（§5），spawn detached，跑 readiness（§4.0），依結果寫 state（§6）並回：
    ```json
-   {"ok":true,"role":"expose","pid":12345,"bind_port":7777,"target":"user@host",
-    "daemon_endpoint":"unix:///run/.../serialwrapd.sock","via":"ssh",
-    "remote_hint":"agent 端用 serialwrap --endpoint tcp://127.0.0.1:7777"}
+   {"ok":true,"status":"active","role":"expose","pid":12345,"listen_port":7777,
+    "target":"user@host","forward_target":"unix:///run/.../serialwrapd.sock","via":"ssh",
+    "remote_hint":"agent 端用 serialwrap --endpoint tcp://127.0.0.1:7777（--remote-socket 時 unix://PATH）"}
    ```
-4. idempotency：該 port 已有**存活**的隧道 → 回 `{"ok":true,"already_running":true,...}` no-op；state 在但 pid 已死 → 覆寫重建。
 
 ### 4.2 `remote -L`（connect / relay；跑在 agent host）
 
 1. 解析 target 與本機 `--local`（預設 = target port）。
-2. 組 `ssh -N -L <local>:localhost:<port> <ssh_target>`，spawn detached，寫 state，回：
+2. identity 衝突檢查同 §4.1 step 3（以 local_port 選取）。
+3. 組 `ssh -N -T -o BatchMode=yes -L 127.0.0.1:<local>:localhost:<port> <ssh_target>`（**顯式綁本機 loopback**，見 §8），spawn，跑 readiness（`-L` 可直接探測本機 `127.0.0.1:<local>` 可連性），寫 state，回：
    ```json
-   {"ok":true,"role":"connect","pid":23456,"local_port":7777,"target":"user@relay",
-    "endpoint":"tcp://127.0.0.1:7777"}
+   {"ok":true,"status":"active","role":"connect","pid":23456,"local_port":7777,
+    "target":"user@relay","endpoint":"tcp://127.0.0.1:7777"}
    ```
-   `endpoint` 即 agent 接著要餵給 `--endpoint` 的值。
-3. 本機 `local` port 已被佔 → `PORT_IN_USE`。
+   `endpoint` 即 agent 接著餵給 `--endpoint` 的值。
+4. 本機 `local` port 已被佔（非本工具的隧道）→ `PORT_IN_USE`。
 
 ### 4.3 direct 情境（agent 端免 connect）
 
@@ -119,58 +138,84 @@ UART host 的 `-R` 已直接落在 agent host 時，agent 端**不需任何新�
 serialwrap --endpoint tcp://127.0.0.1:7777 session list
 ```
 
-`remote -L` 僅在 relay／雙 NAT（需要在 agent 端再撥一段 `-L` 到 relay）時使用。文件（§10）必須清楚標示這條岔路，避免 agent 誤用。
+`remote -L` 僅在 relay／雙 NAT 時使用。文件（§10）須清楚標示這條岔路，避免 agent 誤用。
 
 ### 4.4 `remote status`（含裸 `remote`）
 
-掃 state registry，對每筆探測 pid 存活；死的 prune 掉。輸出：
+掃 state registry，對每筆以 **pid + 行程啟動時刻**（§6，防 PID reuse）驗證存活，死的 prune 掉；`starting` 狀態順手重探是否已 `active`。輸出：
 
 ```json
 {"ok":true,"tunnels":[
-  {"role":"expose","pid":12345,"alive":true,"bind_port":7777,"target":"user@host","via":"ssh","started":"..."},
-  {"role":"connect","pid":23456,"alive":true,"local_port":7778,"target":"user@relay","endpoint":"tcp://127.0.0.1:7778"}
+  {"status":"active","role":"expose","pid":12345,"alive":true,"listen_port":7777,"target":"user@host","via":"ssh"},
+  {"status":"starting","role":"connect","pid":23456,"alive":true,"local_port":7778,"target":"user@relay","endpoint":"tcp://127.0.0.1:7778"}
 ]}
 ```
 
 ### 4.5 `remote close <port|all>`
 
-對指定 port（或全部）的隧道 pid 送 `SIGTERM`，移除其 state 檔。找不到該 port → `{"ok":true,"closed":[]}`（冪等，不視為錯誤）。
+對選中的隧道（持 registry flock）：
+1. 以 **pid + 啟動時刻** 驗證確為本工具 spawn 的該行程（不符 → 略過該 pid，不誤殺被 reuse 的 PID）。
+2. 對其 **process group** 送 `SIGTERM`（`os.killpg`），bounded 等待退出（如 5s），未退再 `SIGKILL`。
+3. 確認退出後才移除 state 檔與 ControlPath；**驗證／等待失敗 → 保留 `status="error"` state**（不靜默刪，讓孤兒隧道仍能被 `status`／再次 `close` 看到、處理）。
+
+找不到該 port → `{"ok":true,"closed":[]}`（冪等）。
 
 ## 5. 隧道 argv 組裝
 
-- 基底：`["ssh","-N","-T", *ssh_opts, direction_args, ssh_target]`
-  - `-N`（不開 shell）、`-T`（不配 tty）。
-  - 預設附健全性 `-o`：`ExitOnForwardFailure=yes`（forward 建不起來即讓 ssh 失敗，配合 §4.1 step ‑spawn 檢查回 `TUNNEL_SPAWN_FAILED`）、`ServerAliveInterval=30`、`ServerAliveCountMax=3`（可被 `--ssh-opt` 覆寫）。
-- `-R`：`["-R", f"{port}:{forward_target}"]`，`forward_target` = unix socket 路徑 或 `127.0.0.1:{tcpport}`。
-- `-L`：`["-L", f"{local}:localhost:{port}"]`。
-- `--autossh`：改用 `["autossh","-M","0", ...其後同 ssh...]`。
-- **安全**：`ssh -R` 預設只 bind 遠端 loopback（不設 `GatewayPorts`），維持「絕不對外」。
-- **Windows UART host**：無 AF_UNIX，daemon 為 TCP loopback，`-R` 轉發目標自動為 `127.0.0.1:<tcpport>`；需系統有 `ssh`（Win10+ OpenSSH client）。此為次要平台，文件標注即可。
+- 基底：`["ssh","-N","-T", *default_opts, *ssh_opts, direction_args, ssh_target]`，spawn 時 `stdin=DEVNULL`（配合 `BatchMode=yes`，禁互動認證卡死——finding 3）。
+- 預設 `-o`（可被 `--ssh-opt` 覆寫）：
+  - `BatchMode=yes`：禁密碼／passphrase 互動提示；認證只走金鑰／agent，失敗即退出而非卡住。
+  - `ExitOnForwardFailure=yes`：forward 建不起即 ssh 退出，供 readiness 判死（配合 §4.0）。
+  - `ControlMaster=auto`、`ControlPath=<run>/remote/cm-<id>`、`ControlPersist=no`：供 `ssh -O check` readiness 探測與精準 teardown。
+  - `ServerAliveInterval=30`、`ServerAliveCountMax=3`。
+- `-R`（expose）：
+  - `--remote-socket PATH` → `["-R", f"{PATH}:{forward_src}"]`（遠端 unix socket，硬化）。
+  - 否則 → `["-R", f"127.0.0.1:{port}:{forward_src}"]`（**顯式遠端 loopback bind**）。
+  - `forward_src` = 本機 unix socket 路徑 或 `127.0.0.1:{tcpport}`。
+  - **GatewayPorts 前提**（finding 2）：遠端 bind 是否真的只綁 loopback，最終受 **relay sshd 的 `GatewayPorts`** 決定——`GatewayPorts yes` 會強制 remote forward 綁 wildcard，client 無法覆寫。故本設計要求「relay `GatewayPorts no`（預設）」為前提，於 docker gate 以 `ss` 斷言實測（§11），文件明講此前提。
+- `-L`（connect）：`["-L", f"127.0.0.1:{local}:localhost:{port}"]`（**顯式本機 loopback bind**，不受 client `GatewayPorts` 影響——finding 2）。
+- `--autossh`：改用 `["autossh","-M","0", ...其後同 ssh...]`（pid 為 autossh；readiness／close 對 autossh 行程操作，其子 ssh 由 autossh 管）。
+- **Windows UART host**：無 AF_UNIX，daemon 為 TCP loopback，`forward_src` 自動為 `127.0.0.1:<tcpport>`；需系統有 `ssh`（Win10+ OpenSSH client）。次要平台，文件標注即可。
 
 ## 6. 背景行程與 state registry
 
-- spawn 方式：`subprocess.Popen(..., start_new_session=True)`（setsid，脫離父行程與終端），stdout/stderr 導到 state 目錄下的 log 檔（供 `TUNNEL_SPAWN_FAILED` 撈 stderr 尾）。
-- state 目錄：`$RUN_DIR/remote/`（`RUN_DIR` 預設 XDG runtime，與 socket／lock 同層；reboot 清掉剛好隧道也一併消失，語意一致）。
-- 每條隧道一檔 `$RUN_DIR/remote/<bind_or_local_port>.json`：
+- spawn：`subprocess.Popen(..., start_new_session=True, stdin=DEVNULL, stdout=log, stderr=log)`（setsid：脫離父行程與終端，並使子行程自成 process group，供 §4.5 `killpg`）。log 檔在 state 目錄下（供 `TUNNEL_SPAWN_FAILED` 撈 stderr 尾）。
+- state 目錄：`$RUN_DIR/remote/`（`RUN_DIR` 預設 XDG runtime，與 socket／lock 同層；reboot 清掉剛好隧道也一併消失）。
+- **registry 鎖（finding 5）**：`$RUN_DIR/remote/.registry.lock` 的 flock，包住每次 `check → spawn → readiness → atomic replace`（`os.replace` 換檔）與 `close` 的 read-verify-remove，序列化並行 `remote` 操作，消除「兩個並行 start 同時通過檢查」競態。沿用 `sw_core/lock_posix.py` 既有 flock 慣例。
+- 每條隧道一檔 `$RUN_DIR/remote/<listen_port>.json`：
   ```json
-  {"role":"expose|connect","pid":12345,"target":"user@host","bind_port":7777,
-   "local_port":null,"daemon_endpoint":"unix:///…","via":"ssh|autossh",
-   "argv":["ssh","-N",...],"started_mono":123456.7,"started_wall":"2026-07-19T..."}
+  {"identity":"<hash(role,target,listen_port,forward_target)>","status":"active|starting|error",
+   "role":"expose|connect","pid":12345,"pid_start_ticks":8837201,
+   "target":"user@host","listen_port":7777,"forward_target":"unix:///…","via":"ssh|autossh",
+   "control_path":"…/cm-<id>","argv":["ssh","-N",...],
+   "started_mono":123456.7,"started_wall":"2026-07-19T..."}
   ```
   以 `sort_keys=True` 寫出（對齊 state.json 慣例）。
-- 存活判定：`os.kill(pid, 0)`；`autossh` 情境 pid 為 autossh 本身（其子 ssh 由 autossh 管）。
-- idempotency／prune 規則見 §4.1、§4.4。
-- **與 serialwrapd 生命週期完全解耦**：daemon 死了隧道還在（連過去會 EOF）；daemon 重啟不需重開隧道（AF_UNIX 路徑不變）。
+- **存活與身分驗證（finding 4）**：`os.kill(pid,0)` 只判 pid 存在，無法分辨 **PID reuse**；故另存 `pid_start_ticks`（Linux `/proc/<pid>/stat` 第 22 欄行程啟動時刻），驗活時比對 pid 現行 start-ticks 是否一致——不一致即「該 pid 已非我方隧道」→ 不誤殺、prune 舊 state。非 Linux POSIX 無 `/proc` → 退化 pid-only（best-effort，文件標注）。`autossh` 情境 pid 為 autossh 本身。
+- idempotency／conflict／close 規則見 §4.1、§4.4、§4.5。
+- **與 serialwrapd 生命週期完全解耦**：daemon 死了隧道還在（連過去 EOF）；daemon 重啟不需重開隧道（AF_UNIX 路徑不變）。
 
 ## 7. daemon socket 解析（-R）
 
 重用 `sw_core/cli.py::_resolve_endpoint(args)`（既有優先序：`--endpoint` > `--socket` > config.yaml > 平台預設）取得本機 daemon endpoint，再依 transport（unix／tcp）決定 `-R` 的 forward target。不新增解析邏輯、不改寫 config（維持 CLI 對 config.yaml 唯讀）。
 
-## 8. 安全
+## 8. 安全（adversarial review findings 1/2）
 
-- auth 全數委由 `ssh`（金鑰／known_hosts／agent forwarding 皆 ssh 自理），serialwrap 不碰金鑰。
-- `-R` 只 bind 遠端 loopback；不提供 `GatewayPorts`／`0.0.0.0` 對外選項。
-- 隧道等於讓對端全權操控 DUT（`command.submit`／`file.push`／`daemon.stop`）→ `remote` 輸出與 `--help`／SKILL 文件明確標警語：**只透過 ssh-tunnel 使用、不可對網路直接開放**。
+**信任邊界（trust boundary）**——SSH 只認證「誰建立隧道」，**不認證之後連入被轉發 endpoint 的 client**。RPC request 僅 `id/method/params`、無 token，daemon 不做 peer 認證（本期不改，見 §2 非目標）。故：
+
+- **本機（UART host）**：daemon socket 為 0660＋group，受檔案權限把關。
+- **relay／agent host 的轉發 endpoint**：
+  - tcp loopback（預設）→ **同機任何本機使用者／程序皆可連**並全權操控 DUT（`command.submit`／`file.push`／`daemon.stop`）＝**殘留風險**。**要求 relay／agent host 為單租戶／可信主機**。
+  - `--remote-socket PATH`（硬化）→ 遠端 unix socket 受檔案權限把關，等同把 0660 語意延伸到 relay，**多租戶／共享 relay 建議必開**。
+
+**loopback bind 不變量**：
+- `-L` 顯式 `127.0.0.1:` bind，不受 client `GatewayPorts` 影響。
+- `-R` 顯式 `127.0.0.1:` bind，但**最終受 relay sshd `GatewayPorts` 決定**——`GatewayPorts yes` 會強制綁 wildcard 對外，client 無法覆寫。**前提：relay `GatewayPorts no`（預設）**；docker gate 以 `ss` 實測非 loopback 不可達（§11），文件明講。
+
+**其他**：
+- `BatchMode=yes` 禁互動認證，避免弱認證與卡死。
+- auth（金鑰／known_hosts／agent forwarding）全交 ssh，serialwrap 不碰金鑰。
+- `remote` 輸出與 `--help`／SKILL 文件標警語：**只透過 ssh-tunnel、單租戶 relay 或 `--remote-socket`，不可對網路直接開放**。
 
 ## 9. 錯誤處理（回 error_code，不讓例外穿越）
 
@@ -178,24 +223,27 @@ serialwrap --endpoint tcp://127.0.0.1:7777 session list
 |---|---|
 | target 非 `[user@]host:port` | `INVALID_TARGET` |
 | 無 `ssh`（或 `--autossh` 但無 `autossh`）於 PATH | `SSH_NOT_FOUND` |
-| spawn 後 ~0.5s 子行程即死 | `TUNNEL_SPAWN_FAILED`（附 stderr 尾） |
+| readiness 期間子行程死亡（認證／forward 失敗） | `TUNNEL_SPAWN_FAILED`（附 stderr 尾） |
+| 同 listen_port 已有**不同 identity** 的隧道 | `TUNNEL_CONFLICT` |
 | `-R` 完全解析不到任何本機 endpoint | `NO_LOCAL_DAEMON` |
-| `-L` 本機 port 已被佔 | `PORT_IN_USE` |
+| `-L` 本機 port 已被佔（非本工具隧道） | `PORT_IN_USE` |
 | `-R` 與 `-L` 同時指定 | `INVALID_ARGS` |
+
+- **`status` 非 error**：`active`／`starting`／`error` 為隧道生命週期狀態，隨 `{"ok":true,...}` 回傳（`starting`＝已 spawn、forward 尚未確認，readiness 逾時走此；`error`＝`close` 驗證／等待失敗保留的孤兒 state，見 §4.5）。
 
 ## 10. 改動表面（顯式同步多表面）
 
 ### Code
 
-- `sw_core/cli.py`：新增 `remote` subparser（positional target、`-R`/`-L`/`--autossh`/`--local`/`--socket`/`--ssh-opt`、`status`/`close` 子動作）+ 平面 if/elif 分派。
-- 新模組 `sw_core/remote_tunnel.py`：target 解析、argv 組裝、spawn（注入式 spawner 便於測試）、state 讀寫、status prune、close。以純函式為主，副作用（Popen／檔案）集中且可注入。
+- `sw_core/cli.py`：新增 `remote` subparser（positional target、`-R`/`-L`/`--autossh`/`--local`/`--socket`/`--remote-socket`/`--ready-timeout`/`--ssh-opt`、`status`/`close` 子動作）+ 平面 if/elif 分派。
+- 新模組 `sw_core/remote_tunnel.py`：target 解析、identity 計算、argv 組裝、spawn（注入式 spawner）、**readiness probe（注入式 `ssh -O check`）**、**flock registry**（state 讀寫／identity 衝突／atomic replace）、status prune（pid+start-ticks）、robust close（verify→killpg→wait→error-state）。純函式為主，副作用（Popen／flock／檔案）集中且可注入。
 
 ### Docs / help / skill（本次硬需求：讓 agent 會用、會連）
 
 - `sw_core/assets/skill/SKILL.md`：**改寫「Remote Support 用法（ssh-tunnel）」（現 line 92-112）**。現內容教舊的 `ssh -L`（inbound）正是誤導源頭，改為：
   - UART host：`serialwrap remote user@host:7777`（`-R` 預設）。
   - agent 端連線 runbook：direct → `serialwrap --endpoint tcp://127.0.0.1:7777 …`；relay → 先 `serialwrap remote -L user@relay:7777` 再用回傳 endpoint。
-  - 明確標示 direct vs relay 岔路與 `remote status`/`close`、安全警語。
+  - 明確標示 direct vs relay 岔路、`remote status`/`close`、`starting` 狀態需再確認、以及信任邊界警語（**單租戶／可信 relay**，共享 relay 用 `--remote-socket` 硬化）。
 - `sw_core/assets/skill/SKILL_WINDOWS.md`：新增精簡 remote 段（Windows daemon 為 TCP loopback，`-R` 轉發 `127.0.0.1:48700`；需 OpenSSH client）。
 - `README.md`：**改寫「Remote Support（ssh-tunnel 遠端連線）」（現 line 1632+）**，以 `serialwrap remote` 為主軸、保留 `ssh -R`/`-L` 手動等價、涵蓋 direct/relay。依語言政策 **README 中英雙語並存**，英文段與繁中段一致更新。
 - `README.md` cli-help markers（R-16）：新增 `serialwrap-remote-help` marker 區塊；因 `remote` 進入子命令列表，**一併再生 `serialwrap-help` 區塊**。
@@ -207,16 +255,19 @@ serialwrap --endpoint tcp://127.0.0.1:7777 session list
 ### 11.1 單元（`tests/test_remote_tunnel.py`）
 
 - target 解析（`user@host:port`／`alias:port`／缺 port／壞格式）。
-- argv 組裝：`-R` unix-socket 與 tcp 兩種 forward target、`-L`、`--autossh`、`--ssh-opt` 透傳、預設 `-o` 附加。
-- state 讀寫、`status` prune 死 pid、`close` 送訊號與移檔、idempotency（同 port 活著→no-op、死→覆寫）。
-- error_code 路徑：`INVALID_TARGET`／`SSH_NOT_FOUND`（PATH monkeypatch）／`INVALID_ARGS`／`NO_LOCAL_DAEMON`／`PORT_IN_USE`。
-- 生命週期以**注入式 spawner + 假長命行程**（如 `sleep`）驗證，不真的起 ssh。
+- argv 組裝：`-R` unix-socket／tcp／`--remote-socket` 三種 forward 形式、`-R` 顯式 `127.0.0.1:` bind、`-L` 顯式 `127.0.0.1:` bind、`--autossh`、`--ssh-opt` 透傳、預設 `-o`（`BatchMode`／`ExitOnForwardFailure`／`ControlMaster`／`ControlPath`）附加。
+- identity／衝突（finding 5）：同 port 同 identity→`already_running`；同 port 不同 identity→`TUNNEL_CONFLICT`；死 state→覆寫。
+- readiness 狀態機（finding 3；注入式 `ssh -O check` probe）：確認→`active`；逾時行程仍活→`starting`；行程即死→`TUNNEL_SPAWN_FAILED`。
+- `close`（finding 4）：pid+start-ticks 驗證（**PID reuse**：start-ticks 不符→不殺、prune）、`killpg`→wait→移檔；驗證／等待失敗→保留 `error` state。
+- flock 並行（finding 5）：barrier 式兩個並行 start 同 port → 只成一條、另一條 `TUNNEL_CONFLICT`／`already_running`；並行 start/close 不留孤兒。
+- error_code：`INVALID_TARGET`／`SSH_NOT_FOUND`（PATH monkeypatch）／`INVALID_ARGS`／`NO_LOCAL_DAEMON`／`PORT_IN_USE`／`TUNNEL_CONFLICT`。
+- 生命週期以**注入式 spawner + 假長命行程**（如 `sleep`）＋**注入式 readiness probe** 驗證，不真的起 ssh。
 
 ### 11.2 docker 拓樸驗收（acceptance gate；`tools/docker/remote_tunnel_test.sh`）
 
 以真 sshd + 真 `serialwrap remote` 跑三種拓樸，**全過才算通過**。以 docker network 隔離模擬 NAT（不共網段＝互不可達，只能經 relay）。
 
-**測試映像**：延伸現有 `serialwrap:remote-smoke`，加 `openssh-server`／`openssh-client`／`autossh` + 預燒 keypair（passwordless），內含 fake target + `serialwrapd`（AF_UNIX socket）。
+**測試映像**：延伸現有 `serialwrap:remote-smoke`，加 `openssh-server`／`openssh-client`／`autossh`／`iproute2`（`ss`）+ 預燒 keypair（passwordless），內含 fake target + `serialwrapd`（AF_UNIX socket）。relay/agent sshd 明設 **`GatewayPorts no`**。另備 `attacker` 角色：同 relay 網段的獨立容器（無金鑰），及 relay 容器內第二個非特權使用者。
 
 **拓樸 1 — direct**
 - `net_direct`：`uart`（serialwrapd）、`agent`（跑 sshd）同網段。
@@ -237,6 +288,9 @@ serialwrap --endpoint tcp://127.0.0.1:7777 session list
 2. **手動啟動後正常**：`remote -R`/`-L` 後 agent 端 `session list` 有 READY session、`cmd submit`→`cmd status` 得 `done` 且輸出正確。
 3. **serialwrapd 不重啟**：擷取 daemon pid，全程（expose/connect/close 前後）不變。
 4. **teardown 乾淨**：`serialwrap remote close all` 後隧道行程消失、state 檔清空、`--endpoint` 復歸不可連。
+5. **loopback 不變量**（finding 2）：relay/agent 上 `ss -ltn` 斷言 forward listener 綁 `127.0.0.1`（非 `0.0.0.0`／`::`）；獨立 `attacker` 容器連 `relay:<port>` **必失敗**（證明非對外）。
+6. **信任邊界實測**（finding 1）：relay 內第二個本機使用者連 `127.0.0.1:<port>`——tcp loopback 模式**可連**（記錄為已知殘留風險）；`--remote-socket` 模式無檔案權限者**被拒**（證明硬化有效）。
+7. **readiness 誠實**（finding 3/4）：錯 key／未知 host key／`BatchMode` 擋互動時 `remote` 回 `starting`／錯誤而非假 `ok`；真 sshd 下 PID reuse 不誤殺、並行 start/close 不留孤兒。
 
 **執行與 CI**：docker 可用時列為必跑驗收；docker 不可用的環境明確 SKIP 並印原因（不靜默略過）。單元測試（11.1）恆入 CI。
 
@@ -246,7 +300,9 @@ serialwrap --endpoint tcp://127.0.0.1:7777 session list
 
 ## 12. 相依與相容性
 
-- 執行期需系統 `ssh`（`--autossh` 時另需 `autossh`）；`-R port:unix-socket` 需 OpenSSH ≥ 6.7（2014，現行發行版皆滿足）。
+- 執行期需系統 `ssh`（`--autossh` 時另需 `autossh`）；`-R port:unix-socket`／`--remote-socket` 需 OpenSSH ≥ 6.7（2014，現行發行版皆滿足）；readiness 用的 `ControlMaster`／`ssh -O check` 亦為 OpenSSH 標配。
+- PID-reuse 防護的 `pid_start_ticks` 依賴 Linux `/proc`（生產路徑 Linux/WSL）；非 Linux POSIX 退化 pid-only（best-effort，文件標注）。
+- docker gate 另需 `openssh-server`／`iproute2`（`ss`），僅在測試映像內。
 - 純 CLI 便利層，向後相容：不改 `--endpoint`／daemon／RPC；既有手動 `ssh -R`/`-L` + `--endpoint` 流程照舊可用。
 
 ## 13. 未來（defer）

--- a/docs/superpowers/specs/2026-07-19-remote-tunnel-cli-design.md
+++ b/docs/superpowers/specs/2026-07-19-remote-tunnel-cli-design.md
@@ -1,0 +1,256 @@
+# serialwrap `remote` 隧道便利 CLI 設計
+
+- 日期：2026-07-19
+- 分支：`feature/remote-tunnel-cli`
+- 狀態：設計待複審
+
+## 1. 背景與 root cause
+
+serialwrap 現行的「Remote Support」文件（`README.md`、`sw_core/assets/skill/SKILL.md`）教的遠端連線模型是：
+
+```
+agent/RD 端  ── ssh -L 7777:127.0.0.1:7777 ──►  UART host（FAE）── socat ── serialwrapd.sock
+```
+
+即 **由 agent 端主動發起一條 inbound SSH 連進 UART host**（`ssh -L`，local forward），並在 UART host 上以 `socat` 把 AF_UNIX socket 橋成 TCP。
+
+這個模型的隱含前提是「agent 端能主動連進放 UART 的那台機器」。實務上 UART host 常是使用者的**本機**，在 NAT／防火牆後、無對外 sshd，agent 進不來 → `ssh -L` 這一步根本建立不起來，就是觀察到的「無法連線」。
+
+**Root cause = 連線發起方向錯配（directionality mismatch），非 client 程式 bug。** 佐證：
+
+- `sw_core/client.py` 已完整支援 `tcp://host:port`（`_parse_endpoint` / `_rpc_call_once`），client 端不是瓶頸。
+- POSIX daemon 只透過 `select_rpc_backend()` 起 AF_UNIX server（`sw_core/rpc_posix.py`），**無原生 TCP／遠端 listener**；`daemon start --endpoint tcp://…` 在 POSIX 一律 `REMOTE_NOT_SUPPORTED`。遠端存取被刻意外包給「外部 bridge + SSH tunnel」。
+
+實際能通的方向是**由 UART host 主動撥出**的反向隧道（`ssh -R`）：本機撥出去，把 daemon socket 推到對端，agent 再打對端 loopback 即被隧道回本機。使用者目前手動這樣做，本設計把它收斂成 serialwrap 原生便利指令。
+
+## 2. 目標與非目標
+
+### 目標
+
+- 新增 `serialwrap remote` 子命令群，用**極簡語法**（比照 `--endpoint` 的 `host:port`）在 runtime 按需拉起／關閉 SSH 反向隧道，讓遠端 agent 取得本機 serialwrap 操作。
+- **serialwrapd 不得重啟、不新增 listener**：隧道只是外部 `ssh` 子行程，讀既有 daemon socket，daemon 零改動。
+- **不做為預設**：永不自動啟動，只在使用者顯式執行時開啟。
+- direct（agent host 可被撥入）與 relay（雙方皆 NAT 後）**同一套指令都支援**。
+- **help 與所有面向 agent 的文件同步修正**，務必讓 agent 知道如何使用與連線。
+
+### 驗收條件（acceptance gate）
+
+以 docker 模擬三種拓樸，**三者皆須成立才算測試通過**（見 §11）：
+
+1. **direct**：agent host 可被 UART host 撥入。
+2. **NAT → host**：UART host 在 NAT 後，主動 `-R` 撥出到可達的 relay/agent host。
+3. **NAT ← client**：agent／client 亦在 NAT 後，主動 `-L` 從 relay 拉回本機 loopback（與 2 合為雙 NAT relay 全鏈）。
+
+每個拓樸都須同時驗證：
+- **預設不啟用**：跑 `serialwrap remote …` 之前，無隧道行程、無 state 檔、遠端 endpoint 不可連。
+- **手動啟動後正常**：`serialwrap remote …` 後，agent 端可透過隧道 `session list` / `cmd submit` 並取得正確結果。
+- **serialwrapd 不重啟**：daemon pid 全程不變。
+
+### 非目標（本期不做）
+
+- 不在 daemon／RPC 層做任何改動（純 CLI 便利層）。
+- 不自製 SSH（不引入 paramiko）；auth 全數委由系統 `ssh`。
+- 不做 relay 伺服器、不做隧道健康自動修復以外的 orchestration。
+- 不改變既有 `--endpoint` 語意；agent 端 direct 情境仍用既有 `--endpoint tcp://…`。
+
+## 3. 使用者介面（CLI surface）
+
+沿用熟悉的 `host:port`，方向借用 ssh 同名的 `-R`／`-L`：
+
+```bash
+# 你本機（UART host）：反向把本機 daemon 推到對端 —— 日常唯一要記的一行
+serialwrap remote user@host:7777            # 預設 = -R（reverse / expose）
+serialwrap remote -R user@host:7777         # 顯式 reverse
+
+# agent 端（只有 relay / 雙 NAT 才需要）：把對端 port 拉回本機 loopback
+serialwrap remote -L user@host:7777
+
+# 查看 / 關閉
+serialwrap remote                            # 裸命令 = 列目前隧道（等同 status）
+serialwrap remote status                     # 同上（顯式）
+serialwrap remote close 7777                 # 拆除指定 port 的隧道
+serialwrap remote close all                  # 拆除全部
+```
+
+### positional 與旗標
+
+- positional target = `[user@]host:port`。`host` 可為 `~/.ssh/config` 的 Host alias → 可短到 `別名:port`。
+- **方向預設 `-R`**（reverse／expose）；`-R`／`-L` 互斥，`-L` 需顯式。
+- 罕用旗標（皆有預設，日常免帶）：
+  - `--autossh`：以 `autossh -M 0` 取代 `ssh`，斷線自動重連。
+  - `--local N`：`-L` 時本機 loopback port（預設 = target port）。
+  - `--socket EP`：`-R` 時要暴露的本機 daemon endpoint（預設 = `_resolve_endpoint` 解析結果）。
+  - `--ssh-opt "..."`：透傳額外 ssh 參數（可重複），例如 `-o ServerAliveInterval=30`、`-p 2222`。
+- 所有子動作輸出緊湊 JSON（`ensure_ascii=False, separators=(",",":")`，含 `ok`），對齊 CLI 慣例。
+
+## 4. 行為規格
+
+### 4.1 `remote -R`（expose；跑在 UART host）
+
+1. 解析 target 為 `(ssh_target, port)`；格式不符 → `{"ok":false,"error_code":"INVALID_TARGET"}`。
+2. 解析要暴露的本機 daemon endpoint（`--socket` 或 `_resolve_endpoint(args)`）：
+   - AF_UNIX 路徑 → 遠端轉發目標為該 socket 路徑（`ssh -R <port>:<sock>`，**免 socat**，需對端與本機 OpenSSH ≥ 6.7）。
+   - `tcp://127.0.0.1:<p>`（Windows daemon 或顯式覆寫）→ `ssh -R <port>:127.0.0.1:<p>`。
+   - 完全解析不到任何本機 endpoint → `NO_LOCAL_DAEMON`（提示先 `serialwrap daemon status`）。若解析到 unix 路徑但檔案暫不存在 → **僅 warn 不擋**：`ssh -R` 要等遠端有連線進來才連該 socket，daemon 稍後起來即通（隧道可先於 daemon 起）。
+3. 組 argv（見 §5），spawn detached 子行程，寫 state（見 §6），立即返回：
+   ```json
+   {"ok":true,"role":"expose","pid":12345,"bind_port":7777,"target":"user@host",
+    "daemon_endpoint":"unix:///run/.../serialwrapd.sock","via":"ssh",
+    "remote_hint":"agent 端用 serialwrap --endpoint tcp://127.0.0.1:7777"}
+   ```
+4. idempotency：該 port 已有**存活**的隧道 → 回 `{"ok":true,"already_running":true,...}` no-op；state 在但 pid 已死 → 覆寫重建。
+
+### 4.2 `remote -L`（connect / relay；跑在 agent host）
+
+1. 解析 target 與本機 `--local`（預設 = target port）。
+2. 組 `ssh -N -L <local>:localhost:<port> <ssh_target>`，spawn detached，寫 state，回：
+   ```json
+   {"ok":true,"role":"connect","pid":23456,"local_port":7777,"target":"user@relay",
+    "endpoint":"tcp://127.0.0.1:7777"}
+   ```
+   `endpoint` 即 agent 接著要餵給 `--endpoint` 的值。
+3. 本機 `local` port 已被佔 → `PORT_IN_USE`。
+
+### 4.3 direct 情境（agent 端免 connect）
+
+UART host 的 `-R` 已直接落在 agent host 時，agent 端**不需任何新指令**，照舊：
+
+```bash
+serialwrap --endpoint tcp://127.0.0.1:7777 session list
+```
+
+`remote -L` 僅在 relay／雙 NAT（需要在 agent 端再撥一段 `-L` 到 relay）時使用。文件（§10）必須清楚標示這條岔路，避免 agent 誤用。
+
+### 4.4 `remote status`（含裸 `remote`）
+
+掃 state registry，對每筆探測 pid 存活；死的 prune 掉。輸出：
+
+```json
+{"ok":true,"tunnels":[
+  {"role":"expose","pid":12345,"alive":true,"bind_port":7777,"target":"user@host","via":"ssh","started":"..."},
+  {"role":"connect","pid":23456,"alive":true,"local_port":7778,"target":"user@relay","endpoint":"tcp://127.0.0.1:7778"}
+]}
+```
+
+### 4.5 `remote close <port|all>`
+
+對指定 port（或全部）的隧道 pid 送 `SIGTERM`，移除其 state 檔。找不到該 port → `{"ok":true,"closed":[]}`（冪等，不視為錯誤）。
+
+## 5. 隧道 argv 組裝
+
+- 基底：`["ssh","-N","-T", *ssh_opts, direction_args, ssh_target]`
+  - `-N`（不開 shell）、`-T`（不配 tty）。
+  - 預設附健全性 `-o`：`ExitOnForwardFailure=yes`（forward 建不起來即讓 ssh 失敗，配合 §4.1 step ‑spawn 檢查回 `TUNNEL_SPAWN_FAILED`）、`ServerAliveInterval=30`、`ServerAliveCountMax=3`（可被 `--ssh-opt` 覆寫）。
+- `-R`：`["-R", f"{port}:{forward_target}"]`，`forward_target` = unix socket 路徑 或 `127.0.0.1:{tcpport}`。
+- `-L`：`["-L", f"{local}:localhost:{port}"]`。
+- `--autossh`：改用 `["autossh","-M","0", ...其後同 ssh...]`。
+- **安全**：`ssh -R` 預設只 bind 遠端 loopback（不設 `GatewayPorts`），維持「絕不對外」。
+- **Windows UART host**：無 AF_UNIX，daemon 為 TCP loopback，`-R` 轉發目標自動為 `127.0.0.1:<tcpport>`；需系統有 `ssh`（Win10+ OpenSSH client）。此為次要平台，文件標注即可。
+
+## 6. 背景行程與 state registry
+
+- spawn 方式：`subprocess.Popen(..., start_new_session=True)`（setsid，脫離父行程與終端），stdout/stderr 導到 state 目錄下的 log 檔（供 `TUNNEL_SPAWN_FAILED` 撈 stderr 尾）。
+- state 目錄：`$RUN_DIR/remote/`（`RUN_DIR` 預設 XDG runtime，與 socket／lock 同層；reboot 清掉剛好隧道也一併消失，語意一致）。
+- 每條隧道一檔 `$RUN_DIR/remote/<bind_or_local_port>.json`：
+  ```json
+  {"role":"expose|connect","pid":12345,"target":"user@host","bind_port":7777,
+   "local_port":null,"daemon_endpoint":"unix:///…","via":"ssh|autossh",
+   "argv":["ssh","-N",...],"started_mono":123456.7,"started_wall":"2026-07-19T..."}
+  ```
+  以 `sort_keys=True` 寫出（對齊 state.json 慣例）。
+- 存活判定：`os.kill(pid, 0)`；`autossh` 情境 pid 為 autossh 本身（其子 ssh 由 autossh 管）。
+- idempotency／prune 規則見 §4.1、§4.4。
+- **與 serialwrapd 生命週期完全解耦**：daemon 死了隧道還在（連過去會 EOF）；daemon 重啟不需重開隧道（AF_UNIX 路徑不變）。
+
+## 7. daemon socket 解析（-R）
+
+重用 `sw_core/cli.py::_resolve_endpoint(args)`（既有優先序：`--endpoint` > `--socket` > config.yaml > 平台預設）取得本機 daemon endpoint，再依 transport（unix／tcp）決定 `-R` 的 forward target。不新增解析邏輯、不改寫 config（維持 CLI 對 config.yaml 唯讀）。
+
+## 8. 安全
+
+- auth 全數委由 `ssh`（金鑰／known_hosts／agent forwarding 皆 ssh 自理），serialwrap 不碰金鑰。
+- `-R` 只 bind 遠端 loopback；不提供 `GatewayPorts`／`0.0.0.0` 對外選項。
+- 隧道等於讓對端全權操控 DUT（`command.submit`／`file.push`／`daemon.stop`）→ `remote` 輸出與 `--help`／SKILL 文件明確標警語：**只透過 ssh-tunnel 使用、不可對網路直接開放**。
+
+## 9. 錯誤處理（回 error_code，不讓例外穿越）
+
+| 情境 | error_code |
+|---|---|
+| target 非 `[user@]host:port` | `INVALID_TARGET` |
+| 無 `ssh`（或 `--autossh` 但無 `autossh`）於 PATH | `SSH_NOT_FOUND` |
+| spawn 後 ~0.5s 子行程即死 | `TUNNEL_SPAWN_FAILED`（附 stderr 尾） |
+| `-R` 完全解析不到任何本機 endpoint | `NO_LOCAL_DAEMON` |
+| `-L` 本機 port 已被佔 | `PORT_IN_USE` |
+| `-R` 與 `-L` 同時指定 | `INVALID_ARGS` |
+
+## 10. 改動表面（顯式同步多表面）
+
+### Code
+
+- `sw_core/cli.py`：新增 `remote` subparser（positional target、`-R`/`-L`/`--autossh`/`--local`/`--socket`/`--ssh-opt`、`status`/`close` 子動作）+ 平面 if/elif 分派。
+- 新模組 `sw_core/remote_tunnel.py`：target 解析、argv 組裝、spawn（注入式 spawner 便於測試）、state 讀寫、status prune、close。以純函式為主，副作用（Popen／檔案）集中且可注入。
+
+### Docs / help / skill（本次硬需求：讓 agent 會用、會連）
+
+- `sw_core/assets/skill/SKILL.md`：**改寫「Remote Support 用法（ssh-tunnel）」（現 line 92-112）**。現內容教舊的 `ssh -L`（inbound）正是誤導源頭，改為：
+  - UART host：`serialwrap remote user@host:7777`（`-R` 預設）。
+  - agent 端連線 runbook：direct → `serialwrap --endpoint tcp://127.0.0.1:7777 …`；relay → 先 `serialwrap remote -L user@relay:7777` 再用回傳 endpoint。
+  - 明確標示 direct vs relay 岔路與 `remote status`/`close`、安全警語。
+- `sw_core/assets/skill/SKILL_WINDOWS.md`：新增精簡 remote 段（Windows daemon 為 TCP loopback，`-R` 轉發 `127.0.0.1:48700`；需 OpenSSH client）。
+- `README.md`：**改寫「Remote Support（ssh-tunnel 遠端連線）」（現 line 1632+）**，以 `serialwrap remote` 為主軸、保留 `ssh -R`/`-L` 手動等價、涵蓋 direct/relay。依語言政策 **README 中英雙語並存**，英文段與繁中段一致更新。
+- `README.md` cli-help markers（R-16）：新增 `serialwrap-remote-help` marker 區塊；因 `remote` 進入子命令列表，**一併再生 `serialwrap-help` 區塊**。
+- `.paul-project.yml`：`cli:` 新增 `{command:"./serialwrap remote", help_args:["--help"], reflected_in:"README.md", marker:"serialwrap-remote-help"}`。
+- `changelog.d/remote-tunnel-cli.md`：per-PR fragment（policy v1.0.10；無對應 issue，以 slug 命名）。
+
+## 11. 測試策略
+
+### 11.1 單元（`tests/test_remote_tunnel.py`）
+
+- target 解析（`user@host:port`／`alias:port`／缺 port／壞格式）。
+- argv 組裝：`-R` unix-socket 與 tcp 兩種 forward target、`-L`、`--autossh`、`--ssh-opt` 透傳、預設 `-o` 附加。
+- state 讀寫、`status` prune 死 pid、`close` 送訊號與移檔、idempotency（同 port 活著→no-op、死→覆寫）。
+- error_code 路徑：`INVALID_TARGET`／`SSH_NOT_FOUND`（PATH monkeypatch）／`INVALID_ARGS`／`NO_LOCAL_DAEMON`／`PORT_IN_USE`。
+- 生命週期以**注入式 spawner + 假長命行程**（如 `sleep`）驗證，不真的起 ssh。
+
+### 11.2 docker 拓樸驗收（acceptance gate；`tools/docker/remote_tunnel_test.sh`）
+
+以真 sshd + 真 `serialwrap remote` 跑三種拓樸，**全過才算通過**。以 docker network 隔離模擬 NAT（不共網段＝互不可達，只能經 relay）。
+
+**測試映像**：延伸現有 `serialwrap:remote-smoke`，加 `openssh-server`／`openssh-client`／`autossh` + 預燒 keypair（passwordless），內含 fake target + `serialwrapd`（AF_UNIX socket）。
+
+**拓樸 1 — direct**
+- `net_direct`：`uart`（serialwrapd）、`agent`（跑 sshd）同網段。
+- `uart`：`serialwrap remote -R tester@agent:7777`（`-R` 為預設，亦即裸 `serialwrap remote tester@agent:7777`）。
+- `agent`：`serialwrap --endpoint tcp://127.0.0.1:7777 session list` / `cmd submit`。
+
+**拓樸 2 — NAT → host**
+- `net_a`：`uart`（NAT，僅與 `relay` 同網段）、`relay`（可達，跑 sshd，agent CLI 在此）。
+- `uart`：`serialwrap remote -R tester@relay:7777` → agent CLI 於 `relay` 用 `--endpoint tcp://127.0.0.1:7777`。
+
+**拓樸 3 — NAT ← client（雙 NAT relay 全鏈）**
+- `net_a`：`uart`＋`relay`；`net_b`：`agent`＋`relay`。`uart` 與 `agent` **無共網段**（互不可達）。
+- `uart`：`serialwrap remote -R tester@relay:7777`（把 daemon 推上 relay loopback:7777）。
+- `agent`：`serialwrap remote -L tester@relay:7777`（把 relay:7777 拉回本機 loopback）→ 再用回傳 `endpoint` 下命令。
+
+**每個拓樸的斷言（缺一不可）**
+1. **預設不啟用**（跑 `remote` 前）：`serialwrap remote status` 回空 `tunnels`；`$RUN_DIR/remote/` 無 state 檔；無 serialwrap-spawn 的 `ssh`/`autossh` 行程；遠端 `--endpoint` 連線失敗（`SOCKET_ERROR`）。
+2. **手動啟動後正常**：`remote -R`/`-L` 後 agent 端 `session list` 有 READY session、`cmd submit`→`cmd status` 得 `done` 且輸出正確。
+3. **serialwrapd 不重啟**：擷取 daemon pid，全程（expose/connect/close 前後）不變。
+4. **teardown 乾淨**：`serialwrap remote close all` 後隧道行程消失、state 檔清空、`--endpoint` 復歸不可連。
+
+**執行與 CI**：docker 可用時列為必跑驗收；docker 不可用的環境明確 SKIP 並印原因（不靜默略過）。單元測試（11.1）恆入 CI。
+
+### 11.3 政策
+
+`python3 -m pytest -q tests/` 無新失敗；`python3 -m policy_check --repo .` 通過（R-09 fragment、R-16 help、R-18 docs 對齊）。
+
+## 12. 相依與相容性
+
+- 執行期需系統 `ssh`（`--autossh` 時另需 `autossh`）；`-R port:unix-socket` 需 OpenSSH ≥ 6.7（2014，現行發行版皆滿足）。
+- 純 CLI 便利層，向後相容：不改 `--endpoint`／daemon／RPC；既有手動 `ssh -R`/`-L` + `--endpoint` 流程照舊可用。
+
+## 13. 未來（defer）
+
+- `remote` 隧道健康的主動探測／自動重連（超出 `--autossh` 的部分）。
+- 多 UART host → 單 agent host 的 endpoint 名錄／自動選號。
+- Windows daemon 端 `device release`／remote 編排（對齊 #84 尚未完成的 Windows daemon 面）。

--- a/docs/superpowers/specs/2026-07-19-remote-tunnel-cli-design.md
+++ b/docs/superpowers/specs/2026-07-19-remote-tunnel-cli-design.md
@@ -87,7 +87,7 @@ serialwrap remote close all                  # 拆除全部
   - `--socket EP`：`-R` 時要暴露的本機 daemon endpoint（預設 = `_resolve_endpoint` 解析結果）。
   - `--remote-socket PATH`（**硬化模式**，R1 finding 1／R2 finding 1）：`-R` 時遠端改建 **unix socket** 而非 tcp loopback port，用檔案權限把關；**成對地** `-L` 亦以 `--remote-socket PATH` 指定要連的 relay-side unix socket（雙 NAT 全鏈需兩側配對，見 §4.2）。agent 端仍用回傳的 `tcp://127.0.0.1:<local>`。**共享／多租戶 relay 建議必開**；省略則預設 tcp loopback（便利但受 §8 殘留風險）。
   - `--ready-timeout S`：readiness 確認上限（預設 10s）；逾時仍未確認 forward 建立 → 回 `starting`（見 §4）。
-  - `--ssh-opt "..."`：透傳額外 ssh 參數（可重複），例如 `-o ServerAliveInterval=30`、`-p 2222`。
+  - `--ssh-opt "..."`：透傳額外 ssh 參數（可重複），例如 `-p 2222`、`-J jumphost`。
 - 所有子動作輸出緊湊 JSON（`ensure_ascii=False, separators=(",",":")`，含 `ok`），對齊 CLI 慣例。
 
 ## 4. 行為規格
@@ -176,7 +176,7 @@ serialwrap --endpoint tcp://127.0.0.1:7777 session list
 ## 5. 隧道 argv 組裝
 
 - 基底：`["ssh","-N","-T", *default_opts, *ssh_opts, direction_args, ssh_target]`，spawn 時 `stdin=DEVNULL`（配合 `BatchMode=yes`，禁互動認證卡死——finding 3）。
-- 預設 `-o`（可被 `--ssh-opt` 覆寫）：
+- 預設 `-o`（置於 `--ssh-opt` 前；OpenSSH 取同鍵首個，故這些預設**權威不可被 --ssh-opt 覆寫**，刻意固定 BatchMode／ExitOnForwardFailure／ControlPath 等）：
   - `BatchMode=yes`：禁密碼／passphrase 互動提示；認證只走金鑰／agent，失敗即退出而非卡住。
   - `ExitOnForwardFailure=yes`：forward 建不起即 ssh 退出，供 readiness 判死（配合 §4.0）。
   - `ControlMaster=auto`、`ControlPath=<run>/remote/cm-<id>`、`ControlPersist=no`：供 `ssh -O check` readiness 探測與精準 teardown。

--- a/sw_core/assets/skill/SKILL.md
+++ b/sw_core/assets/skill/SKILL.md
@@ -89,27 +89,26 @@ serialwrap 另提供原生 MCU flash 端點（與上面 device handoff 互補）
 - 若板子已卡在 bootloader prompt（`=> `／`U-Boot> `）：prpl-template 有 `bootloader_prompts`，用 `serialwrap session interactive-open --selector COM0 --allow-attached` 開 recovery lease 打 `boot` 脫困。
 - 若板子會 autoboot 載入壞 image、想**刻意中斷** autoboot（#114）：不必等它停在 `=> `——在倒數窗（RX 見 `Hit any key to stop autoboot`／`U-Boot` banner）即可 `serialwrap session interactive-open --selector COM0 --allow-attached` 搶開 lease（回應帶 `boot_interrupt: true`），再以 `interactive-send` 連打按鍵中斷 autoboot 停在 `=> ` 後救 fw。lease 送鍵不受 boot quiet window gate。
 
-## Remote Support 用法（ssh-tunnel）
-當 Agent 不在 target 所在機器上，而要從遠端 debug UART 時，走 **remote endpoint** 模式。
-- daemon 仍跑在 **target 所在主機**；Agent 端只透過 `--endpoint tcp://host:port` 連到遠端 daemon。
-- 正式環境優先使用 **ssh-tunnel**。
+## Remote Support 用法（serialwrap remote，ssh-tunnel）
 
-target 端（暴露 daemon socket，務必 bind 127.0.0.1）：
+Agent 要從遠端操作本機 UART 時：**在 UART host（daemon 所在機）** 跑一行反向隧道，agent 端照舊用 `--endpoint`。daemon 不重啟、不做預設。
+
 ```bash
-socat TCP-LISTEN:7777,bind=127.0.0.1,reuseaddr,fork \
-      UNIX-CONNECT:/run/serialwrap/serialwrapd.sock &
+# UART host（有 serialwrapd）：把本機 daemon 反向推到對端（-R 為預設）
+serialwrap remote tester@AGENT_OR_RELAY:7777
 ```
-（socket 路徑依監管模式：systemd-system 預設 `/run/serialwrap/serialwrapd.sock`；實際值見 `~/.config/serialwrap/config.yaml` 的 `socket_path`。）
-RD / Agent 端：
-```bash
-ssh -N -L 127.0.0.1:7777:127.0.0.1:7777 remote_user@target_host
-serialwrap --endpoint tcp://127.0.0.1:7777 session list
-```
-注意事項：
-- `serialwrap daemon start` 不支援 `--endpoint`。
-- `file push` / `file pull` 的 `--local` 路徑是 **daemon 所在 host/container** 的路徑，不是 Agent 本機路徑。
-- 正式環境 `socat` 必須 `bind=127.0.0.1`，不可直接暴露到外網。
-- 隔離煙測可跑 `./tools/docker/remote_smoke.sh`，不代表 production 暴露方式。
+
+Agent 端連線（依拓樸擇一）：
+
+- **direct**（agent host 就是上面 ssh 的對端）：直接
+  `serialwrap --endpoint tcp://127.0.0.1:7777 session list`
+- **relay / 雙 NAT**（agent 與 UART host 互不可達，各自對 relay 撥出）：agent 端先
+  `serialwrap remote -L tester@RELAY:7777`（回傳 `endpoint`），再用該 endpoint。
+
+管理：`serialwrap remote`（列隧道）、`serialwrap remote close 7777|all`（拆除）。
+回傳 `status`：`active`＝就緒可用；`starting`＝尚未確認（慢速認證／上游未就緒），需再 `remote status` 或重試。
+
+安全：隧道讓對端全權操控 DUT。**只用單租戶／可信 relay**；共享 relay 加 `--remote-socket /path`（遠端改建檔案權限把關的 unix socket）。`-R` tcp 模式若偵測遠端被 `GatewayPorts` 綁到對外，會拒絕（`REMOTE_BIND_UNVERIFIED`）。
 
 ## Event Trigger Engine
 用於 UART RX 觸發自動化 handler。**先呼叫 `serialwrap event status`** 確認狀態再 enable/disable，避免假設狀態。

--- a/sw_core/assets/skill/SKILL_WINDOWS.md
+++ b/sw_core/assets/skill/SKILL_WINDOWS.md
@@ -149,7 +149,17 @@ console listener 講 **Telnet**（server 主動協商 char-mode + 遠端回顯�
 | MCU 燒錄 | `/dev/ttyMCU` PTY-bridge（#55） | `device release` 釋放 COM → 外部燒錄工具獨佔 → `device attach` 收回（#54 語意） |
 | 單例防護 | flock + socket probe | msvcrt 檔鎖 + TCP probe |
 
-## 10. MCU 燒錄（device release / attach）
+## 10. Remote Support（native Windows：本期不支援 serialwrap remote）
+
+native Windows 執行 `serialwrap remote` 回 `REMOTE_NOT_SUPPORTED`。需遠端存取時**手動**建反向隧道：
+
+```powershell
+ssh -N -R 7777:127.0.0.1:48700 user@AGENT_OR_RELAY
+```
+
+（Windows daemon 為 TCP loopback `48700`。）agent 端照舊 `serialwrap --endpoint tcp://127.0.0.1:7777`。
+
+## 11. MCU 燒錄（device release / attach）
 
 Windows 燒錄工具直接獨佔開 `COMx`，serialwrap 只需讓出 handle：
 
@@ -159,7 +169,7 @@ serialwrap device release --selector COM0 --source agent:flash --reason "flash M
 serialwrap device attach --selector COM0
 ```
 
-## 11. 疑難排解
+## 12. 疑難排解
 
 - 任何指令連不上 → `serialwrap doctor` 看 `daemon_endpoint`；未在跑則
   `serialwrap daemon start`。

--- a/sw_core/cli.py
+++ b/sw_core/cli.py
@@ -703,6 +703,93 @@ def _run_skill(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_remote(args: argparse.Namespace) -> int:
+    """serialwrap remote 分派：words → status / close / open。
+
+    ``sw_core.remote_tunnel`` 於此延遲匯入（而非 cli.py 模組層級）：該模組硬依賴
+    ``fcntl``（POSIX-only），cli.py 頂層需在 Windows 也能正常 import，故不得在
+    模組層級引入；`guard_platform()` 在 open 分支對 native Windows fail-closed
+    拒絕（``REMOTE_NOT_SUPPORTED``），status／close 分支則本期不受限（純讀寫
+    ``<run_dir>/remote/`` 下的 state 檔）。全程例外皆經 ``except rt.TunnelError``
+    轉為 JSON，不讓例外穿越 CLI 邊界。
+    """
+    from . import remote_tunnel as rt  # noqa: PLC0415
+
+    run_dir = _remote_run_dir()
+    words = list(getattr(args, "words", []) or [])
+    try:
+        if not words or words[0] == "status":
+            _print(rt.status(run_dir))
+            return 0
+        if words[0] == "close":
+            selector = words[1] if len(words) > 1 else "all"
+            _print(rt.close(run_dir, selector))
+            return 0
+
+        rt.guard_platform()
+        if args.reverse and args.forward:
+            raise rt.TunnelError("INVALID_ARGS", "-R 與 -L 不可同時指定")
+        role = "connect" if args.forward else "expose"  # -R 預設
+        ssh_target, port = rt.parse_target(words[0])
+        rt.resolve_ssh_bin("autossh" if args.autossh else "ssh")
+
+        forward_src = None
+        if role == "expose":
+            forward_src = _forward_src_from_endpoint(_resolve_endpoint(args))
+
+        spec = rt.TunnelSpec(
+            role=role,
+            ssh_target=ssh_target,
+            port=port,
+            local=args.local,
+            forward_src=forward_src,
+            remote_socket=args.remote_socket,
+            via="autossh" if args.autossh else "ssh",
+            ssh_opts=tuple(args.ssh_opt),
+            ready_timeout=args.ready_timeout,
+        )
+        res = rt.open_tunnel(
+            spec,
+            run_dir,
+            spawner=rt.real_spawner,
+            runner=rt.make_runner(),
+            ping=rt.real_ping,
+        )
+        _print(res)
+        return 0
+    except rt.TunnelError as exc:
+        _print({"ok": False, "error_code": exc.code, "message": exc.message or exc.code})
+        return 1
+
+
+def _forward_src_from_endpoint(endpoint: str) -> str:
+    """把 ``_resolve_endpoint`` 解出的 endpoint 轉成 ssh ``-R`` 的本機轉發源。
+
+    unix endpoint → 原樣回傳 AF_UNIX 路徑；tcp endpoint → 改指 ``127.0.0.1:<port>``
+    （對端只需連到本機 loopback 上該 daemon 監聽的 port，host 部分無意義）。
+    """
+    transport, address = _parse_endpoint(endpoint)
+    if transport == "unix":
+        return address  # AF_UNIX 路徑
+    host, tcp_port = address
+    return f"127.0.0.1:{tcp_port}"
+
+
+def _remote_run_dir() -> str:
+    """remote state 落在 ``<run_dir>/remote/``。
+
+    **於呼叫時讀 env**（不可用 import-time ``constants.SOCKET_PATH`` 之類的凍結值）：
+    測試以 ``monkeypatch.setenv("SERIALWRAP_RUN_DIR", ...)`` 於 import 之後覆寫，
+    需要每次呼叫都即時生效，才能達到 per-test 隔離。
+    """
+    run = os.environ.get("SERIALWRAP_RUN_DIR")
+    if run and run.strip():
+        return os.path.expanduser(run)
+    from . import constants  # noqa: PLC0415
+
+    return constants.RUN_DIR
+
+
 def _run_doctor(args: argparse.Namespace) -> int:
     """執行環境診斷並印出 JSON 報告；advisory 項不影響整體 ok。"""
     report = run_doctor()
@@ -1115,6 +1202,54 @@ def build_parser() -> argparse.ArgumentParser:
     mcu_sub.add_parser("patterns", help="列出所有已知 MCU 家族 flash pattern（family／probe／expect／baud）")
     mcu_sub.add_parser("status", help="顯示 flash 端點狀態：候選 COM port 清單與目前是否 flashing")
 
+    p_remote = sub.add_parser(
+        "remote",
+        help="按需開關 ssh 反向隧道，讓遠端 agent 連本機 daemon（-R 預設 expose）",
+        description=(
+            "serialwrap remote：外包系統 ssh 建立 -R（expose，把本機 daemon 推到對端）／"
+            "-L（connect，relay 情境把對端 port 拉回本機 loopback）隧道，background 常駐。\n"
+            "  serialwrap remote user@host:7777        # -R 預設：expose 本機 daemon\n"
+            "  serialwrap remote -L user@relay:7777    # connect（relay/雙 NAT）\n"
+            "  serialwrap remote                        # 列目前隧道（status）\n"
+            "  serialwrap remote close 7777|all         # 拆除\n"
+            "安全：只透過 ssh-tunnel、單租戶/可信 relay 或 --remote-socket；不可對網路直接開放。"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p_remote.add_argument("words", nargs="*", help="[user@]host:port ｜ status ｜ close <port|all>")
+    # 註：-R/-L 刻意不用 add_mutually_exclusive_group()——argparse 對同群組 store_true
+    # 旗標的互斥是在 parse_args 當場 parser.error() → SystemExit(2)（usage 訊息印到
+    # stderr），會讓「同時給 -R -L」整條命令繞過 _run_remote() 的 try/except
+    # TunnelError，無法回傳本 CLI 一貫的機器可解析 JSON
+    # {"ok": false, "error_code": ...} 邊界契約（「例外不得穿越 CLI 邊界」慣例）。
+    # 改成兩個獨立旗標，互斥檢查留給 _run_remote() 內顯式判斷並 raise
+    # TunnelError("INVALID_ARGS")。
+    p_remote.add_argument("-R", dest="reverse", action="store_true", help="reverse/expose（預設）")
+    p_remote.add_argument("-L", dest="forward", action="store_true", help="forward/connect（relay）")
+    p_remote.add_argument("--autossh", action="store_true", help="以 autossh 斷線自動重連")
+    p_remote.add_argument("--local", type=int, default=None, help="-L 本機 loopback port（預設=對端 port）")
+    p_remote.add_argument(
+        "--remote-socket",
+        dest="remote_socket",
+        default=None,
+        help="硬化：-R 建遠端 unix socket／-L 連該 socket（共享 relay 建議）",
+    )
+    p_remote.add_argument(
+        "--ready-timeout",
+        dest="ready_timeout",
+        type=float,
+        default=10.0,
+        help="readiness 確認上限秒數（逾時回 starting）",
+    )
+    p_remote.add_argument(
+        "--ssh-opt",
+        dest="ssh_opt",
+        action="append",
+        default=[],
+        help="透傳額外 ssh 參數（可重複），如 --ssh-opt=-p --ssh-opt=2222",
+    )
+    # 註：--socket / --endpoint / --timeout 為既有全域參數，_resolve_endpoint 會取用。
+
     p_event = sub.add_parser(
         "event",
         help="event-trigger 規則註冊與 matcher 控制",
@@ -1451,6 +1586,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.cmd == "skill":
         return _run_skill(args)
+
+    if args.cmd == "remote":
+        return _run_remote(args)
 
     _print({"ok": False, "error_code": "INVALID_ARGS"})
     return 2

--- a/sw_core/cli.py
+++ b/sw_core/cli.py
@@ -708,16 +708,29 @@ def _run_remote(args: argparse.Namespace) -> int:
 
     ``sw_core.remote_tunnel`` 於此延遲匯入（而非 cli.py 模組層級）：該模組硬依賴
     ``fcntl``（POSIX-only），cli.py 頂層需在 Windows 也能正常 import，故不得在
-    模組層級引入；`guard_platform()` 在 open 分支對 native Windows fail-closed
-    拒絕（``REMOTE_NOT_SUPPORTED``），status／close 分支則本期不受限（純讀寫
-    ``<run_dir>/remote/`` 下的 state 檔）。全程例外皆經 ``except rt.TunnelError``
-    轉為 JSON，不讓例外穿越 CLI 邊界。
+    模組層級引入。在匯入之前先於此函式最頂端攔截 native Windows（``os.name ==
+    "nt"``），統一回 ``REMOTE_NOT_SUPPORTED`` JSON——涵蓋 status／close／open 三條
+    路徑，避免 ``import remote_tunnel`` 觸發的 ``ModuleNotFoundError``（缺
+    ``fcntl``）穿越此函式與 ``main()`` 變成原始 traceback。open 分支內的
+    ``rt.guard_platform()`` 為 defense-in-depth，保留不動。全程例外皆經
+    ``except rt.TunnelError`` 與 catch-all ``except Exception`` 轉為 JSON，不讓
+    例外穿越 CLI 邊界。
     """
+    if os.name == "nt":
+        _print(
+            {
+                "ok": False,
+                "error_code": "REMOTE_NOT_SUPPORTED",
+                "message": "native Windows 本期不支援 serialwrap remote；請手動 ssh -R（見 SKILL_WINDOWS.md）",
+            }
+        )
+        return 1
+
     from . import remote_tunnel as rt  # noqa: PLC0415
 
-    run_dir = _remote_run_dir()
-    words = list(getattr(args, "words", []) or [])
     try:
+        run_dir = _remote_run_dir()
+        words = list(getattr(args, "words", []) or [])
         if not words or words[0] == "status":
             _print(rt.status(run_dir))
             return 0
@@ -762,6 +775,9 @@ def _run_remote(args: argparse.Namespace) -> int:
         return 0
     except rt.TunnelError as exc:
         _print({"ok": False, "error_code": exc.code, "message": exc.message or exc.code})
+        return 1
+    except Exception as exc:  # noqa: BLE001 — 任何非預期例外不得穿越 CLI 邊界
+        _print({"ok": False, "error_code": "INTERNAL_ERROR", "message": str(exc)})
         return 1
 
 

--- a/sw_core/cli.py
+++ b/sw_core/cli.py
@@ -743,6 +743,11 @@ def _run_remote(args: argparse.Namespace) -> int:
         if args.reverse and args.forward:
             raise rt.TunnelError("INVALID_ARGS", "-R 與 -L 不可同時指定")
         role = "connect" if args.forward else "expose"  # -R 預設
+        # --local 僅對 -L（connect）有意義；-R/預設帶入視為誤用，早擋而非交給 ssh 晚爆
+        if args.local is not None and role == "expose":
+            raise rt.TunnelError("INVALID_ARGS", "--local 僅用於 -L（connect）")
+        if args.local is not None and not (1 <= args.local <= 65535):
+            raise rt.TunnelError("INVALID_ARGS", f"--local 超出範圍：{args.local}")
         ssh_target, port = rt.parse_target(words[0])
         rt.resolve_ssh_bin("autossh" if args.autossh else "ssh")
 

--- a/sw_core/cli.py
+++ b/sw_core/cli.py
@@ -735,7 +735,10 @@ def _run_remote(args: argparse.Namespace) -> int:
 
         forward_src = None
         if role == "expose":
-            forward_src = _forward_src_from_endpoint(_resolve_endpoint(args))
+            try:
+                forward_src = _forward_src_from_endpoint(_resolve_endpoint(args))
+            except ValueError as exc:
+                raise rt.TunnelError("INVALID_ENDPOINT", str(exc)) from exc
 
         spec = rt.TunnelSpec(
             role=role,

--- a/sw_core/remote_tunnel.py
+++ b/sw_core/remote_tunnel.py
@@ -477,8 +477,10 @@ def open_tunnel(
             alive=lambda: pid_alive(pid, start_ticks),
             stderr_tail=stderr_tail,
         )
-    except TunnelError:
-        # fail-closed：拆除已 spawn 的行程群組並移除 state，不留下暴露隧道。
+    except BaseException:
+        # fail-closed：teardown 對任何 readiness 例外都要觸發（不只 TunnelError；
+        # 含 probe 逾時、Ctrl-C 等），拆除已 spawn 的行程群組並移除 state，
+        # 不留下暴露隧道，再原樣 re-raise。
         _terminate_pgid(pgid, sleep=sleep)
         with reg.lock():
             reg.remove(listen_port)
@@ -635,10 +637,19 @@ def real_spawner(
 def make_runner() -> Callable[[list[str]], tuple[int, str]]:
     """回傳 real `subprocess.run` runner，供 `make_ssh_check`／`make_role_probe` 的 `runner` 參數注入。"""
     def _run(argv: list[str]) -> tuple[int, str]:
-        proc = subprocess.run(
-            argv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-            text=True, timeout=10.0, check=False,
-        )
+        try:
+            proc = subprocess.run(
+                argv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                text=True, timeout=10.0, check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            # probe 逾時視為「未就緒」而非崩潰：保持在 readiness 狀態機內
+            # （回傳非 0 rc → role_probe/ssh_check 判 False → wait_ready 續 poll
+            # 或逾時回 "starting"），不讓 TimeoutExpired 穿越到 open_tunnel。
+            partial = exc.output or ""
+            if isinstance(partial, bytes):
+                partial = partial.decode("utf-8", "replace")
+            return 124, f"probe timeout: {partial}"[:500]
         return proc.returncode, proc.stdout or ""
     return _run
 

--- a/sw_core/remote_tunnel.py
+++ b/sw_core/remote_tunnel.py
@@ -219,6 +219,11 @@ class Registry:
         """狀態檔路徑。"""
         return os.path.join(self.remote_dir, f"{listen_port}.json")
 
+    def log_path(self, listen_port: int) -> str:
+        """spawn log 路徑（ssh/autossh stdout+stderr 導向處）；單一事實來源，
+        `open_tunnel` 與 `remove()` 皆須經此取得，避免路徑格式各自為政。"""
+        return os.path.join(self.remote_dir, f"{listen_port}.log")
+
     def write(self, state: dict) -> None:
         """原子寫入狀態（先 tmp 再 replace）。"""
         self._ensure_dir()
@@ -253,8 +258,8 @@ class Registry:
         return out
 
     def remove(self, listen_port: int) -> None:
-        """刪除隧道狀態與控制端點。"""
-        for p in (self.state_path(listen_port), self.control_path(listen_port)):
+        """刪除隧道狀態、控制端點與 spawn log（三者同生命週期，避免 `.log` 隨重試累積殘留）。"""
+        for p in (self.state_path(listen_port), self.control_path(listen_port), self.log_path(listen_port)):
             with contextlib.suppress(OSError):
                 os.unlink(p)
 
@@ -449,7 +454,7 @@ def open_tunnel(
                 )
             reg.remove(listen_port)  # 死 state → 視為過期，覆寫
 
-        log_path = os.path.join(reg.remote_dir, f"{listen_port}.log")
+        log_path = reg.log_path(listen_port)
         pid, pgid, start_ticks, stderr_tail = spawner(build_argv(spec, control_path), control_path, log_path)
         state = {
             "identity": identity, "status": "spawning", "role": spec.role,

--- a/sw_core/remote_tunnel.py
+++ b/sw_core/remote_tunnel.py
@@ -250,3 +250,69 @@ class Registry:
         for p in (self.state_path(listen_port), self.control_path(listen_port)):
             with contextlib.suppress(OSError):
                 os.unlink(p)
+
+
+def endpoint_for(spec: TunnelSpec) -> str:
+    """回傳本機可探測的 endpoint（`-L`／direct 皆落在本機 loopback）。"""
+    local = spec.local if spec.local is not None else spec.port
+    return f"tcp://127.0.0.1:{local}"
+
+
+def make_ssh_check(
+    spec: TunnelSpec,
+    control_path: str,
+    *,
+    runner: Callable[[list[str]], tuple[int, str]],
+) -> Callable[[], bool]:
+    """回傳 `() -> bool`：以既有 master 連線跑 `ssh -O check` 確認 control socket 存活。"""
+    def _check() -> bool:
+        rc, _ = runner(["ssh", "-O", "check", "-o", f"ControlPath={control_path}", spec.ssh_target])
+        return rc == 0
+    return _check
+
+
+def make_role_probe(
+    spec: TunnelSpec,
+    control_path: str,
+    endpoint: str,
+    *,
+    runner: Callable[[list[str]], tuple[int, str]],
+    ping: Callable[[str], bool],
+) -> Callable[[], bool]:
+    """回傳 `() -> bool`：依 role 選擇對應 readiness 判定，可 raise TunnelError（REMOTE_BIND_UNVERIFIED）。
+
+    - connect：以 `ping(endpoint)` 驗證本機端可用。
+    - expose + remote_socket（unix）：遠端 bind 天然限定於該 socket 路徑，fail-closed 免驗證。
+    - expose + tcp：借 master 連線在 relay 端跑 `ss` 驗遠端 bind 為 loopback；
+      查不到／查失敗／wildcard bind 一律視為不安全，raise REMOTE_BIND_UNVERIFIED。
+    """
+    def _probe() -> bool:
+        if spec.role == "connect":
+            return bool(ping(endpoint))
+        # expose：unix socket 模式天然 fail-closed，免 ss 驗證
+        if spec.remote_socket:
+            return True
+        # tcp 模式：以 master 連線在 relay 跑 ss，驗遠端 bind 為 loopback（fail-closed）
+        rc, out = runner([
+            "ssh", "-o", f"ControlPath={control_path}", spec.ssh_target,
+            "ss", "-ltnH", f"sport = :{spec.port}",
+        ])
+        if rc != 0 or not out.strip():
+            raise TunnelError("REMOTE_BIND_UNVERIFIED", "無法在 relay 驗證遠端 bind")
+        if _bind_has_wildcard(out, spec.port):
+            raise TunnelError("REMOTE_BIND_UNVERIFIED", out.strip()[:200])
+        return True
+    return _probe
+
+
+def _bind_has_wildcard(ss_out: str, port: int) -> bool:
+    """ss 輸出中該 port 是否綁在非 loopback 位址（0.0.0.0 / :: / *）。"""
+    for line in ss_out.splitlines():
+        if f":{port}" not in line:
+            continue
+        for tok in line.split():
+            if tok.endswith(f":{port}"):
+                addr = tok.rsplit(":", 1)[0].strip("[]")
+                if addr in ("0.0.0.0", "::", "*", ""):
+                    return True
+    return False

--- a/sw_core/remote_tunnel.py
+++ b/sw_core/remote_tunnel.py
@@ -142,6 +142,41 @@ def pid_alive(pid: int, start_ticks: int | None) -> bool:
     return current == start_ticks
 
 
+_POLL_INTERVAL_S = 0.2
+
+
+def wait_ready(
+    spec: TunnelSpec,
+    pid: int,
+    start_ticks: int | None,
+    *,
+    ssh_check,          # () -> bool：master 連線＋forward 建立
+    role_probe,         # () -> bool：-R 遠端 bind loopback；-L health.ping。可 raise TunnelError
+    sleep,              # (float) -> None
+    monotonic,          # () -> float
+    alive,              # () -> bool：行程是否仍活
+    stderr_tail,        # () -> str：spawn log 的 stderr 尾（供 TUNNEL_SPAWN_FAILED）
+) -> str:
+    """回 'active'（就緒）或 'starting'（逾時但行程仍活）；行程死亡 → TUNNEL_SPAWN_FAILED。
+
+    role_probe 可 raise TunnelError（例如 REMOTE_BIND_UNVERIFIED），會直接傳播。
+    """
+    deadline = monotonic() + spec.ready_timeout
+    while True:
+        if not alive():
+            # 行程已死亡，取得 stderr 尾並拋出錯誤
+            tail = (stderr_tail() or "").strip()
+            # 僅保留最後 500 字元（避免長文本）
+            if len(tail) > 500:
+                tail = tail[-500:]
+            raise TunnelError("TUNNEL_SPAWN_FAILED", tail)
+        if ssh_check() and role_probe():   # role_probe 可 raise（REMOTE_BIND_UNVERIFIED）
+            return "active"
+        if monotonic() >= deadline:
+            return "starting"
+        sleep(_POLL_INTERVAL_S)
+
+
 class Registry:
     """`<run_dir>/remote/` 下的 per-tunnel state JSON + flock 序列化。"""
 

--- a/sw_core/remote_tunnel.py
+++ b/sw_core/remote_tunnel.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 # `[user@]host:port`——host 允許 ssh_config alias（不含 '@'/':' 的一段）。
 _TARGET_RE = re.compile(r"^(?:(?P<user>[^@:]+)@)?(?P<host>[^@:]+):(?P<port>\d+)$")
@@ -65,3 +65,39 @@ def compute_identity(spec: TunnelSpec) -> str:
         )
     )
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def default_ssh_opts(control_path: str) -> list[str]:
+    """readiness／安全預設 -o（可被使用者 --ssh-opt 覆寫，故置於其前）。"""
+    return [
+        "-o", "BatchMode=yes",            # 禁互動認證，失敗即退出不卡死
+        "-o", "ExitOnForwardFailure=yes",  # forward 建不起即退出，供 readiness 判死
+        "-o", "ControlMaster=auto",
+        "-o", f"ControlPath={control_path}",
+        "-o", "ControlPersist=no",
+        "-o", "ServerAliveInterval=30",
+        "-o", "ServerAliveCountMax=3",
+    ]
+
+
+def _direction_args(spec: TunnelSpec) -> list[str]:
+    """組裝 -R 或 -L 與其隧道規格（bind:destination）。"""
+    if spec.role == "expose":
+        if spec.remote_socket:
+            bind = spec.remote_socket                      # 遠端 unix socket（硬化）
+        else:
+            bind = f"127.0.0.1:{spec.port}"                # 顯式遠端 loopback bind
+        return ["-R", f"{bind}:{spec.forward_src}"]
+    # connect：顯式本機 loopback bind
+    local = spec.local if spec.local is not None else spec.port
+    dest = spec.remote_socket if spec.remote_socket else f"localhost:{spec.port}"
+    return ["-L", f"127.0.0.1:{local}:{dest}"]
+
+
+def build_argv(spec: TunnelSpec, control_path: str) -> list[str]:
+    """完整 ssh/autossh argv（含方向 -R/-L、預設 -o、--ssh-opt 透傳、target）。"""
+    base = ["autossh", "-M", "0"] if spec.via == "autossh" else ["ssh"]
+    argv = [*base, "-N", "-T", *default_ssh_opts(control_path), *spec.ssh_opts]
+    argv += _direction_args(spec)
+    argv.append(spec.ssh_target)
+    return argv

--- a/sw_core/remote_tunnel.py
+++ b/sw_core/remote_tunnel.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import os
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 
 # `[user@]host:port`——host 允許 ssh_config alias（不含 '@'/':' 的一段）。
@@ -150,12 +151,12 @@ def wait_ready(
     pid: int,
     start_ticks: int | None,
     *,
-    ssh_check,          # () -> bool：master 連線＋forward 建立
-    role_probe,         # () -> bool：-R 遠端 bind loopback；-L health.ping。可 raise TunnelError
-    sleep,              # (float) -> None
-    monotonic,          # () -> float
-    alive,              # () -> bool：行程是否仍活
-    stderr_tail,        # () -> str：spawn log 的 stderr 尾（供 TUNNEL_SPAWN_FAILED）
+    ssh_check: Callable[[], bool],          # master 連線＋forward 建立
+    role_probe: Callable[[], bool],         # -R 遠端 bind loopback；-L health.ping。可 raise TunnelError
+    sleep: Callable[[float], None],         # sleep(float)
+    monotonic: Callable[[], float],         # 單調時鐘 epoch (float)
+    alive: Callable[[], bool],              # 行程是否仍活
+    stderr_tail: Callable[[], str],         # spawn log 的 stderr 尾（供 TUNNEL_SPAWN_FAILED）
 ) -> str:
     """回 'active'（就緒）或 'starting'（逾時但行程仍活）；行程死亡 → TUNNEL_SPAWN_FAILED。
 

--- a/sw_core/remote_tunnel.py
+++ b/sw_core/remote_tunnel.py
@@ -486,6 +486,77 @@ def open_tunnel(
     return {"ok": True, **_public(state)}
 
 
+def status(run_dir: str) -> dict:
+    """列出所有隧道；就地 prune 已死的 state，並掃描孤兒 control socket。
+
+    pid<=0（缺 pid 欄位的殘缺 state）一律視為死亡並 prune，不呼叫
+    `pid_alive()`（同 `open_tunnel` 的 pid<=0 守衛慣例：`os.kill(-1, 0)` 會
+    POSIX-broadcast 且無條件成功，會把殘缺 state 誤判為存活）。
+    """
+    reg = Registry(run_dir)
+    tunnels: list[dict] = []
+    with reg.lock():
+        for st in reg.read_all():
+            pid = int(st.get("pid", -1))
+            if pid > 0 and pid_alive(pid, st.get("pid_start_ticks")):
+                out = _public(st)
+                out["alive"] = True
+                tunnels.append(out)
+            else:
+                reg.remove(int(st["listen_port"]))  # prune 死 state
+        # orphan scan：cm-* control socket 檔案存在卻無對應 state
+        # （ssh master 仍活著，但 state 遺失／未寫入的孤兒）。
+        try:
+            for name in sorted(os.listdir(reg.remote_dir)):
+                if name.startswith("cm-") and not reg.read(_port_of_cm(name)):
+                    tunnels.append({
+                        "status": "orphan",
+                        "control_path": os.path.join(reg.remote_dir, name),
+                        "alive": True,
+                    })
+        except OSError:
+            pass
+    return {"ok": True, "tunnels": tunnels}
+
+
+def _port_of_cm(name: str) -> int:
+    """從 `cm-<port>` 控制端點檔名解析 port；解析失敗回 -1（不會命中任何 state）。"""
+    try:
+        return int(name[len("cm-"):])
+    except ValueError:
+        return -1
+
+
+def close(run_dir: str, selector: str | int, *, sleep: Callable[[float], None] = time.sleep) -> dict:
+    """依 `selector`（port 或 `"all"`）關閉隧道：驗活 → killpg 整組行程 → wait → remove。
+
+    找不到對應 port（已被 prune 或本就不存在）視為冪等 no-op，回
+    `{"ok": True, "closed": []}`，不視為錯誤。`_terminate_pgid` 拆除失敗時
+    保留 `status="error"` 的 state（不 remove），供後續人工排查；pid<=0
+    的殘缺 state 直接跳過 killpg、視為已死並 remove（同 `status` 的守衛慣例）。
+    """
+    reg = Registry(run_dir)
+    closed: list[int] = []
+    with reg.lock():
+        targets = reg.read_all()
+        if str(selector) != "all":
+            targets = [s for s in targets if str(s.get("listen_port")) == str(selector)]
+        for st in targets:
+            port = int(st["listen_port"])
+            pid = int(st.get("pid", -1))
+            pgid = int(st.get("pgid", pid))
+            if pid > 0 and pid_alive(pid, st.get("pid_start_ticks")):
+                try:
+                    _terminate_pgid(pgid, sleep=sleep)
+                except Exception:  # noqa: BLE001 — 拆除失敗不讓例外穿越 RPC/CLI 邊界，改記錄 error 狀態
+                    st["status"] = "error"
+                    reg.write(st)
+                    continue
+            reg.remove(port)
+            closed.append(port)
+    return {"ok": True, "closed": closed}
+
+
 def _public(state: dict) -> dict:
     """對外可見欄位（去掉 control_path 等內部細節）。"""
     keys = ("status", "role", "pid", "listen_port", "target", "remote_bind",

--- a/sw_core/remote_tunnel.py
+++ b/sw_core/remote_tunnel.py
@@ -12,11 +12,15 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import signal
+import subprocess
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Protocol
+
+from .client import rpc_call as _rpc_call
 
 # `[user@]host:port`——host 允許 ssh_config alias（不含 '@'/':' 的一段）。
 _TARGET_RE = re.compile(r"^(?:(?P<user>[^@:]+)@)?(?P<host>[^@:]+):(?P<port>\d+)$")
@@ -568,3 +572,80 @@ def _public(state: dict) -> dict:
             f"{state.get('endpoint', 'tcp://127.0.0.1:%d' % state['listen_port'])}"
         )
     return out
+
+
+def guard_platform() -> None:
+    """本期 remote 隧道僅支援 POSIX；native Windows 明確拒絕（改走手動 ssh -R）。"""
+    if os.name == "nt":
+        raise TunnelError(
+            "REMOTE_NOT_SUPPORTED",
+            "native Windows 本期不支援 serialwrap remote；請手動 ssh -R（見 SKILL_WINDOWS.md）",
+        )
+
+
+def resolve_ssh_bin(via: str) -> str:
+    """以 `shutil.which` 探索 ssh／autossh 執行檔路徑；PATH 找不到即 fail-closed。"""
+    name = "autossh" if via == "autossh" else "ssh"
+    path = shutil.which(name)
+    if not path:
+        raise TunnelError("SSH_NOT_FOUND", f"PATH 找不到 {name}")
+    return path
+
+
+def real_spawner(
+    argv: list[str], control_path: str, log_path: str
+) -> tuple[int, int, int | None, Callable[[], str]]:
+    """以 `subprocess.Popen` 背景常駐產生 ssh/autossh 行程，供 `open_tunnel` 的 `spawner` 參數注入。
+
+    `start_new_session=True` 讓子行程獨立成一個新 process group（獨立 pgid），
+    供之後 `_terminate_pgid()` 以 `killpg` 整組拆除（含 ssh 本身衍生的子行程）；
+    stdout/stderr 皆導向 `log_path`，供 readiness 失敗時的 `stderr_tail_fn` 讀取
+    診斷訊息。父行程端的 log handle 在 `Popen` 後即關閉——子行程已透過
+    `stdout=`/`stderr=` 取得自己 dup 過的 fd，父行程端保留原 handle 只會洩漏 fd。
+    """
+    os.makedirs(os.path.dirname(control_path), exist_ok=True)
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    log = open(log_path, "ab", buffering=0)
+    try:
+        proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=log,
+            stderr=log,
+            start_new_session=True,
+            close_fds=True,
+        )
+    finally:
+        log.close()  # 子行程已 dup 走自己的 fd；父行程端不再需要，避免 fd 洩漏
+    pgid = os.getpgid(proc.pid)
+    start_ticks = read_pid_start_ticks(proc.pid)
+
+    def _stderr_tail() -> str:
+        """讀取 spawn log 尾端（供 `TUNNEL_SPAWN_FAILED` 附診斷訊息）；每次呼叫以路徑重新開檔，
+        不依賴上方已關閉的 `log` handle。"""
+        try:
+            with open(log_path, "rb") as fh:
+                return fh.read()[-500:].decode("utf-8", "replace")
+        except OSError:
+            return ""
+
+    return proc.pid, pgid, start_ticks, _stderr_tail
+
+
+def make_runner() -> Callable[[list[str]], tuple[int, str]]:
+    """回傳 real `subprocess.run` runner，供 `make_ssh_check`／`make_role_probe` 的 `runner` 參數注入。"""
+    def _run(argv: list[str]) -> tuple[int, str]:
+        proc = subprocess.run(
+            argv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, timeout=10.0, check=False,
+        )
+        return proc.returncode, proc.stdout or ""
+    return _run
+
+
+def real_ping(endpoint: str) -> bool:
+    """以既有 RPC client 呼叫 `health.ping` 探測 endpoint 是否就緒；任何例外一律視為未就緒。"""
+    try:
+        return bool(_rpc_call(endpoint, "health.ping", {}, timeout_s=2.0).get("ok"))
+    except Exception:  # noqa: BLE001 — probe 失敗不讓例外穿越，僅視為未就緒
+        return False

--- a/sw_core/remote_tunnel.py
+++ b/sw_core/remote_tunnel.py
@@ -299,20 +299,31 @@ def make_role_probe(
         ])
         if rc != 0 or not out.strip():
             raise TunnelError("REMOTE_BIND_UNVERIFIED", "無法在 relay 驗證遠端 bind")
-        if _bind_has_wildcard(out, spec.port):
+        if not _bind_is_loopback_only(out, spec.port):
             raise TunnelError("REMOTE_BIND_UNVERIFIED", out.strip()[:200])
         return True
     return _probe
 
 
-def _bind_has_wildcard(ss_out: str, port: int) -> bool:
-    """ss 輸出中該 port 是否綁在非 loopback 位址（0.0.0.0 / :: / *）。"""
+def _bind_is_loopback_only(ss_out: str, port: int) -> bool:
+    """ss 輸出中該 port 的所有 bind 位址是否皆為 loopback（allowlist，fail-closed）。
+
+    掃描每一行，取所有以 `:{port}` 結尾的 token，解出位址（`rsplit(":", 1)`
+    取冒號前段，並去除 IPv6 的方括號）。只要找到至少一個 bind token，且全部
+    位址皆屬於 loopback（`127.0.0.1`／`127.*`／`::1`），才回傳 True。
+
+    任何非 loopback 位址（wildcard `0.0.0.0`/`::`/`*`/空字串、特定介面 IP 如
+    `10.0.0.5`、global IPv6 等）→ 回傳 False。完全找不到 bind token → 回傳
+    False（fail-closed，寧可誤判不安全也不誤判安全）。
+    """
+    found = False
     for line in ss_out.splitlines():
         if f":{port}" not in line:
             continue
         for tok in line.split():
             if tok.endswith(f":{port}"):
                 addr = tok.rsplit(":", 1)[0].strip("[]")
-                if addr in ("0.0.0.0", "::", "*", ""):
-                    return True
-    return False
+                found = True
+                if not (addr == "127.0.0.1" or addr.startswith("127.") or addr == "::1"):
+                    return False
+    return found

--- a/sw_core/remote_tunnel.py
+++ b/sw_core/remote_tunnel.py
@@ -1,0 +1,67 @@
+"""serialwrap `remote` 隧道便利層（純 CLI，daemon 零改動）。
+
+外包給系統 ssh 建立 `-R`（expose）／`-L`（connect）隧道，background 常駐、
+flock registry 管理、readiness 確認。設計見
+docs/superpowers/specs/2026-07-19-remote-tunnel-cli-design.md。
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+
+# `[user@]host:port`——host 允許 ssh_config alias（不含 '@'/':' 的一段）。
+_TARGET_RE = re.compile(r"^(?:(?P<user>[^@:]+)@)?(?P<host>[^@:]+):(?P<port>\d+)$")
+
+
+class TunnelError(Exception):
+    """攜帶 error_code 的隧道錯誤；不讓例外穿越 CLI 邊界。"""
+
+    def __init__(self, code: str, message: str | None = None) -> None:
+        super().__init__(message or code)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class TunnelSpec:
+    role: str  # "expose" | "connect"
+    ssh_target: str
+    port: int
+    local: int | None = None
+    forward_src: str | None = None
+    remote_socket: str | None = None
+    via: str = "ssh"  # "ssh" | "autossh"
+    ssh_opts: tuple[str, ...] = ()
+    ready_timeout: float = 10.0
+
+
+def parse_target(target: str) -> tuple[str, int]:
+    m = _TARGET_RE.match(target or "")
+    if not m:
+        raise TunnelError("INVALID_TARGET", f"target 需為 [user@]host:port，取得 {target!r}")
+    port = int(m.group("port"))
+    if not (1 <= port <= 65535):
+        raise TunnelError("INVALID_TARGET", f"port 超出範圍：{port}")
+    user = m.group("user")
+    host = m.group("host")
+    ssh_target = f"{user}@{host}" if user else host
+    return ssh_target, port
+
+
+def compute_identity(spec: TunnelSpec) -> str:
+    # canonical effective forward spec：涵蓋所有會改變入口／目的地的欄位。
+    canonical = "|".join(
+        str(x)
+        for x in (
+            spec.role,
+            spec.ssh_target,
+            spec.port,
+            spec.local,
+            spec.forward_src,
+            spec.remote_socket,
+            spec.via,
+            ";".join(spec.ssh_opts),
+        )
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/sw_core/remote_tunnel.py
+++ b/sw_core/remote_tunnel.py
@@ -68,7 +68,7 @@ def compute_identity(spec: TunnelSpec) -> str:
 
 
 def default_ssh_opts(control_path: str) -> list[str]:
-    """readiness／安全預設 -o（可被使用者 --ssh-opt 覆寫，故置於其前）。"""
+    """readiness／安全預設 -o。置於使用者 --ssh-opt 之前：OpenSSH 取同鍵的第一個 -o，故這些預設為權威、使用者 --ssh-opt 無法覆寫（BatchMode／ExitOnForwardFailure／ControlPath 等必須固定，刻意如此）。"""
     return [
         "-o", "BatchMode=yes",            # 禁互動認證，失敗即退出不卡死
         "-o", "ExitOnForwardFailure=yes",  # forward 建不起即退出，供 readiness 判死

--- a/sw_core/remote_tunnel.py
+++ b/sw_core/remote_tunnel.py
@@ -12,8 +12,11 @@ import hashlib
 import json
 import os
 import re
+import signal
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Protocol
 
 # `[user@]host:port`——host 允許 ssh_config alias（不含 '@'/':' 的一段）。
 _TARGET_RE = re.compile(r"^(?:(?P<user>[^@:]+)@)?(?P<host>[^@:]+):(?P<port>\d+)$")
@@ -327,3 +330,144 @@ def _bind_is_loopback_only(ss_out: str, port: int) -> bool:
                 if not (addr == "127.0.0.1" or addr.startswith("127.") or addr == "::1"):
                     return False
     return found
+
+
+class _Clock(Protocol):
+    """注入時鐘介面（結構化型別）：需提供 `monotonic()` 與 `sleep(seconds)`。
+
+    預設不注入時直接使用標準函式庫 `time` 模組（其 `monotonic`/`sleep`
+    天然滿足此介面）；測試可注入假時鐘加速 readiness 輪詢。
+    """
+
+    def monotonic(self) -> float: ...
+
+    def sleep(self, seconds: float) -> None: ...
+
+
+def _terminate_pgid(
+    pgid: int,
+    *,
+    timeout: float = 5.0,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    """SIGTERM 後有界等待行程群組消失，逾時仍存活才 SIGKILL（fail-closed 拆除）。
+
+    用於 `open_tunnel` readiness 失敗時的收尾：確保不留下已 spawn 但未驗證
+    安全性（例如遠端 bind 未經確認為 loopback）的隧道行程。`ProcessLookupError`
+    （群組已消失）／`PermissionError`（非我方行程，理論上不會發生）皆吞掉，
+    不讓拆除動作本身拋例外。
+    """
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(pgid, signal.SIGTERM)
+    waited = 0.0
+    while waited < timeout:
+        try:
+            os.killpg(pgid, 0)  # 存活探測：不送訊號，僅檢查群組是否還在
+        except ProcessLookupError:
+            return
+        sleep(0.1)
+        waited += 0.1
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(pgid, signal.SIGKILL)
+
+
+def open_tunnel(
+    spec: TunnelSpec,
+    run_dir: str,
+    *,
+    spawner: Callable[[list[str], str, str], tuple[int, int, int | None, Callable[[], str]]],
+    runner: Callable[[list[str]], tuple[int, str]],
+    ping: Callable[[str], bool],
+    ssh_check_factory: Callable[..., Callable[[], bool]] = make_ssh_check,
+    role_probe_factory: Callable[..., Callable[[], bool]] = make_role_probe,
+    clock: _Clock | None = None,
+) -> dict:
+    """編排單一隧道的完整開啟流程：spawn → durable state → readiness → active/starting。
+
+    流程（`spawner(argv, control_path, log_path) -> (pid, pgid, start_ticks, stderr_tail_fn)`）：
+
+    1. 持 `Registry.lock()`：identity 衝突檢查 → `spawner` 產生行程 →
+       **立即寫入 `status="spawning"` 的 durable state** → 釋放鎖。
+       （不在鎖內跑 readiness，避免長時間輪詢阻塞 `remote list`/`remote close`
+       等其他需要鎖的操作。）
+    2. 鎖外跑 `wait_ready`：成功回 `active`／`starting`，重新取鎖寫回 state。
+    3. `wait_ready` raise `TunnelError`（含 `REMOTE_BIND_UNVERIFIED`、
+       `TUNNEL_SPAWN_FAILED`）→ **fail-closed**：`_terminate_pgid()` 拆除已 spawn
+       的行程群組，並移除 durable state（不留下未驗證安全性的暴露隧道），
+       然後 re-raise。
+
+    同 `listen_port` 已有存活且相同 identity 的隧道視為冪等（`already_running`
+    no-op）；存活但不同 identity 視為衝突（raise `TUNNEL_CONFLICT`，避免竊佔
+    他人隧道或造成埠位混用）；已死亡的殘留 state 視為過期，覆寫重來。
+    """
+    reg = Registry(run_dir)
+    listen_port = spec.local if (spec.role == "connect" and spec.local is not None) else spec.port
+    identity = compute_identity(spec)
+    control_path = reg.control_path(listen_port)
+
+    # ── identity 衝突檢查 → spawn → 立即寫 durable state（持鎖）──
+    with reg.lock():
+        existing = reg.read(listen_port)
+        if existing:
+            alive = pid_alive(int(existing.get("pid", -1)), existing.get("pid_start_ticks"))
+            if alive and existing.get("identity") == identity:
+                return {"ok": True, "already_running": True, **_public(existing)}
+            if alive and existing.get("identity") != identity:
+                raise TunnelError(
+                    "TUNNEL_CONFLICT",
+                    f"port {listen_port} 已有不同 identity 的隧道，請先 remote close {listen_port}",
+                )
+            reg.remove(listen_port)  # 死 state → 視為過期，覆寫
+
+        log_path = os.path.join(reg.remote_dir, f"{listen_port}.log")
+        pid, pgid, start_ticks, stderr_tail = spawner(build_argv(spec, control_path), control_path, log_path)
+        state = {
+            "identity": identity, "status": "spawning", "role": spec.role,
+            "pid": pid, "pgid": pgid, "pid_start_ticks": start_ticks,
+            "target": spec.ssh_target, "listen_port": listen_port,
+            "remote_bind": spec.remote_socket or f"127.0.0.1:{spec.port}",
+            "forward_target": spec.forward_src, "via": spec.via,
+            "control_path": control_path, "endpoint": endpoint_for(spec),
+        }
+        reg.write(state)
+
+    # ── readiness（不持鎖，避免阻塞其他操作）──
+    active_clock: _Clock = clock or time  # type: ignore[assignment]
+    monotonic = active_clock.monotonic
+    sleep = active_clock.sleep
+    endpoint = endpoint_for(spec)
+    ssh_check = ssh_check_factory(spec, control_path, runner=runner)
+    role_probe = role_probe_factory(spec, control_path, endpoint, runner=runner, ping=ping)
+
+    try:
+        status = wait_ready(
+            spec, pid, start_ticks,
+            ssh_check=ssh_check, role_probe=role_probe,
+            sleep=sleep, monotonic=monotonic,
+            alive=lambda: pid_alive(pid, start_ticks),
+            stderr_tail=stderr_tail,
+        )
+    except TunnelError:
+        # fail-closed：拆除已 spawn 的行程群組並移除 state，不留下暴露隧道。
+        _terminate_pgid(pgid, sleep=sleep)
+        with reg.lock():
+            reg.remove(listen_port)
+        raise
+
+    with reg.lock():
+        state["status"] = status
+        reg.write(state)
+    return {"ok": True, **_public(state)}
+
+
+def _public(state: dict) -> dict:
+    """對外可見欄位（去掉 control_path 等內部細節）。"""
+    keys = ("status", "role", "pid", "listen_port", "target", "remote_bind",
+            "forward_target", "via", "endpoint", "identity")
+    out = {k: state[k] for k in keys if k in state}
+    if state.get("role") == "expose":
+        out["remote_hint"] = (
+            f"agent 端用 serialwrap --endpoint "
+            f"{state.get('endpoint', 'tcp://127.0.0.1:%d' % state['listen_port'])}"
+        )
+    return out

--- a/sw_core/remote_tunnel.py
+++ b/sw_core/remote_tunnel.py
@@ -344,6 +344,20 @@ class _Clock(Protocol):
     def sleep(self, seconds: float) -> None: ...
 
 
+def _reap_pgid(pgid: int) -> None:
+    """reap 已結束的同群子行程，避免 zombie 讓 killpg(pgid,0) 誤判仍存活。
+
+    僅在本行程為該子行程之父時有效（生產 CLI 與測試皆是）；非父行程時 os.waitpid
+    會拋 ChildProcessError，靜默忽略。"""
+    while True:
+        try:
+            reaped, _ = os.waitpid(-pgid, os.WNOHANG)
+        except (ChildProcessError, ProcessLookupError, OSError):
+            return
+        if reaped == 0:
+            return
+
+
 def _terminate_pgid(
     pgid: int,
     *,
@@ -356,11 +370,19 @@ def _terminate_pgid(
     安全性（例如遠端 bind 未經確認為 loopback）的隧道行程。`ProcessLookupError`
     （群組已消失）／`PermissionError`（非我方行程，理論上不會發生）皆吞掉，
     不讓拆除動作本身拋例外。
+
+    輪詢迴圈每次疊代開頭先 `_reap_pgid()`：被 SIGTERM 殺死的子行程若不被
+    父行程回收會留下 zombie，而 zombie 的 pgid slot 仍在，導致
+    `os.killpg(pgid, 0)` 存活探測持續誤判「仍存活」直到跑滿整個
+    `timeout` 才 fallback 到（對 zombie 而言是 no-op 的）SIGKILL。本行程
+    通常即為該子行程之父（生產 CLI 的 `subprocess.Popen` 單 fork，以及本模組
+    測試 fixture），故主動 reap 可讓 teardown 及時收斂，不必吃滿整個逾時。
     """
     with contextlib.suppress(ProcessLookupError, PermissionError):
         os.killpg(pgid, signal.SIGTERM)
     waited = 0.0
     while waited < timeout:
+        _reap_pgid(pgid)
         try:
             os.killpg(pgid, 0)  # 存活探測：不送訊號，僅檢查群組是否還在
         except ProcessLookupError:
@@ -369,6 +391,7 @@ def _terminate_pgid(
         waited += 0.1
     with contextlib.suppress(ProcessLookupError, PermissionError):
         os.killpg(pgid, signal.SIGKILL)
+    _reap_pgid(pgid)
 
 
 def open_tunnel(
@@ -409,7 +432,10 @@ def open_tunnel(
     with reg.lock():
         existing = reg.read(listen_port)
         if existing:
-            alive = pid_alive(int(existing.get("pid", -1)), existing.get("pid_start_ticks"))
+            existing_pid = int(existing.get("pid", -1))
+            # pid<=0 一律視為死亡：os.kill(-1, 0) 會 POSIX-broadcast 且無條件成功，
+            # 若讓 pid_alive() 收到非正值 pid，缺 pid 欄位的殘缺 state 會被誤判「存活」。
+            alive = existing_pid > 0 and pid_alive(existing_pid, existing.get("pid_start_ticks"))
             if alive and existing.get("identity") == identity:
                 return {"ok": True, "already_running": True, **_public(existing)}
             if alive and existing.get("identity") != identity:

--- a/sw_core/remote_tunnel.py
+++ b/sw_core/remote_tunnel.py
@@ -6,7 +6,11 @@ docs/superpowers/specs/2026-07-19-remote-tunnel-cli-design.md。
 """
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import hashlib
+import json
+import os
 import re
 from dataclasses import dataclass
 
@@ -101,3 +105,112 @@ def build_argv(spec: TunnelSpec, control_path: str) -> list[str]:
     argv += _direction_args(spec)
     argv.append(spec.ssh_target)
     return argv
+
+
+def read_pid_start_ticks(pid: int) -> int | None:
+    """Linux /proc/<pid>/stat 第 22 欄（starttime，clock ticks）。非 Linux／不存在回 None。"""
+    try:
+        with open(f"/proc/{pid}/stat", "rb") as fh:
+            data = fh.read()
+    except OSError:
+        return None
+    # comm 欄可能含空白/括號，故從最後一個 ')' 之後切。
+    rparen = data.rfind(b")")
+    if rparen < 0:
+        return None
+    fields = data[rparen + 2:].split()
+    # 切點後的 fields[0] 為 state(第3欄)，starttime 為第22欄 → index 22-3 = 19。
+    if len(fields) <= 19:
+        return None
+    try:
+        return int(fields[19])
+    except ValueError:
+        return None
+
+
+def pid_alive(pid: int, start_ticks: int | None) -> bool:
+    """檢測 PID 是否存活，並以 start_ticks 防 PID 重用。"""
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    if start_ticks is None:
+        return True  # 無 /proc（非 Linux）→ best-effort pid-only
+    current = read_pid_start_ticks(pid)
+    if current is None:
+        return True
+    return current == start_ticks
+
+
+class Registry:
+    """`<run_dir>/remote/` 下的 per-tunnel state JSON + flock 序列化。"""
+
+    def __init__(self, run_dir: str) -> None:
+        self.run_dir = run_dir
+        self.remote_dir = os.path.join(run_dir, "remote")
+
+    def _ensure_dir(self) -> None:
+        """確保遠端目錄存在。"""
+        os.makedirs(self.remote_dir, exist_ok=True)
+
+    @contextlib.contextmanager
+    def lock(self):
+        """Exclusive flock 保護同步讀寫。"""
+        self._ensure_dir()
+        lock_path = os.path.join(self.remote_dir, ".registry.lock")
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            yield
+        finally:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+
+    def control_path(self, listen_port: int) -> str:
+        """控制端點路徑（ssh -o ControlPath）。"""
+        return os.path.join(self.remote_dir, f"cm-{listen_port}")
+
+    def state_path(self, listen_port: int) -> str:
+        """狀態檔路徑。"""
+        return os.path.join(self.remote_dir, f"{listen_port}.json")
+
+    def write(self, state: dict) -> None:
+        """原子寫入狀態（先 tmp 再 replace）。"""
+        self._ensure_dir()
+        path = self.state_path(int(state["listen_port"]))
+        tmp = f"{path}.tmp.{os.getpid()}"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(state, fh, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        os.replace(tmp, path)  # atomic
+
+    def read(self, listen_port: int) -> dict | None:
+        """讀取單一隧道狀態，不存在回 None。"""
+        try:
+            with open(self.state_path(listen_port), "r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            return None
+
+    def read_all(self) -> list[dict]:
+        """讀取全部隧道狀態。"""
+        out: list[dict] = []
+        try:
+            names = os.listdir(self.remote_dir)
+        except OSError:
+            return out
+        for name in sorted(names):
+            if name.endswith(".json"):
+                try:
+                    with open(os.path.join(self.remote_dir, name), "r", encoding="utf-8") as fh:
+                        out.append(json.load(fh))
+                except (OSError, json.JSONDecodeError):
+                    continue
+        return out
+
+    def remove(self, listen_port: int) -> None:
+        """刪除隧道狀態與控制端點。"""
+        for p in (self.state_path(listen_port), self.control_path(listen_port)):
+            with contextlib.suppress(OSError):
+                os.unlink(p)

--- a/tests/test_remote_cli.py
+++ b/tests/test_remote_cli.py
@@ -47,6 +47,53 @@ def test_remote_open_dispatches_to_open_tunnel(tmp_path, monkeypatch, capsys):
     assert captured["spec"].ssh_target == "tester@relay"
 
 
+def test_remote_local_with_default_role_is_invalid_args(tmp_path, monkeypatch, capsys):
+    """--local 僅用於 -L（connect）；預設（-R/expose）帶入須擋在 CLI 層，不靜默略過。"""
+    monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(tmp_path))
+    monkeypatch.setattr(rt, "resolve_ssh_bin", lambda via: "/usr/bin/ssh")
+    rc, obj = _run(["remote", "--local", "7000", "tester@relay:7777"], capsys)
+    assert rc == 1 and obj["error_code"] == "INVALID_ARGS"
+
+
+def test_remote_local_with_R_is_invalid_args(tmp_path, monkeypatch, capsys):
+    """--local 僅用於 -L（connect）；明確帶 -R 仍須擋。"""
+    monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(tmp_path))
+    monkeypatch.setattr(rt, "resolve_ssh_bin", lambda via: "/usr/bin/ssh")
+    rc, obj = _run(["remote", "-R", "--local", "7000", "tester@relay:7777"], capsys)
+    assert rc == 1 and obj["error_code"] == "INVALID_ARGS"
+
+
+def test_remote_local_zero_is_invalid_args(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(tmp_path))
+    monkeypatch.setattr(rt, "resolve_ssh_bin", lambda via: "/usr/bin/ssh")
+    rc, obj = _run(["remote", "-L", "--local", "0", "tester@relay:7777"], capsys)
+    assert rc == 1 and obj["error_code"] == "INVALID_ARGS"
+
+
+def test_remote_local_too_large_is_invalid_args(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(tmp_path))
+    monkeypatch.setattr(rt, "resolve_ssh_bin", lambda via: "/usr/bin/ssh")
+    rc, obj = _run(["remote", "-L", "--local", "99999", "tester@relay:7777"], capsys)
+    assert rc == 1 and obj["error_code"] == "INVALID_ARGS"
+
+
+def test_remote_local_valid_with_L_dispatches(tmp_path, monkeypatch, capsys):
+    """有效範圍內的 --local 搭 -L 仍照常派送到 open_tunnel。"""
+    monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(tmp_path))
+    captured = {}
+
+    def fake_open(spec, run_dir, **kw):
+        captured["spec"] = spec
+        return {"ok": True, "status": "active", "role": "connect", "listen_port": spec.local}
+
+    monkeypatch.setattr(rt, "open_tunnel", fake_open)
+    monkeypatch.setattr(rt, "resolve_ssh_bin", lambda via: "/usr/bin/ssh")
+    rc, obj = _run(["remote", "-L", "--local", "7000", "tester@relay:7777"], capsys)
+    assert rc == 0 and obj["status"] == "active"
+    assert captured["spec"].role == "connect"
+    assert captured["spec"].local == 7000
+
+
 def test_remote_malformed_endpoint_returns_json_error(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(tmp_path))
     monkeypatch.setattr(rt, "resolve_ssh_bin", lambda via: "/usr/bin/ssh")

--- a/tests/test_remote_cli.py
+++ b/tests/test_remote_cli.py
@@ -54,3 +54,35 @@ def test_remote_malformed_endpoint_returns_json_error(tmp_path, monkeypatch, cap
     assert rc == 1 and obj is not None
     assert obj["ok"] is False
     assert obj["error_code"] == "INVALID_ENDPOINT"
+
+
+def test_remote_windows_returns_not_supported(tmp_path, monkeypatch, capsys):
+    """native Windows：guard 需在 `import remote_tunnel`（頂層 import fcntl）之前
+    就攔截，status／open 兩條路徑皆須回 JSON REMOTE_NOT_SUPPORTED，不得拋例外。
+    """
+    monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(tmp_path))
+    monkeypatch.setattr(cli.os, "name", "nt")
+
+    rc, obj = _run(["remote"], capsys)
+    assert rc == 1 and obj is not None
+    assert obj["ok"] is False
+    assert obj["error_code"] == "REMOTE_NOT_SUPPORTED"
+
+    rc, obj = _run(["remote", "u@h:7777"], capsys)
+    assert rc == 1 and obj is not None
+    assert obj["ok"] is False
+    assert obj["error_code"] == "REMOTE_NOT_SUPPORTED"
+
+
+def test_remote_internal_error_is_json_not_traceback(tmp_path, monkeypatch, capsys):
+    """非 TunnelError 例外（如壞掉的 SERIALWRAP_RUN_DIR）不得穿越 CLI 邊界，
+    須經 catch-all 轉為 JSON INTERNAL_ERROR。"""
+    bad_parent = tmp_path / "not_a_dir"
+    bad_parent.write_text("i am a file, not a directory")
+    monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(bad_parent / "sub"))
+    monkeypatch.setattr(rt, "resolve_ssh_bin", lambda via: "/usr/bin/ssh")
+
+    rc, obj = _run(["remote", "tester@relay:7777"], capsys)
+    assert rc == 1 and obj is not None
+    assert obj["ok"] is False
+    assert "error_code" in obj

--- a/tests/test_remote_cli.py
+++ b/tests/test_remote_cli.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from sw_core import cli
+from sw_core import remote_tunnel as rt
+
+
+def _run(argv, capsys):
+    rc = cli.main(argv)
+    out = capsys.readouterr().out
+    return rc, json.loads(out) if out.strip() else None
+
+
+def test_remote_bare_is_status(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(tmp_path))
+    rc, obj = _run(["remote"], capsys)
+    assert rc == 0 and obj["ok"] and obj["tunnels"] == []
+
+
+def test_remote_mutually_exclusive_R_L(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(tmp_path))
+    rc, obj = _run(["remote", "-R", "-L", "u@h:7777"], capsys)
+    assert rc == 1 and obj["error_code"] == "INVALID_ARGS"
+
+
+def test_remote_invalid_target(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(tmp_path))
+    rc, obj = _run(["remote", "nohost"], capsys)
+    assert rc == 1 and obj["error_code"] == "INVALID_TARGET"
+
+
+def test_remote_open_dispatches_to_open_tunnel(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(tmp_path))
+    captured = {}
+    def fake_open(spec, run_dir, **kw):
+        captured["spec"] = spec
+        return {"ok": True, "status": "active", "role": "expose", "listen_port": spec.port}
+    monkeypatch.setattr(rt, "open_tunnel", fake_open)
+    monkeypatch.setattr(rt, "resolve_ssh_bin", lambda via: "/usr/bin/ssh")
+    rc, obj = _run(["remote", "tester@relay:7777"], capsys)
+    assert rc == 0 and obj["status"] == "active"
+    assert captured["spec"].role == "expose"  # -R 預設
+    assert captured["spec"].ssh_target == "tester@relay"

--- a/tests/test_remote_cli.py
+++ b/tests/test_remote_cli.py
@@ -45,3 +45,12 @@ def test_remote_open_dispatches_to_open_tunnel(tmp_path, monkeypatch, capsys):
     assert rc == 0 and obj["status"] == "active"
     assert captured["spec"].role == "expose"  # -R 預設
     assert captured["spec"].ssh_target == "tester@relay"
+
+
+def test_remote_malformed_endpoint_returns_json_error(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("SERIALWRAP_RUN_DIR", str(tmp_path))
+    monkeypatch.setattr(rt, "resolve_ssh_bin", lambda via: "/usr/bin/ssh")
+    rc, obj = _run(["--endpoint", "http://badscheme:1", "remote", "tester@relay:7777"], capsys)
+    assert rc == 1 and obj is not None
+    assert obj["ok"] is False
+    assert obj["error_code"] == "INVALID_ENDPOINT"

--- a/tests/test_remote_tunnel.py
+++ b/tests/test_remote_tunnel.py
@@ -36,3 +36,59 @@ def test_identity_distinguishes_via_and_ssh_opts():
     assert rt.compute_identity(base) != rt.compute_identity(
         rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/run/s.sock",
                       ssh_opts=("-p", "2222")))
+
+
+def _cp():
+    return "/run/user/1000/serialwrap/remote/cm-abc"
+
+
+def test_build_argv_expose_unix_socket_loopback_bind():
+    spec = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777,
+                         forward_src="/run/serialwrapd.sock")
+    argv = rt.build_argv(spec, _cp())
+    assert argv[0] == "ssh"
+    assert "-N" in argv and "-T" in argv
+    assert "-R" in argv
+    assert argv[argv.index("-R") + 1] == "127.0.0.1:7777:/run/serialwrapd.sock"
+    joined = " ".join(argv)
+    assert "BatchMode=yes" in joined
+    assert "ExitOnForwardFailure=yes" in joined
+    assert "ControlMaster=auto" in joined
+    assert f"ControlPath={_cp()}" in joined
+    assert argv[-1] == "u@h"
+
+
+def test_build_argv_expose_remote_socket_hardened():
+    spec = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777,
+                         forward_src="/run/serialwrapd.sock", remote_socket="/relay/x.sock")
+    argv = rt.build_argv(spec, _cp())
+    assert argv[argv.index("-R") + 1] == "/relay/x.sock:/run/serialwrapd.sock"
+
+
+def test_build_argv_expose_tcp_forward_src():
+    spec = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777,
+                         forward_src="127.0.0.1:48700")
+    argv = rt.build_argv(spec, _cp())
+    assert argv[argv.index("-R") + 1] == "127.0.0.1:7777:127.0.0.1:48700"
+
+
+def test_build_argv_connect_tcp_loopback():
+    spec = rt.TunnelSpec(role="connect", ssh_target="u@relay", port=7777, local=7777)
+    argv = rt.build_argv(spec, _cp())
+    assert argv[argv.index("-L") + 1] == "127.0.0.1:7777:localhost:7777"
+
+
+def test_build_argv_connect_remote_socket():
+    spec = rt.TunnelSpec(role="connect", ssh_target="u@relay", port=7777, local=7788,
+                         remote_socket="/relay/x.sock")
+    argv = rt.build_argv(spec, _cp())
+    assert argv[argv.index("-L") + 1] == "127.0.0.1:7788:/relay/x.sock"
+
+
+def test_build_argv_autossh_and_ssh_opts_passthrough():
+    spec = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777,
+                         forward_src="/s.sock", via="autossh", ssh_opts=("-p", "2222"))
+    argv = rt.build_argv(spec, _cp())
+    assert argv[0] == "autossh"
+    assert argv[1:3] == ["-M", "0"]
+    assert "-p" in argv and argv[argv.index("-p") + 1] == "2222"

--- a/tests/test_remote_tunnel.py
+++ b/tests/test_remote_tunnel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import subprocess
@@ -267,3 +268,73 @@ def test_role_probe_connect_uses_health_ping():
         runner=lambda argv: (0, ""), ping=lambda ep: seen.setdefault("ep", ep) or True)
     assert probe() is True
     assert seen["ep"] == "tcp://127.0.0.1:7777"
+
+
+# Task 6: open_tunnel 編排（spawn → durable state → readiness → active/starting）
+class _FakeProc:
+    def __init__(self, pid):
+        self.pid = pid
+
+    def poll(self):
+        return None
+
+
+def _fake_spawner(alive=True, stderr=""):
+    procs = {}
+
+    def spawn(argv, control_path, log_path):
+        # `start_new_session=True`：讓存活分支的子行程落在獨立 pgid，
+        # 不與目前跑 pytest 的行程共用 process group——否則
+        # `_terminate_pgid` 的 fail-closed teardown 對 pgid 送
+        # `os.killpg(SIGTERM)` 時會連 pytest 本身一併殺死（已實測驗證）。
+        proc = subprocess.Popen(["sleep", "30"], start_new_session=True) if alive \
+            else subprocess.Popen(["true"])
+        if not alive:
+            proc.wait()
+        procs["p"] = proc
+        return proc.pid, os.getpgid(proc.pid) if alive else proc.pid, \
+            rt.read_pid_start_ticks(proc.pid), (lambda: stderr)
+    spawn.procs = procs
+    return spawn
+
+
+def test_open_tunnel_expose_active(tmp_path):
+    spec = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock")
+    spawn = _fake_spawner(alive=True)
+    try:
+        res = rt.open_tunnel(spec, str(tmp_path), spawner=spawn,
+                             runner=lambda a: (0, "LISTEN 0 128 127.0.0.1:7777 *:*"),
+                             ping=lambda ep: True)
+        assert res["ok"] and res["status"] == "active" and res["role"] == "expose"
+        reg = rt.Registry(str(tmp_path))
+        assert reg.read(7777)["status"] == "active"
+    finally:
+        spawn.procs["p"].terminate(); spawn.procs["p"].wait()
+
+
+def test_open_tunnel_conflict_same_port_diff_identity(tmp_path):
+    reg = rt.Registry(str(tmp_path))
+    with reg.lock():
+        reg.write({"listen_port": 7777, "status": "active", "role": "expose",
+                   "identity": "OTHER", "pid": os.getpid(),
+                   "pid_start_ticks": rt.read_pid_start_ticks(os.getpid())})
+    spec = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock")
+    with pytest.raises(rt.TunnelError) as ei:
+        rt.open_tunnel(spec, str(tmp_path), spawner=_fake_spawner(),
+                       runner=lambda a: (0, ""), ping=lambda ep: True)
+    assert ei.value.code == "TUNNEL_CONFLICT"
+
+
+def test_open_tunnel_fail_closed_removes_state_on_bind_unverified(tmp_path):
+    spec = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock")
+    spawn = _fake_spawner(alive=True)
+    try:
+        with pytest.raises(rt.TunnelError) as ei:
+            rt.open_tunnel(spec, str(tmp_path), spawner=spawn,
+                           runner=lambda a: (0, "LISTEN 0 128 0.0.0.0:7777 *:*"),  # wildcard
+                           ping=lambda ep: True)
+        assert ei.value.code == "REMOTE_BIND_UNVERIFIED"
+        assert rt.Registry(str(tmp_path)).read(7777) is None  # 拆除、不留暴露隧道
+    finally:
+        with contextlib.suppress(Exception):
+            spawn.procs["p"].wait(timeout=2)

--- a/tests/test_remote_tunnel.py
+++ b/tests/test_remote_tunnel.py
@@ -442,3 +442,41 @@ def test_real_ping_uses_client(monkeypatch):
     monkeypatch.setattr(rt, "_rpc_call", _fake_rpc_call)
     assert rt.real_ping("tcp://127.0.0.1:7777") is True
     assert seen["ep"] == "tcp://127.0.0.1:7777"
+
+
+# Task 8 review fix：fail-closed 涵蓋 probe 逾時與任意 readiness 例外
+def test_make_runner_timeout_returns_nonzero(monkeypatch):
+    """`subprocess.run` 逾時拋 `TimeoutExpired` 時，`make_runner()` 的 `_run` 需吞下並
+    回傳非 0 rc（非崩潰），讓逾時留在 readiness 狀態機內（probe 回 False 續 poll）。"""
+    def _raise_timeout(argv, stdout=None, stderr=None, text=None, timeout=None, check=None):
+        raise subprocess.TimeoutExpired(cmd=["x"], timeout=10.0)
+
+    monkeypatch.setattr(rt.subprocess, "run", _raise_timeout)
+    rc, msg = rt.make_runner()(["x"])
+    assert rc != 0
+    assert isinstance(msg, str)
+
+
+def test_open_tunnel_teardown_on_nontunnel_exception(tmp_path):
+    """readiness 階段丟出非 `TunnelError`（例如 `RuntimeError`）時，`open_tunnel` 仍需
+    fail-closed：拆除已 spawn 的行程群組、移除 durable state，再原樣 re-raise。"""
+    spec = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock")
+    spawn = _fake_spawner(alive=True)
+
+    def _raising_role_probe_factory(spec, control_path, endpoint, *, runner, ping):
+        def _probe():
+            raise RuntimeError("probe 爆炸（非 TunnelError）")
+        return _probe
+
+    try:
+        with pytest.raises(RuntimeError):
+            rt.open_tunnel(
+                spec, str(tmp_path), spawner=spawn,
+                runner=lambda a: (0, ""), ping=lambda ep: True,
+                role_probe_factory=_raising_role_probe_factory,
+            )
+        assert spawn.procs["p"].poll() is not None  # 已被 teardown 終止
+        assert rt.Registry(str(tmp_path)).read(7777) is None  # state 已移除，fail-closed
+    finally:
+        with contextlib.suppress(Exception):
+            spawn.procs["p"].wait(timeout=2)

--- a/tests/test_remote_tunnel.py
+++ b/tests/test_remote_tunnel.py
@@ -111,6 +111,23 @@ def test_registry_write_read_remove_atomic(tmp_path):
     assert reg.read(7777) is None
 
 
+def test_registry_remove_also_deletes_log(tmp_path):
+    """`.log`（ssh stdout/stderr）須與 state/control socket 同生命週期清除，
+    否則重試/失敗會在 `<run_dir>/remote/` 下累積孤兒 `.log`。"""
+    reg = rt.Registry(str(tmp_path))
+    with reg.lock():
+        reg.write({"listen_port": 7777, "status": "active", "role": "expose"})
+    log_path = reg.log_path(7777)
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    with open(log_path, "w", encoding="utf-8") as fh:
+        fh.write("ssh spawn log\n")
+    assert os.path.exists(log_path)
+    with reg.lock():
+        reg.remove(7777)
+    assert reg.read(7777) is None
+    assert not os.path.exists(log_path)
+
+
 def test_pid_alive_true_for_running_and_reuse_guard(tmp_path):
     proc = subprocess.Popen(["sleep", "30"])
     try:

--- a/tests/test_remote_tunnel.py
+++ b/tests/test_remote_tunnel.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from sw_core import remote_tunnel as rt
+
+
+def test_parse_target_user_host_port():
+    assert rt.parse_target("tester@relay:7777") == ("tester@relay", 7777)
+
+
+def test_parse_target_alias_only():
+    assert rt.parse_target("myrelay:22000") == ("myrelay", 22000)
+
+
+@pytest.mark.parametrize("bad", ["nohost", "host:", "host:abc", "host:-1", "", "a@b@c:1"])
+def test_parse_target_rejects_bad(bad):
+    with pytest.raises(rt.TunnelError) as ei:
+        rt.parse_target(bad)
+    assert ei.value.code == "INVALID_TARGET"
+
+
+def test_identity_stable_and_distinguishes_remote_socket():
+    a = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/run/s.sock")
+    b = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/run/s.sock")
+    c = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/run/s.sock",
+                      remote_socket="/relay/b.sock")
+    assert rt.compute_identity(a) == rt.compute_identity(b)
+    assert rt.compute_identity(a) != rt.compute_identity(c)
+
+
+def test_identity_distinguishes_via_and_ssh_opts():
+    base = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/run/s.sock")
+    assert rt.compute_identity(base) != rt.compute_identity(
+        rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/run/s.sock", via="autossh"))
+    assert rt.compute_identity(base) != rt.compute_identity(
+        rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/run/s.sock",
+                      ssh_opts=("-p", "2222")))

--- a/tests/test_remote_tunnel.py
+++ b/tests/test_remote_tunnel.py
@@ -370,3 +370,46 @@ def test_terminate_pgid_reaps_and_returns_promptly():
     except ChildProcessError:
         result = None
     assert result is None or result[0] == proc.pid
+
+
+# Task 7: status（prune 死 state + orphan scan）與 close（killpg 整組 + verify + error-state）
+def test_status_prunes_dead_and_lists_alive(tmp_path):
+    reg = rt.Registry(str(tmp_path))
+    # `start_new_session=True`：獨立 pgid，避免與目前跑 pytest 的行程共用
+    # process group（見上方 `_fake_spawner`／`test_terminate_pgid_reaps_and_returns_promptly`
+    # 的既有慣例與理由；本測試雖不對 live 呼叫 killpg，仍統一套用避免僥倖依賴）。
+    live = subprocess.Popen(["sleep", "30"], start_new_session=True)
+    try:
+        with reg.lock():
+            reg.write({"listen_port": 7777, "status": "active", "role": "expose",
+                       "pid": live.pid, "pgid": os.getpgid(live.pid),
+                       "pid_start_ticks": rt.read_pid_start_ticks(live.pid),
+                       "target": "u@h"})
+            reg.write({"listen_port": 7778, "status": "active", "role": "connect",
+                       "pid": 999999, "pgid": 999999, "pid_start_ticks": 1, "target": "u@r"})
+        res = rt.status(str(tmp_path))
+        ports = {t["listen_port"] for t in res["tunnels"]}
+        assert 7777 in ports and 7778 not in ports  # 死的被 prune
+    finally:
+        live.terminate(); live.wait()
+
+
+def test_close_terminates_and_removes(tmp_path):
+    reg = rt.Registry(str(tmp_path))
+    # `start_new_session=True`：務必獨立 pgid——`close()` 會對 pgid 送
+    # `os.killpg(SIGTERM)`；若沿用 pytest 本身的 pgid，會連 pytest 行程一併
+    # 殺死（已實測驗證：無此旗標時子行程與呼叫者同 pgid，killpg 會連呼叫者
+    # 一起中止，整個測試行程被 SIGTERM 中斷而非乾淨地跑完斷言）。
+    live = subprocess.Popen(["sleep", "30"], start_new_session=True)
+    with reg.lock():
+        reg.write({"listen_port": 7777, "status": "active", "role": "expose",
+                   "pid": live.pid, "pgid": os.getpgid(live.pid),
+                   "pid_start_ticks": rt.read_pid_start_ticks(live.pid), "target": "u@h"})
+    res = rt.close(str(tmp_path), 7777)
+    assert 7777 in res["closed"]
+    assert reg.read(7777) is None
+    assert live.poll() is not None  # 已被終止
+
+
+def test_close_missing_is_idempotent(tmp_path):
+    assert rt.close(str(tmp_path), 12345) == {"ok": True, "closed": []}

--- a/tests/test_remote_tunnel.py
+++ b/tests/test_remote_tunnel.py
@@ -195,3 +195,55 @@ def test_wait_ready_remote_bind_unverified_propagates():
                       sleep=clk.sleep, monotonic=clk.monotonic,
                       alive=lambda: True, stderr_tail=lambda: "")
     assert ei.value.code == "REMOTE_BIND_UNVERIFIED"
+
+
+# Task 5: probe 具體實作（ssh -O check / ss 遠端 bind / health.ping）
+def test_ssh_check_true_on_rc0():
+    calls = []
+    def runner(argv):
+        calls.append(argv)
+        return (0, "")
+    chk = rt.make_ssh_check(rt.TunnelSpec(role="expose", ssh_target="u@h", port=1),
+                            "/cp", runner=runner)
+    assert chk() is True
+    assert "-O" in calls[0] and "check" in calls[0]
+
+
+def test_role_probe_expose_tcp_rejects_wildcard():
+    def runner(argv):
+        return (0, "LISTEN 0 128 0.0.0.0:7777 0.0.0.0:*")
+    probe = rt.make_role_probe(
+        rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock"),
+        "/cp", "tcp://127.0.0.1:7777", runner=runner, ping=lambda ep: True)
+    with pytest.raises(rt.TunnelError) as ei:
+        probe()
+    assert ei.value.code == "REMOTE_BIND_UNVERIFIED"
+
+
+def test_role_probe_expose_tcp_accepts_loopback():
+    def runner(argv):
+        return (0, "LISTEN 0 128 127.0.0.1:7777 0.0.0.0:*")
+    probe = rt.make_role_probe(
+        rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock"),
+        "/cp", "tcp://127.0.0.1:7777", runner=runner, ping=lambda ep: True)
+    assert probe() is True
+
+
+def test_role_probe_expose_remote_socket_skips_bind_check():
+    def runner(argv):
+        raise AssertionError("unix 模式不應跑 ss")
+    probe = rt.make_role_probe(
+        rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock",
+                      remote_socket="/relay/x.sock"),
+        "/cp", "", runner=runner, ping=lambda ep: True)
+    assert probe() is True
+
+
+def test_role_probe_connect_uses_health_ping():
+    seen = {}
+    probe = rt.make_role_probe(
+        rt.TunnelSpec(role="connect", ssh_target="u@relay", port=7777, local=7777),
+        "/cp", "tcp://127.0.0.1:7777",
+        runner=lambda argv: (0, ""), ping=lambda ep: seen.setdefault("ep", ep) or True)
+    assert probe() is True
+    assert seen["ep"] == "tcp://127.0.0.1:7777"

--- a/tests/test_remote_tunnel.py
+++ b/tests/test_remote_tunnel.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+import os
+import subprocess
+
 import pytest
 
 from sw_core import remote_tunnel as rt
@@ -92,3 +96,44 @@ def test_build_argv_autossh_and_ssh_opts_passthrough():
     assert argv[0] == "autossh"
     assert argv[1:3] == ["-M", "0"]
     assert "-p" in argv and argv[argv.index("-p") + 1] == "2222"
+
+
+# Task 3: Registry + PID liveness
+def test_registry_write_read_remove_atomic(tmp_path):
+    reg = rt.Registry(str(tmp_path))
+    with reg.lock():
+        reg.write({"listen_port": 7777, "status": "active", "role": "expose"})
+    assert reg.read(7777)["status"] == "active"
+    assert [s["listen_port"] for s in reg.read_all()] == [7777]
+    with reg.lock():
+        reg.remove(7777)
+    assert reg.read(7777) is None
+
+
+def test_pid_alive_true_for_running_and_reuse_guard(tmp_path):
+    proc = subprocess.Popen(["sleep", "30"])
+    try:
+        ticks = rt.read_pid_start_ticks(proc.pid)
+        assert ticks is not None
+        assert rt.pid_alive(proc.pid, ticks) is True
+        # start-ticks 不符 → 視為非我方（PID reuse 防護）
+        assert rt.pid_alive(proc.pid, ticks + 999999) is False
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+def test_pid_alive_false_for_dead(tmp_path):
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    assert rt.pid_alive(proc.pid, 12345) is False
+
+
+def test_lock_is_exclusive_serialized(tmp_path):
+    # 兩次 lock 不會同時持有（LOCK_EX）；此處驗證可重入取得、釋放後再取。
+    reg = rt.Registry(str(tmp_path))
+    with reg.lock():
+        pass
+    with reg.lock():
+        reg.write({"listen_port": 1, "status": "spawning", "role": "connect"})
+    assert reg.read(1)["status"] == "spawning"

--- a/tests/test_remote_tunnel.py
+++ b/tests/test_remote_tunnel.py
@@ -229,6 +229,26 @@ def test_role_probe_expose_tcp_accepts_loopback():
     assert probe() is True
 
 
+def test_role_probe_expose_tcp_rejects_interface_ip():
+    def runner(argv):
+        return (0, "LISTEN 0 128 10.0.0.5:7777 0.0.0.0:*")
+    probe = rt.make_role_probe(
+        rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock"),
+        "/cp", "tcp://127.0.0.1:7777", runner=runner, ping=lambda ep: True)
+    with pytest.raises(rt.TunnelError) as ei:
+        probe()
+    assert ei.value.code == "REMOTE_BIND_UNVERIFIED"
+
+
+def test_role_probe_expose_tcp_accepts_ipv6_loopback():
+    def runner(argv):
+        return (0, "LISTEN 0 128 [::1]:7777 [::]:*")
+    probe = rt.make_role_probe(
+        rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock"),
+        "/cp", "tcp://127.0.0.1:7777", runner=runner, ping=lambda ep: True)
+    assert probe() is True
+
+
 def test_role_probe_expose_remote_socket_skips_bind_check():
     def runner(argv):
         raise AssertionError("unix 模式不應跑 ss")

--- a/tests/test_remote_tunnel.py
+++ b/tests/test_remote_tunnel.py
@@ -338,3 +338,35 @@ def test_open_tunnel_fail_closed_removes_state_on_bind_unverified(tmp_path):
     finally:
         with contextlib.suppress(Exception):
             spawn.procs["p"].wait(timeout=2)
+
+
+def test_open_tunnel_already_running_noop(tmp_path):
+    spec = rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock")
+    identity = rt.compute_identity(spec)
+    reg = rt.Registry(str(tmp_path))
+    with reg.lock():
+        reg.write({
+            "listen_port": 7777, "status": "active", "role": "expose",
+            "identity": identity, "pid": os.getpid(),
+            "pid_start_ticks": rt.read_pid_start_ticks(os.getpid()),
+        })
+
+    def _spawner_should_not_be_called(argv, control_path, log_path):
+        raise AssertionError("已存活且 identity 相同時不應呼叫 spawner")
+
+    res = rt.open_tunnel(spec, str(tmp_path), spawner=_spawner_should_not_be_called,
+                         runner=lambda a: (0, ""), ping=lambda ep: True)
+    assert res["ok"] is True
+    assert res["already_running"] is True
+
+
+def test_terminate_pgid_reaps_and_returns_promptly():
+    proc = subprocess.Popen(["sleep", "30"], start_new_session=True)
+    pgid = os.getpgid(proc.pid)
+    rt._terminate_pgid(pgid)
+    assert proc.poll() is not None
+    try:
+        result = os.waitpid(proc.pid, os.WNOHANG)
+    except ChildProcessError:
+        result = None
+    assert result is None or result[0] == proc.pid

--- a/tests/test_remote_tunnel.py
+++ b/tests/test_remote_tunnel.py
@@ -137,3 +137,61 @@ def test_lock_is_exclusive_serialized(tmp_path):
     with reg.lock():
         reg.write({"listen_port": 1, "status": "spawning", "role": "connect"})
     assert reg.read(1)["status"] == "spawning"
+
+
+# Task 4: readiness 狀態機（注入式 probe）
+class _Clock:
+    """注入時鐘，用於測試 wait_ready。"""
+    def __init__(self):
+        self.t = 0.0
+    def monotonic(self):
+        return self.t
+    def sleep(self, dt):
+        self.t += dt
+
+
+def _spec_R():
+    """測試用的 expose spec。"""
+    return rt.TunnelSpec(role="expose", ssh_target="u@h", port=7777, forward_src="/s.sock",
+                         ready_timeout=5.0)
+
+
+def test_wait_ready_active_when_check_and_probe_ok():
+    clk = _Clock()
+    st = rt.wait_ready(_spec_R(), pid=1, start_ticks=1,
+                       ssh_check=lambda: True, role_probe=lambda: True,
+                       sleep=clk.sleep, monotonic=clk.monotonic,
+                       alive=lambda: True, stderr_tail=lambda: "")
+    assert st == "active"
+
+
+def test_wait_ready_starting_on_timeout_process_alive():
+    clk = _Clock()
+    st = rt.wait_ready(_spec_R(), pid=1, start_ticks=1,
+                       ssh_check=lambda: False, role_probe=lambda: False,
+                       sleep=clk.sleep, monotonic=clk.monotonic,
+                       alive=lambda: True, stderr_tail=lambda: "")
+    assert st == "starting"
+
+
+def test_wait_ready_spawn_failed_when_process_dies():
+    clk = _Clock()
+    with pytest.raises(rt.TunnelError) as ei:
+        rt.wait_ready(_spec_R(), pid=1, start_ticks=1,
+                      ssh_check=lambda: False, role_probe=lambda: False,
+                      sleep=clk.sleep, monotonic=clk.monotonic,
+                      alive=lambda: False, stderr_tail=lambda: "Permission denied (publickey).")
+    assert ei.value.code == "TUNNEL_SPAWN_FAILED"
+    assert "publickey" in (ei.value.message or "")
+
+
+def test_wait_ready_remote_bind_unverified_propagates():
+    clk = _Clock()
+    def probe():
+        raise rt.TunnelError("REMOTE_BIND_UNVERIFIED", "0.0.0.0:7777")
+    with pytest.raises(rt.TunnelError) as ei:
+        rt.wait_ready(_spec_R(), pid=1, start_ticks=1,
+                      ssh_check=lambda: True, role_probe=probe,
+                      sleep=clk.sleep, monotonic=clk.monotonic,
+                      alive=lambda: True, stderr_tail=lambda: "")
+    assert ei.value.code == "REMOTE_BIND_UNVERIFIED"

--- a/tests/test_remote_tunnel.py
+++ b/tests/test_remote_tunnel.py
@@ -413,3 +413,32 @@ def test_close_terminates_and_removes(tmp_path):
 
 def test_close_missing_is_idempotent(tmp_path):
     assert rt.close(str(tmp_path), 12345) == {"ok": True, "closed": []}
+
+
+def test_resolve_ssh_bin_missing(monkeypatch):
+    monkeypatch.setattr(rt.shutil, "which", lambda name: None)
+    with pytest.raises(rt.TunnelError) as ei:
+        rt.resolve_ssh_bin("ssh")
+    assert ei.value.code == "SSH_NOT_FOUND"
+
+
+def test_guard_platform_rejects_windows(monkeypatch):
+    monkeypatch.setattr(rt.os, "name", "nt")
+    with pytest.raises(rt.TunnelError) as ei:
+        rt.guard_platform()
+    assert ei.value.code == "REMOTE_NOT_SUPPORTED"
+
+
+def test_real_ping_uses_client(monkeypatch):
+    # 注意：不可寫成 `seen.setdefault("ep", ep) or {"ok": True}`——setdefault
+    # 首次呼叫回傳剛設定的 ep（truthy 字串），`or` 短路後整條表達式會變成該字串
+    # 而非 dict，導致 real_ping 對字串呼叫 .get() 拋例外、被吞成 False。
+    seen = {}
+
+    def _fake_rpc_call(ep, m, p, timeout_s):
+        seen["ep"] = ep
+        return {"ok": True}
+
+    monkeypatch.setattr(rt, "_rpc_call", _fake_rpc_call)
+    assert rt.real_ping("tcp://127.0.0.1:7777") is True
+    assert seen["ep"] == "tcp://127.0.0.1:7777"

--- a/tools/docker/remote_tunnel_test.sh
+++ b/tools/docker/remote_tunnel_test.sh
@@ -324,13 +324,14 @@ topology_direct() {
 topology_nat_host() {
   log "=== 拓樸 2／NAT→host：uart(NAT) + relay 同網段（net_a），agent CLI colocate 在 relay ==="
   local net="net_a_${SUFFIX}"
-  local uart="sw-rt-uart2-${SUFFIX}" relay="sw-rt-relay2-${SUFFIX}"
+  local uart="sw-rt-uart2-${SUFFIX}" relay="sw-rt-relay2-${SUFFIX}" attacker="sw-rt-attacker2-${SUFFIX}"
   local ep="tcp://127.0.0.1:7777"
   local sock=/home/tester/.sw-relay/relay-sw.sock
 
   mk_net "$net"
   start_uart "$uart" "$net"
   start_role "$relay" "$net"
+  start_plain "$attacker" "$net"
   wait_uart_ready "$uart"
 
   assert_default_off "$uart" "$relay" "$ep" root
@@ -343,6 +344,16 @@ topology_nat_host() {
   assert_session_and_cmd "$relay" root "$ep"
   assert_pid_unchanged "$uart" "$pid_before" "拓樸2 tcp expose 後"
   assert_loopback_bind "$relay" 7777
+
+  # 斷言⑤延伸（R2 review finding：補真攻擊者連線隔離斷言，不只是 ss 位址檢查）——
+  # attacker 是與 relay 同網段（net_a）的獨立容器，直連 relay 的「非 loopback」容器位址
+  # （tcp://<relay-container>:7777，不是合法 agent 用的 relay 自身 127.0.0.1）應失敗，
+  # 證明轉發真的只綁 relay loopback、network 上其他 host 連不進來。
+  local atk_out; atk_out=$(endpoint_exec "$attacker" root "tcp://${relay}:7777" daemon status)
+  assert_ok_false "$atk_out" "拓樸2 attacker（net_a，非 loopback 位址）應無法連 ${relay}:7777"
+  [[ "$(jpath "$atk_out" error_code)" == "SOCKET_ERROR" ]] \
+    || fail "拓樸2 attacker（net_a）：預期 error_code=SOCKET_ERROR，實得：$atk_out"
+  log "assertion⑤延伸（跨容器攻擊者隔離，tcp 模式）PASS：拓樸2"
 
   # 斷言⑥ 前半：relay 上第二個本機使用者（otheruser）tcp loopback 模式「可連」（已知殘留風險）
   local other_out; other_out=$(endpoint_exec "$relay" otheruser "$ep" daemon status)
@@ -376,7 +387,7 @@ topology_nat_host() {
   assert_default_off "$uart" "$relay" "$ep" root
   assert_pid_unchanged "$uart" "$pid_before" "拓樸2 remote-socket close 後（assertion④）"
 
-  teardown_now "$uart" "$relay" -- "$net"
+  teardown_now "$uart" "$relay" "$attacker" -- "$net"
   log "=== 拓樸 2／NAT→host：PASS ==="
 }
 
@@ -384,7 +395,7 @@ topology_nat_host() {
 topology_dual_nat() {
   log "=== 拓樸 3／NAT←client：net_a=uart+relay、net_b=agent+relay，uart 與 agent 無共網段 ==="
   local neta="net_a_${SUFFIX}" netb="net_b_${SUFFIX}"
-  local uart="sw-rt-uart3-${SUFFIX}" relay="sw-rt-relay3-${SUFFIX}" agent="sw-rt-agent3-${SUFFIX}"
+  local uart="sw-rt-uart3-${SUFFIX}" relay="sw-rt-relay3-${SUFFIX}" agent="sw-rt-agent3-${SUFFIX}" attacker="sw-rt-attacker3-${SUFFIX}"
   local ep="tcp://127.0.0.1:7777"
   local sock=/home/tester/.sw-relay/relay-sw.sock
 
@@ -395,6 +406,7 @@ topology_dual_nat() {
   docker network connect "$netb" "$relay"
   sshd_up "$relay"
   start_plain "$agent" "$netb"
+  start_plain "$attacker" "$neta"
   wait_uart_ready "$uart"
 
   # 確認雙 NAT 隔離：uart 與 agent 互不可達
@@ -436,6 +448,21 @@ except OSError:
   assert_pid_unchanged "$uart" "$pid_before" "拓樸3 tcp 端到端後"
   assert_loopback_bind "$relay" 7777
 
+  # 斷言⑤延伸（R2 review finding：雙 NAT 拓樸也補真攻擊者連線隔離斷言）——
+  # attacker 與 relay/uart 同 net_a，直連 relay 的「非 loopback」容器位址應失敗。
+  local atk_out; atk_out=$(endpoint_exec "$attacker" root "tcp://${relay}:7777" daemon status)
+  assert_ok_false "$atk_out" "拓樸3 attacker（net_a，非 loopback 位址）應無法連 ${relay}:7777"
+  [[ "$(jpath "$atk_out" error_code)" == "SOCKET_ERROR" ]] \
+    || fail "拓樸3 attacker（net_a）：預期 error_code=SOCKET_ERROR，實得：$atk_out"
+  # agent 雖是合法一方，但這裡繞過自己的 -L 轉發、改直連 relay 的容器位址（非 relay 自身
+  # 127.0.0.1）：relay port 只綁 loopback，即使是 net_b 上「已授權」的 host 這樣連也該失敗，
+  # 證明合法路徑必須經過 relay 自身的 127.0.0.1（-L 轉發），而不是網路可達即可連。
+  local agent_direct_out; agent_direct_out=$(endpoint_exec "$agent" root "tcp://${relay}:7777" daemon status)
+  assert_ok_false "$agent_direct_out" "拓樸3 agent（net_b，繞過 -L 直連）應無法連 ${relay}:7777"
+  [[ "$(jpath "$agent_direct_out" error_code)" == "SOCKET_ERROR" ]] \
+    || fail "拓樸3 agent（net_b 繞過 -L）：預期 error_code=SOCKET_ERROR，實得：$agent_direct_out"
+  log "assertion⑤延伸（跨容器攻擊者隔離：net_a attacker + net_b agent 繞過 -L 直連皆失敗）PASS：拓樸3"
+
   role_close_all "$agent" >/dev/null
   uart_close_all "$uart" >/dev/null
   sleep 1
@@ -463,7 +490,7 @@ except OSError:
   assert_role_default_off "$agent"
   assert_pid_unchanged "$uart" "$pid_before" "拓樸3 remote-socket close 後（assertion④）"
 
-  teardown_now "$uart" "$relay" "$agent" -- "$neta" "$netb"
+  teardown_now "$uart" "$relay" "$agent" "$attacker" -- "$neta" "$netb"
   log "=== 拓樸 3／NAT←client：PASS ==="
 }
 
@@ -472,6 +499,7 @@ topology_gatewayports_failclosed() {
   log "=== 額外／斷言⑦：GatewayPorts yes relay 的 fail-closed 驗證 ==="
   local net="net_gw_${SUFFIX}"
   local uart="sw-rt-uartgw-${SUFFIX}" relay="sw-rt-relaygw-${SUFFIX}"
+  local ep="tcp://127.0.0.1:7777"
   local sock=/home/tester/.sw-relay/gw.sock
 
   mk_net "$net"
@@ -507,6 +535,14 @@ topology_gatewayports_failclosed() {
 
   uart_close_all "$uart" >/dev/null
   docker exec "$relay" rm -f "$sock" >/dev/null 2>&1 || true
+  sleep 1
+
+  # 補：⑦b（--remote-socket 成功案例）的 teardown 收尾重查（原本只有⑦a tcp fail-closed
+  # 分支有此複查，remote-socket 成功分支的 close 若有 teardown 迴歸不會被抓到）。
+  # 沿用其他拓樸關閉後共用的 assert_default_off（無殘留 state／ssh 行程、endpoint 不可連）。
+  assert_default_off "$uart" "$relay" "$ep" root
+  assert_pid_unchanged "$uart" "$pid_before" "assertion⑦ remote-socket close 後（收尾重查）"
+  log "assertion⑦c（--remote-socket close 後收尾重查：復歸預設不啟用）PASS"
 
   teardown_now "$uart" "$relay" -- "$net"
   log "=== 額外／斷言⑦：PASS ==="

--- a/tools/docker/remote_tunnel_test.sh
+++ b/tools/docker/remote_tunnel_test.sh
@@ -1,0 +1,528 @@
+#!/usr/bin/env bash
+# serialwrap remote 隧道 docker 三拓樸驗收（設計 spec §11.2）。
+#
+# 以真 sshd + 真 `serialwrap remote`（外包系統 ssh）跑三種拓樸，全過才算通過：
+#   拓樸 1 direct        uart + agent 同網段
+#   拓樸 2 NAT→host      uart（NAT）+ relay 同網段，agent CLI colocate 在 relay
+#   拓樸 3 NAT←client    net_a=uart+relay、net_b=agent+relay，雙 NAT，僅能經 relay
+# 另跑一組額外驗收（GatewayPorts yes fail-closed）覆蓋斷言⑦。
+#
+# 每個拓樸驗證（缺一不可，對照 spec §11.2 / task-12-brief）：
+#   ① 預設不啟用：remote status 空、無 state 檔、無 ssh/autossh 行程、--endpoint 連線失敗（SOCKET_ERROR）
+#   ② 手動啟動後：agent 端 session list 有 READY、cmd submit→cmd status 得 done 且輸出正確
+#   ③ serialwrapd 不重啟：daemon pid 全程不變
+#   ④ close all 後乾淨復歸（同①的檢查方式）
+#   ⑤ loopback 不變量：ss -ltn 綁 127.0.0.1；獨立 attacker 容器連不到
+#   ⑥ trust boundary：relay 第二個本機使用者 tcp 模式可連（記錄殘留風險）、--remote-socket 模式被拒
+#   ⑦ GatewayPorts yes → -R tcp 回 REMOTE_BIND_UNVERIFIED 且無殘留；--remote-socket 仍成功
+#   ⑧ -L 對無對應 -R 的 relay 回 starting（非 active）
+#
+# docker 不可用時：印原因、exit 0（SKIP，不靜默略過）。任何斷言失敗：exit 1。
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE_TAG="${IMAGE_TAG:-serialwrap:remote-tunnel-test}"
+SUFFIX="${SUFFIX:-$$}"
+
+log() { echo "[serialwrap] $*"; }
+fail() { echo "[serialwrap] FAIL: $*" >&2; exit 1; }
+
+# ── docker 可用性檢查（不可用 → SKIP，非靜默略過）──
+if ! command -v docker >/dev/null 2>&1; then
+  log "SKIP：找不到 docker 指令，略過 remote-tunnel 三拓樸驗收"
+  exit 0
+fi
+if ! docker info >/dev/null 2>&1; then
+  log "SKIP：docker daemon 不可連（docker info 失敗），略過 remote-tunnel 三拓樸驗收"
+  exit 0
+fi
+
+CONTAINERS=()
+NETWORKS=()
+
+cleanup() {
+  local rc=$?
+  log "cleanup（containers=${#CONTAINERS[@]}, networks=${#NETWORKS[@]}）..."
+  for c in ${CONTAINERS[@]+"${CONTAINERS[@]}"}; do
+    docker rm -f "$c" >/dev/null 2>&1 || true
+  done
+  for n in ${NETWORKS[@]+"${NETWORKS[@]}"}; do
+    docker network rm "$n" >/dev/null 2>&1 || true
+  done
+  exit "$rc"
+}
+trap cleanup EXIT
+
+# ── JSON 取值（host 端 python3；避免每次 parse 都 docker run，加速）──
+jpath() {  # jpath <json> <dotted.path> -> 值（純量／true／false／空字串）
+  python3 -c '
+import json, sys
+path = sys.argv[2].split(".") if sys.argv[2] else []
+cur = json.loads(sys.argv[1])
+for part in path:
+    if isinstance(cur, list):
+        try:
+            cur = cur[int(part)]
+        except (ValueError, IndexError):
+            cur = None
+    elif isinstance(cur, dict):
+        cur = cur.get(part)
+    else:
+        cur = None
+    if cur is None:
+        break
+if cur is None:
+    print("")
+elif isinstance(cur, bool):
+    print("true" if cur else "false")
+else:
+    print(cur)
+' "$1" "$2"
+}
+
+tunnels_count() {  # tunnels_count <remote-status-json>
+  python3 -c 'import json,sys; print(len(json.loads(sys.argv[1]).get("tunnels",[])))' "$1"
+}
+
+session_ready() {  # session_ready <session-list-json> <com>
+  python3 -c '
+import json, sys
+obj = json.loads(sys.argv[1])
+com = sys.argv[2]
+ok = any(s.get("com") == com and s.get("state") == "READY" for s in obj.get("sessions", []))
+print("true" if ok else "false")
+' "$1" "$2"
+}
+
+# ── 基本斷言 helper ──
+assert_ok_true() { [[ "$(jpath "$1" ok)" == "true" ]] || fail "$2：預期 ok:true，實得：$1"; }
+assert_ok_false() { [[ "$(jpath "$1" ok)" == "false" ]] || fail "$2：預期 ok:false，實得：$1"; }
+assert_field_eq() {  # assert_field_eq <json> <field> <expected> <desc>
+  local got; got=$(jpath "$1" "$2")
+  [[ "$got" == "$3" ]] || fail "$4：欄位 $2 預期 '$3'，實得 '$got'（完整：$1）"
+}
+
+# ── docker 資源 helper ──
+mk_net() {
+  docker network rm "$1" >/dev/null 2>&1 || true
+  docker network create "$1" >/dev/null
+  NETWORKS+=("$1")
+}
+
+start_plain() {  # start_plain <name> <network>
+  docker rm -f "$1" >/dev/null 2>&1 || true
+  docker run -d --init --name "$1" --network "$2" "${IMAGE_TAG}" sleep infinity >/dev/null
+  CONTAINERS+=("$1")
+}
+
+start_uart() {  # start_uart <name> <network> — 容器主行程即 uart_harness.py（fake target + serialwrapd）
+  docker rm -f "$1" >/dev/null 2>&1 || true
+  docker run -d --init --name "$1" --network "$2" -u tester "${IMAGE_TAG}" \
+    python3 /opt/serialwrap/tools/docker/uart_harness.py >/dev/null
+  CONTAINERS+=("$1")
+}
+
+sshd_up() {  # sshd_up <container> [config]
+  local c=$1 cfg=${2:-/etc/ssh/sshd_config}
+  docker exec "$c" bash -c "mkdir -p /run/sshd && /usr/sbin/sshd -f ${cfg}" >/dev/null
+}
+
+start_role() {  # start_role <name> <network> [gwyes] — sshd host（agent/relay）
+  local name=$1 net=$2 variant=${3:-normal}
+  start_plain "$name" "$net"
+  local cfg=/etc/ssh/sshd_config
+  [[ "$variant" == "gwyes" ]] && cfg=/etc/ssh/sshd_config.gwyes
+  sshd_up "$name" "$cfg"
+}
+
+wait_uart_ready() {  # wait_uart_ready <container> [timeout_s]
+  local c=$1 timeout=${2:-30} waited=0
+  while (( waited < timeout )); do
+    if docker exec -u tester "$c" test -f /home/tester/sw-uart.env 2>/dev/null; then
+      return 0
+    fi
+    sleep 1; waited=$((waited + 1))
+  done
+  log "uart harness 逾時未就緒，$c 的 stdout："
+  docker logs "$c" || true
+  fail "$c：uart harness（fake target + serialwrapd）逾時未就緒"
+}
+
+teardown_now() {  # teardown_now c1 c2 ... -- net1 net2 ...（立即回收，trap 仍作最後防線）
+  local containers=() networks=() seen_dash=0
+  for a in "$@"; do
+    if [[ "$a" == "--" ]]; then seen_dash=1; continue; fi
+    if [[ "$seen_dash" == "0" ]]; then containers+=("$a"); else networks+=("$a"); fi
+  done
+  for c in ${containers[@]+"${containers[@]}"}; do docker rm -f "$c" >/dev/null 2>&1 || true; done
+  for n in ${networks[@]+"${networks[@]}"}; do docker network rm "$n" >/dev/null 2>&1 || true; done
+}
+
+# ── uart 端（expose／-R）呼叫封裝：daemon harness 的 RUN_DIR 是動態 tempdir，
+#    每次呼叫先讀 harness 寫出的 env 檔，轉成 `docker exec -e K=V` 陣列注入 ──
+UART_ENV_ARGS=()
+uart_load_env() {
+  local c=$1 content
+  content=$(docker exec -u tester "$c" cat /home/tester/sw-uart.env 2>/dev/null) \
+    || fail "$c：讀不到 sw-uart.env（harness 未就緒？）"
+  UART_ENV_ARGS=()
+  local line
+  while IFS= read -r line; do
+    [[ "$line" =~ ^export\ ([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]] || continue
+    UART_ENV_ARGS+=("-e" "${BASH_REMATCH[1]}=${BASH_REMATCH[2]}")
+  done <<< "$content"
+  [[ ${#UART_ENV_ARGS[@]} -gt 0 ]] || fail "$c：sw-uart.env 內容為空或解析失敗：$content"
+}
+uart_exec() {  # uart_exec <container> <serialwrap-subcmd...>
+  local c=$1; shift
+  uart_load_env "$c"
+  docker exec -u tester "${UART_ENV_ARGS[@]}" "$c" serialwrap "$@"
+}
+uart_open() { local c=$1; shift; uart_exec "$c" remote "$@"; }
+uart_close_all() { uart_exec "$1" remote close all; }
+uart_status() { uart_exec "$1" remote status; }
+uart_daemon_pid() { jpath "$(uart_exec "$1" daemon status)" pid; }
+uart_state_files() {
+  uart_load_env "$1"
+  docker exec -u tester "${UART_ENV_ARGS[@]}" "$1" bash -c 'ls "$SERIALWRAP_RUN_DIR"/remote/*.json 2>/dev/null'
+}
+
+# ── connect 端（-L，僅拓樸 3 用）：固定 RUN_DIR，無 daemon，不需動態 env 檔 ──
+ROLE_RUN_DIR=/home/tester/.sw-run
+role_exec() { local c=$1; shift; docker exec -u tester -e SERIALWRAP_RUN_DIR="${ROLE_RUN_DIR}" "$c" serialwrap "$@"; }
+role_open() { local c=$1; shift; role_exec "$c" remote "$@"; }
+role_close_all() { role_exec "$1" remote close all; }
+role_status() { role_exec "$1" remote status; }
+role_state_files() {
+  docker exec -u tester -e SERIALWRAP_RUN_DIR="${ROLE_RUN_DIR}" "$1" bash -c 'ls "$SERIALWRAP_RUN_DIR"/remote/*.json 2>/dev/null'
+}
+
+# ── endpoint 端（agent CLI／attacker）：純 --endpoint，與 remote CLI 的 RUN_DIR 無關 ──
+endpoint_exec() {  # endpoint_exec <container> <user> <endpoint> <serialwrap-subcmd...>
+  local c=$1 u=$2 ep=$3; shift 3
+  docker exec -u "$u" "$c" serialwrap --endpoint "$ep" "$@"
+}
+
+assert_no_tunnel_process() {  # assert_no_tunnel_process <container> [user]
+  local c=$1 u=${2:-tester} out
+  out=$(docker exec -u "$u" "$c" bash -c 'pgrep -x ssh; pgrep -x autossh' 2>/dev/null || true)
+  [[ -z "$out" ]] || fail "$c：仍有殘留 ssh/autossh 行程（user=$u）：$out"
+}
+
+assert_loopback_bind() {  # assert_loopback_bind <container> <port>
+  local c=$1 port=$2 line addr
+  line=$(docker exec "$c" ss -ltn 2>/dev/null | awk -v p=":${port}\$" '$4 ~ p {print; exit}')
+  [[ -n "$line" ]] || fail "assertion⑤：$c port $port 找不到 listener（ss -ltn 無輸出）"
+  addr=$(echo "$line" | awk '{print $4}')
+  case "$addr" in
+    127.0.0.1:*|127.*) : ;;
+    *) fail "assertion⑤：$c port $port bind 位址非 loopback：$addr" ;;
+  esac
+  log "  ss 確認 $c:$port 綁 $addr（loopback-only）"
+}
+
+# ── 斷言①／④共用：預設不啟用／teardown 後乾淨復歸 ──
+assert_default_off() {  # assert_default_off <uart_c> <endpoint_container> <endpoint> [user]
+  local uart_c=$1 epc=$2 ep=$3 user=${4:-root}
+  local st n sf out ec
+  st=$(uart_status "$uart_c")
+  n=$(tunnels_count "$st")
+  [[ "$n" == "0" ]] || fail "$uart_c：remote status 非空：$st"
+  sf=$(uart_state_files "$uart_c")
+  [[ -z "$sf" ]] || fail "$uart_c：發現殘留 state 檔：$sf"
+  assert_no_tunnel_process "$uart_c" tester
+  out=$(endpoint_exec "$epc" "$user" "$ep" daemon status)
+  assert_ok_false "$out" "$epc -> $ep 應不可連"
+  ec=$(jpath "$out" error_code)
+  [[ "$ec" == "SOCKET_ERROR" ]] || fail "$epc -> $ep：預期 error_code=SOCKET_ERROR，實得 $ec（$out）"
+  log "  default-off 確認：$uart_c 無 state／行程；$epc -> $ep 不可連（SOCKET_ERROR）"
+}
+
+assert_role_default_off() {  # assert_role_default_off <container>（-L 端自身 state，僅拓樸3用）
+  local c=$1 st n sf
+  st=$(role_status "$c")
+  n=$(tunnels_count "$st")
+  [[ "$n" == "0" ]] || fail "$c：remote status 非空：$st"
+  sf=$(role_state_files "$c")
+  [[ -z "$sf" ]] || fail "$c：發現殘留 state 檔：$sf"
+  assert_no_tunnel_process "$c" tester
+}
+
+assert_pid_unchanged() {  # assert_pid_unchanged <uart_c> <expected_pid> <desc>
+  local got; got=$(uart_daemon_pid "$1")
+  [[ "$got" == "$2" ]] || fail "$3：serialwrapd pid 改變了！before=$2 after=$got"
+  log "  assertion③（pid-unchanged）PASS：$1 pid=$got（$3）"
+}
+
+# ── 斷言②：agent 端 session list READY + cmd submit -> done ──
+assert_session_and_cmd() {  # assert_session_and_cmd <endpoint_container> <user> <endpoint>
+  local c=$1 u=$2 ep=$3 sl ready submit cmd_id status_json done stdout
+  sl=$(endpoint_exec "$c" "$u" "$ep" session list)
+  assert_ok_true "$sl" "session list（$c -> $ep）"
+  ready=$(session_ready "$sl" "COM0")
+  [[ "$ready" == "true" ]] || fail "COM0 未 READY（$c -> $ep）：$sl"
+
+  submit=$(endpoint_exec "$c" "$u" "$ep" cmd submit --selector COM0 --cmd 'uname -a')
+  assert_ok_true "$submit" "cmd submit（$c -> $ep）"
+  cmd_id=$(jpath "$submit" cmd_id)
+  [[ -n "$cmd_id" ]] || fail "cmd submit 未回 cmd_id（$c -> $ep）：$submit"
+
+  status_json="" done=0
+  for _ in $(seq 1 30); do
+    status_json=$(endpoint_exec "$c" "$u" "$ep" cmd status --cmd-id "$cmd_id")
+    if [[ "$(jpath "$status_json" command.status)" == "done" ]]; then done=1; break; fi
+    sleep 1
+  done
+  [[ "$done" == "1" ]] || fail "cmd 逾時未完成（$c -> $ep）：$status_json"
+  stdout=$(jpath "$status_json" command.stdout)
+  [[ "$stdout" == "RESULT:uname -a:OK" ]] || fail "cmd stdout 不符（$c -> $ep）：得 '$stdout'"
+  log "  assertion②（session+cmd）PASS：$c -> $ep（stdout=$stdout）"
+}
+
+# ══════════════════════════ 拓樸 1／direct ══════════════════════════
+topology_direct() {
+  log "=== 拓樸 1／direct：uart + agent 同網段（net_direct）==="
+  local net="net_direct_${SUFFIX}"
+  local uart="sw-rt-uart1-${SUFFIX}" agent="sw-rt-agent1-${SUFFIX}" attacker="sw-rt-attacker1-${SUFFIX}"
+  local ep="tcp://127.0.0.1:7777"
+
+  mk_net "$net"
+  start_uart "$uart" "$net"
+  start_role "$agent" "$net"
+  start_plain "$attacker" "$net"
+  wait_uart_ready "$uart"
+
+  assert_default_off "$uart" "$agent" "$ep" root
+  local pid_before; pid_before=$(uart_daemon_pid "$uart")
+
+  local open_json; open_json=$(uart_open "$uart" "tester@${agent}:7777")
+  assert_ok_true "$open_json" "拓樸1 uart 裸 remote（-R 預設）expose"
+  assert_field_eq "$open_json" status active "拓樸1 uart 裸 remote（-R 預設）expose"
+
+  assert_session_and_cmd "$agent" root "$ep"
+  assert_pid_unchanged "$uart" "$pid_before" "拓樸1 expose 後"
+
+  # 斷言⑤：loopback 不變量 + 獨立 attacker 容器連不到
+  assert_loopback_bind "$agent" 7777
+  local atk_out; atk_out=$(endpoint_exec "$attacker" root "tcp://${agent}:7777" daemon status)
+  assert_ok_false "$atk_out" "拓樸1 attacker 應無法連 ${agent}:7777"
+  [[ "$(jpath "$atk_out" error_code)" == "SOCKET_ERROR" ]] \
+    || fail "拓樸1 attacker：預期 error_code=SOCKET_ERROR，實得：$atk_out"
+  log "assertion⑤（loopback+attacker 隔離）PASS：拓樸1"
+
+  local closed; closed=$(uart_close_all "$uart")
+  assert_ok_true "$closed" "拓樸1 remote close all"
+  sleep 1
+  assert_default_off "$uart" "$agent" "$ep" root
+  assert_pid_unchanged "$uart" "$pid_before" "拓樸1 close 後（assertion④）"
+
+  teardown_now "$uart" "$agent" "$attacker" -- "$net"
+  log "=== 拓樸 1／direct：PASS ==="
+}
+
+# ══════════════════════════ 拓樸 2／NAT→host ══════════════════════════
+topology_nat_host() {
+  log "=== 拓樸 2／NAT→host：uart(NAT) + relay 同網段（net_a），agent CLI colocate 在 relay ==="
+  local net="net_a_${SUFFIX}"
+  local uart="sw-rt-uart2-${SUFFIX}" relay="sw-rt-relay2-${SUFFIX}"
+  local ep="tcp://127.0.0.1:7777"
+  local sock=/home/tester/.sw-relay/relay-sw.sock
+
+  mk_net "$net"
+  start_uart "$uart" "$net"
+  start_role "$relay" "$net"
+  wait_uart_ready "$uart"
+
+  assert_default_off "$uart" "$relay" "$ep" root
+  local pid_before; pid_before=$(uart_daemon_pid "$uart")
+
+  # --- tcp 模式（-R 預設） ---
+  local open_json; open_json=$(uart_open "$uart" -R "tester@${relay}:7777")
+  assert_ok_true "$open_json" "拓樸2 tcp -R expose"
+  assert_field_eq "$open_json" status active "拓樸2 tcp -R expose"
+  assert_session_and_cmd "$relay" root "$ep"
+  assert_pid_unchanged "$uart" "$pid_before" "拓樸2 tcp expose 後"
+  assert_loopback_bind "$relay" 7777
+
+  # 斷言⑥ 前半：relay 上第二個本機使用者（otheruser）tcp loopback 模式「可連」（已知殘留風險）
+  local other_out; other_out=$(endpoint_exec "$relay" otheruser "$ep" daemon status)
+  assert_ok_true "$other_out" "assertion⑥（tcp 殘留風險）otheruser 應可連 ${relay} ${ep}"
+  log "assertion⑥a（trust-boundary tcp 殘留風險，符合預期）PASS：otheruser 可連 tcp loopback"
+
+  uart_close_all "$uart" >/dev/null
+  sleep 1
+  assert_default_off "$uart" "$relay" "$ep" root
+  assert_pid_unchanged "$uart" "$pid_before" "拓樸2 tcp close 後"
+
+  # --- --remote-socket 硬化模式 ---
+  open_json=$(uart_open "$uart" --remote-socket "$sock" "tester@${relay}:7777")
+  assert_ok_true "$open_json" "拓樸2 remote-socket expose"
+  assert_field_eq "$open_json" status active "拓樸2 remote-socket expose"
+
+  local sl ready
+  sl=$(endpoint_exec "$relay" tester "$sock" session list)
+  assert_ok_true "$sl" "拓樸2 remote-socket：tester session list"
+  ready=$(session_ready "$sl" "COM0")
+  [[ "$ready" == "true" ]] || fail "拓樸2 remote-socket：tester 應可見 COM0 READY：$sl"
+
+  # 斷言⑥ 後半：otheruser 對 --remote-socket endpoint 應被拒（無檔案權限，.sw-relay 目錄 0700）
+  local other_json; other_json=$(endpoint_exec "$relay" otheruser "$sock" session list)
+  assert_ok_false "$other_json" "assertion⑥（remote-socket 硬化）otheruser 應被拒於 $sock"
+  log "assertion⑥b（trust-boundary remote-socket 硬化）PASS：otheruser 被拒，tester 仍可連"
+
+  uart_close_all "$uart" >/dev/null
+  sleep 1
+  docker exec "$relay" rm -f "$sock" >/dev/null 2>&1 || true
+  assert_default_off "$uart" "$relay" "$ep" root
+  assert_pid_unchanged "$uart" "$pid_before" "拓樸2 remote-socket close 後（assertion④）"
+
+  teardown_now "$uart" "$relay" -- "$net"
+  log "=== 拓樸 2／NAT→host：PASS ==="
+}
+
+# ══════════════════════════ 拓樸 3／NAT←client（雙 NAT relay）══════════════════════════
+topology_dual_nat() {
+  log "=== 拓樸 3／NAT←client：net_a=uart+relay、net_b=agent+relay，uart 與 agent 無共網段 ==="
+  local neta="net_a_${SUFFIX}" netb="net_b_${SUFFIX}"
+  local uart="sw-rt-uart3-${SUFFIX}" relay="sw-rt-relay3-${SUFFIX}" agent="sw-rt-agent3-${SUFFIX}"
+  local ep="tcp://127.0.0.1:7777"
+  local sock=/home/tester/.sw-relay/relay-sw.sock
+
+  mk_net "$neta"
+  mk_net "$netb"
+  start_uart "$uart" "$neta"
+  start_plain "$relay" "$neta"
+  docker network connect "$netb" "$relay"
+  sshd_up "$relay"
+  start_plain "$agent" "$netb"
+  wait_uart_ready "$uart"
+
+  # 確認雙 NAT 隔離：uart 與 agent 互不可達
+  local direct_out
+  direct_out=$(docker exec "$agent" python3 -c "
+import socket
+s = socket.socket(); s.settimeout(2)
+try:
+    s.connect((\"${uart}\", 22))
+    print(\"REACHABLE\")
+except OSError:
+    print(\"unreachable\")
+" 2>/dev/null || echo "unreachable")
+  [[ "$direct_out" != "REACHABLE" ]] || fail "拓樸3：uart 與 agent 竟然互通（net_a／net_b 未隔離）"
+
+  # 斷言⑧：-L 對「無對應 -R」的 relay 應回 starting（先於 uart 開 -R 之前跑）
+  local l_json
+  l_json=$(role_open "$agent" -L --ready-timeout 3 "tester@${relay}:7777")
+  assert_ok_true "$l_json" "拓樸3 assertion⑧：-L pre-check（無對應 -R）"
+  assert_field_eq "$l_json" status starting "assertion⑧：-L 無對應 -R 時應回 starting（非 active）"
+  role_close_all "$agent" >/dev/null
+  sleep 1
+  log "assertion⑧（-L 端到端誠實）PASS：無對應 -R 時回 starting"
+
+  assert_default_off "$uart" "$agent" "$ep" root
+  assert_role_default_off "$agent"
+  local pid_before; pid_before=$(uart_daemon_pid "$uart")
+
+  # --- tcp 模式端到端：uart -R、agent -L ---
+  local r_json; r_json=$(uart_open "$uart" "tester@${relay}:7777")
+  assert_ok_true "$r_json" "拓樸3 tcp -R expose"
+  assert_field_eq "$r_json" status active "拓樸3 tcp -R expose"
+
+  l_json=$(role_open "$agent" -L "tester@${relay}:7777")
+  assert_ok_true "$l_json" "拓樸3 tcp -L connect"
+  assert_field_eq "$l_json" status active "拓樸3 tcp -L connect"
+
+  assert_session_and_cmd "$agent" root "$ep"
+  assert_pid_unchanged "$uart" "$pid_before" "拓樸3 tcp 端到端後"
+  assert_loopback_bind "$relay" 7777
+
+  role_close_all "$agent" >/dev/null
+  uart_close_all "$uart" >/dev/null
+  sleep 1
+  assert_default_off "$uart" "$agent" "$ep" root
+  assert_role_default_off "$agent"
+  assert_pid_unchanged "$uart" "$pid_before" "拓樸3 tcp close 後（assertion④）"
+
+  # --- --remote-socket 硬化模式端到端（R2 finding 1：必須也走得通）---
+  r_json=$(uart_open "$uart" --remote-socket "$sock" "tester@${relay}:7777")
+  assert_ok_true "$r_json" "拓樸3 remote-socket -R expose"
+  assert_field_eq "$r_json" status active "拓樸3 remote-socket -R expose"
+
+  l_json=$(role_open "$agent" -L --remote-socket "$sock" "tester@${relay}:7777")
+  assert_ok_true "$l_json" "拓樸3 remote-socket -L connect"
+  assert_field_eq "$l_json" status active "拓樸3 remote-socket -L connect"
+
+  assert_session_and_cmd "$agent" root "$ep"
+  assert_pid_unchanged "$uart" "$pid_before" "拓樸3 remote-socket 端到端後"
+
+  role_close_all "$agent" >/dev/null
+  uart_close_all "$uart" >/dev/null
+  sleep 1
+  docker exec "$relay" rm -f "$sock" >/dev/null 2>&1 || true
+  assert_default_off "$uart" "$agent" "$ep" root
+  assert_role_default_off "$agent"
+  assert_pid_unchanged "$uart" "$pid_before" "拓樸3 remote-socket close 後（assertion④）"
+
+  teardown_now "$uart" "$relay" "$agent" -- "$neta" "$netb"
+  log "=== 拓樸 3／NAT←client：PASS ==="
+}
+
+# ══════════════════════════ 額外／斷言⑦：GatewayPorts yes fail-closed ══════════════════════════
+topology_gatewayports_failclosed() {
+  log "=== 額外／斷言⑦：GatewayPorts yes relay 的 fail-closed 驗證 ==="
+  local net="net_gw_${SUFFIX}"
+  local uart="sw-rt-uartgw-${SUFFIX}" relay="sw-rt-relaygw-${SUFFIX}"
+  local sock=/home/tester/.sw-relay/gw.sock
+
+  mk_net "$net"
+  start_uart "$uart" "$net"
+  start_role "$relay" "$net" gwyes
+  wait_uart_ready "$uart"
+  [[ "$(docker exec "$relay" grep -c '^GatewayPorts yes' /etc/ssh/sshd_config.gwyes)" == "1" ]] \
+    || fail "$relay：sshd_config.gwyes 內容不符預期，前置條件不成立"
+
+  local pid_before; pid_before=$(uart_daemon_pid "$uart")
+
+  local tcp_json; tcp_json=$(uart_open "$uart" "tester@${relay}:7777")
+  assert_ok_false "$tcp_json" "assertion⑦：tcp -R against GatewayPorts yes 應失敗"
+  local ec; ec=$(jpath "$tcp_json" error_code)
+  [[ "$ec" == "REMOTE_BIND_UNVERIFIED" ]] \
+    || fail "assertion⑦：預期 error_code=REMOTE_BIND_UNVERIFIED，實得 $ec（$tcp_json）"
+
+  local st n relay_ss
+  st=$(uart_status "$uart")
+  n=$(tunnels_count "$st")
+  [[ "$n" == "0" ]] || fail "assertion⑦：fail-closed 後仍有殘留隧道：$st"
+  assert_no_tunnel_process "$uart" tester
+  relay_ss=$(docker exec "$relay" ss -ltn 2>/dev/null | grep ':7777' || true)
+  [[ -z "$relay_ss" ]] || fail "assertion⑦：relay 仍殘留 :7777 listener：$relay_ss"
+  assert_pid_unchanged "$uart" "$pid_before" "assertion⑦ tcp fail-closed 後"
+  log "assertion⑦a（GatewayPorts yes → REMOTE_BIND_UNVERIFIED 無殘留）PASS"
+
+  local sock_json; sock_json=$(uart_open "$uart" --remote-socket "$sock" "tester@${relay}:7777")
+  assert_ok_true "$sock_json" "assertion⑦：--remote-socket against GatewayPorts yes 應仍成功"
+  assert_field_eq "$sock_json" status active "assertion⑦：--remote-socket against GatewayPorts yes 應仍成功"
+  assert_pid_unchanged "$uart" "$pid_before" "assertion⑦ remote-socket 成功後"
+  log "assertion⑦b（GatewayPorts yes + --remote-socket 不受影響、仍成功）PASS"
+
+  uart_close_all "$uart" >/dev/null
+  docker exec "$relay" rm -f "$sock" >/dev/null 2>&1 || true
+
+  teardown_now "$uart" "$relay" -- "$net"
+  log "=== 額外／斷言⑦：PASS ==="
+}
+
+# ══════════════════════════ main ══════════════════════════
+main() {
+  log "build image: ${IMAGE_TAG}"
+  DOCKER_BUILDKIT=1 docker build --progress=plain -t "${IMAGE_TAG}" "${ROOT_DIR}" || fail "docker build 失敗"
+
+  topology_direct
+  topology_nat_host
+  topology_dual_nat
+  topology_gatewayports_failclosed
+
+  log "remote-tunnel acceptance: PASS"
+}
+
+main

--- a/tools/docker/uart_harness.py
+++ b/tools/docker/uart_harness.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Docker 內的「uart 端」daemon 啟動器，供 remote_tunnel_test.sh 使用。
+
+與 tools/docker/remote_lab.py 的差異：本程式**不**做 socat unix->tcp 橋接——
+`remote_tunnel_test.sh` 驗收的是 `serialwrap remote`（ssh -R/-L）本身如何把
+本機 daemon 的 AF_UNIX socket 推到對端，橋接工作交給 `serialwrap remote`，
+不能再有第二條（不安全的）0.0.0.0 socat 通道混進來污染斷言。
+
+流程：
+1. 啟動 fake target（PTY）+ serialwrapd（AF_UNIX socket），沿用
+   func-test/lib/daemon_harness.py 的 DaemonHarness。
+2. 等待 session READY。
+3. 把 DaemonHarness 解出的 SERIALWRAP_* 目錄寫成 shell-sourceable env 檔
+   （預設 /home/tester/sw-uart.env），供同容器之後的 `docker exec ... serialwrap
+   remote ...` / `serialwrap daemon status` 呼叫 source 後拿到一致的
+   RUN_DIR／STATE_DIR／BY_ID_DIR（DaemonHarness 用 tempfile.TemporaryDirectory()
+   產生，事先不可預測，故用檔案傳遞而非固定路徑）。
+4. 印一行 JSON（event=UART_HARNESS_READY）到 stdout 供外部（docker logs）確認，
+   然後阻塞至收到 SIGTERM/SIGINT，離開前呼叫 harness.stop() 清理。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import shlex
+import signal
+import subprocess
+import sys
+import time
+
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[2]
+FUNC_TEST_DIR = ROOT_DIR / "func-test"
+if str(FUNC_TEST_DIR) not in sys.path:
+    sys.path.insert(0, str(FUNC_TEST_DIR))
+
+from lib.daemon_harness import DaemonHarness, HarnessConfig  # noqa: E402
+from lib.fake_target import TargetConfig  # noqa: E402
+
+_ENV_KEYS = (
+    "SERIALWRAP_STATE_DIR",
+    "SERIALWRAP_RUN_DIR",
+    "SERIALWRAP_BY_ID_DIR",
+    "SERIALWRAP_BY_PATH_DIR",
+)
+
+
+def _serialwrap_bin() -> str:
+    return str(ROOT_DIR / "serialwrap")
+
+
+def _json_cmd(argv: list[str], env: dict[str, str], timeout: float = 5.0) -> dict[str, object]:
+    proc = subprocess.run(
+        argv, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, timeout=timeout, check=False,
+    )
+    stdout = (proc.stdout or "").strip()
+    if not stdout:
+        return {}
+    try:
+        obj = json.loads(stdout)
+    except json.JSONDecodeError:
+        return {}
+    return obj if isinstance(obj, dict) else {}
+
+
+def _wait_ready(harness: DaemonHarness, selector: str, timeout_s: float) -> None:
+    deadline = time.monotonic() + timeout_s
+    last: dict[str, object] = {}
+    while time.monotonic() < deadline:
+        last = _json_cmd(
+            [_serialwrap_bin(), "--socket", harness.socket_path, "session", "list"],
+            env=harness.env, timeout=5.0,
+        )
+        sessions = last.get("sessions") if isinstance(last, dict) else None
+        if isinstance(sessions, list):
+            for session in sessions:
+                if not isinstance(session, dict):
+                    continue
+                if session.get("com") == selector and session.get("state") == "READY":
+                    return
+        time.sleep(0.3)
+    raise RuntimeError(f"session {selector} 未於 {timeout_s}s 內 READY：{last}")
+
+
+def _write_env_file(path: str, env: dict[str, str]) -> None:
+    lines = [f"export {key}={shlex.quote(env[key])}\n" for key in _ENV_KEYS if key in env]
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.writelines(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="docker uart 端 fake target + serialwrapd 啟動器")
+    parser.add_argument("--selector", default="COM0")
+    parser.add_argument("--ready-timeout", type=float, default=20.0)
+    parser.add_argument("--env-out", default="/home/tester/sw-uart.env", help="寫出 shell-sourceable env 檔路徑")
+    args = parser.parse_args(argv)
+
+    target_cfg = TargetConfig(
+        platform="prpl",
+        boot_banner="boot done\r\nroot@prplOS:/# ",
+        noise_enabled=False,
+        default_response="EXEC:{cmd}\r\nRESULT:{cmd}:OK\r\nroot@prplOS:/# ",
+    )
+    harness = DaemonHarness(HarnessConfig(target_config=target_cfg, com=args.selector, alias="docker-remote-tunnel"))
+    stop = False
+
+    def _handle_stop(_signum: int, _frame: object) -> None:
+        nonlocal stop
+        stop = True
+
+    signal.signal(signal.SIGTERM, _handle_stop)
+    signal.signal(signal.SIGINT, _handle_stop)
+
+    harness.start()
+    try:
+        _wait_ready(harness, args.selector, args.ready_timeout)
+        _write_env_file(args.env_out, harness.env)
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "event": "UART_HARNESS_READY",
+                    "selector": args.selector,
+                    "socket": harness.socket_path,
+                    "env_out": args.env_out,
+                },
+                ensure_ascii=False, separators=(",", ":"),
+            ),
+            flush=True,
+        )
+        while not stop:
+            time.sleep(0.5)
+    finally:
+        harness.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

新增 `serialwrap remote` 子命令群：在 runtime 按需開／關 SSH 反向隧道，讓**遠端 agent 取得本機 serialwrap 操作**，**daemon 零改動、不重啟、不做預設**。

**Root cause**：現行文件教的遠端模型是 agent 端主動 `ssh -L`（inbound）連進 UART host，但 UART host 常在 NAT／防火牆後、agent 進不來 → 無法連線。實際能通的方向是由 UART host 主動撥出的反向隧道（`ssh -R`）。本 PR 把這個手動流程收斂成原生便利指令。

**介面**（沿用熟悉的 `host:port`）：
- `serialwrap remote user@host:7777` — `-R` 預設 expose（把本機 daemon 反向推到對端）
- `serialwrap remote -L user@relay:7777` — connect（relay／雙 NAT）
- `serialwrap remote` / `serialwrap remote close 7777|all` — 列出／拆除
- agent 端：`serialwrap --endpoint tcp://127.0.0.1:7777 ...`

**設計要點**：外包系統 `ssh`（auth 全交 ssh、`-o BatchMode=yes`）、background 常駐、flock registry + durable state + pid+start-ticks 存活（PID-reuse 防護）、ControlMaster readiness（`ssh -O check` + role 補強）、`--remote-socket` 硬化（遠端 unix socket 檔案權限把關）。

**安全不變量**（fail-closed）：
- `-R`/`-L` 顯式綁 `127.0.0.1:`；`-R` tcp 模式 active 前以 `ss` 實測遠端 bind 為 loopback，偵測 wildcard（`GatewayPorts yes` 漂移）→ `REMOTE_BIND_UNVERIFIED` + 拆除。
- 任何 readiness 例外（含 probe 逾時）皆觸發 fail-closed teardown。
- 例外不穿越 CLI 邊界（一律 `{"ok":false,"error_code":...}`）。
- native Windows → `REMOTE_NOT_SUPPORTED`（POSIX-only；lifecycle 用 POSIX primitive）。

**設計歷程**：spec 經 2 輪 Codex adversarial review（信任邊界／GatewayPorts fail-closed／readiness／registry／雙 NAT 硬化）；實作以 TDD 逐任務 + task review + opus 全分支審收斂。

## Test Plan

- [x] 執行 `python3 -m pytest -q tests/` — 1196 passed、無新增失敗
- [x] 執行 `python3 -m policy_check --repo .` — 通過（R-22 為 pre-existing advisory warn）
- [x] **docker 三拓樸驗收** `./tools/docker/remote_tunnel_test.sh` — `PASS`（direct／NAT→host／NAT←client，含 tcp + `--remote-socket` 硬化全鏈）；每拓樸驗**預設不啟用**、**手動啟動後 `session list`/`cmd submit` 正常**、**serialwrapd pid 不變**、**teardown 乾淨**；另驗 loopback `ss` 不變量、跨容器攻擊者隔離、`GatewayPorts=yes` fail-closed、`-L` 端到端誠實

## Policy Checklist (R-11)

- [x] 分支不是 `main`（`feature/remote-tunnel-cli`）
- [x] 變更已記錄：`changelog.d/remote-tunnel-cli.md`（+ `remote-tunnel-attacker-isolation.md`／`remote-tunnel-windows-guard-hoist.md`）
- [x] `VERSION` 已更新（若有版本號變動）— 本 PR 為 feature，無版本 bump
- [x] `python3 -m pytest -q tests/` 通過（無新失敗）
- [x] `python3 -m policy_check --repo .` 通過
- [x] 四份 agent 檔案已同步（本 PR 未修改 `CLAUDE.md` 等，無需同步）
- [x] 已標記適用 label — 無需 exemption label

## Issue Reference

無對應 issue（查無相關 issue，照常進行）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qPdqCND6FkefauydhBUZ6
