### PR TITLE
docs(skill): 補上 remote-socket 硬化模式的 agent 端連線指引

### DIFF
--- a/changelog.d/remote-tunnel-client-skill-doc.md
+++ b/changelog.d/remote-tunnel-client-skill-doc.md
@@ -1,0 +1,5 @@
+---
+type: feat
+scope: skill
+---
+`SKILL.md` 的 Remote Support 章節補上 `--remote-socket` 硬化模式下的 agent 端連線格式（`unix:///path/to.sock`）、`remote_hint` 欄位在該模式下不會更新為 unix endpoint 的已知落差，以及給「隧道對端」agent 的操作提醒（`--source` 標記、共用硬體先 `session self-test`、隧道非常駐服務需回報而非自行繞過）。

--- a/sw_core/assets/skill/SKILL.md
+++ b/sw_core/assets/skill/SKILL.md
@@ -110,6 +110,25 @@ Agent 端連線（依拓樸擇一）：
 
 安全：隧道讓對端全權操控 DUT。**只用單租戶／可信 relay**；共享 relay 加 `--remote-socket /path`（遠端改建檔案權限把關的 unix socket）。`-R` tcp 模式若偵測遠端被 `GatewayPorts` 綁到對外，會拒絕（`REMOTE_BIND_UNVERIFIED`）。
 
+### `--remote-socket` 模式：agent 端連線格式與已知落差
+
+硬化後對端**不開 TCP port**，只落地一個檔案權限管控的 unix socket。agent 端連線指令要相應改為：
+
+```bash
+serialwrap --endpoint unix:///path/to.sock session list
+```
+
+**已知落差**：`serialwrap remote` 回傳 JSON 裡的 `remote_hint` 欄位固定顯示 `tcp://127.0.0.1:<port>`，**不會**因為用了 `--remote-socket` 而更新——照抄會連不上（該 port 根本沒開）。硬化模式下請忽略 `remote_hint`，改用 `unix://` + 該次回傳的 `remote_bind` 欄位組出正確 endpoint。
+
+### 給「隧道對端」agent 的操作提醒
+
+若你是被交接 `--endpoint`（tcp 或 unix）的那一端，而非起隧道的那一端：
+
+- 每筆命令帶 `--source agent:<your-name>`，方便回溯是誰下的。
+- 這條隧道等同對端全權操控 DUT／STA（`command.submit`／`file.push`／`daemon.stop` 皆可達，daemon 不做額外身分驗證，安全性完全靠 ssh）。共用硬體時，動作前先 `session self-test` 確認目前狀態、無人在用再下手。
+- 隧道是背景 ssh process，不是常駐服務；UART host 重開機或該 ssh process 被殺掉都會讓連線失效。你這端沒有權限重建，遇到 `SOCKET_ERROR` 或連不上時回報給 UART host 那邊的操作者，不要自行嘗試繞過。
+- 不要直接碰 `/dev/ttyUSB*`；一切透過 `serialwrap` CLI 走 broker 仲裁（見上方「安全規則」）。
+
 ## Event Trigger Engine
 用於 UART RX 觸發自動化 handler。**先呼叫 `serialwrap event status`** 確認狀態再 enable/disable，避免假設狀態。
 ```bash


### PR DESCRIPTION
## 摘要
- SKILL.md 的 Remote Support 章節補上 `--remote-socket` 硬化模式下 agent 端正確的 `--endpoint` 格式（`unix:///path/to.sock`）
- 記錄已知落差：`serialwrap remote` 回傳的 `remote_hint` 欄位在 `--remote-socket` 模式下仍顯示 tcp endpoint，不會更新為 unix endpoint，照抄會連不上
- 新增給「隧道對端」agent 的操作提醒：`--source` 標記、共用硬體先 `session self-test`、隧道非常駐服務需回報而非自行繞過

## 背景
實際部署一條 `--remote-socket` 硬化的反向 tunnel（testpilot UART host → build20）時發現，CLI 回傳的 `remote_hint` 沒有對應 `--remote-socket` 更新，若照抄會連不上；用手動 `ss`／unix socket RPC 驗證後才找到正確連線方式。這次補進 skill 文件，避免下次踩同樣的坑。

## 測試
- `python3 -m pytest -q tests/`：1312 passed, 16 skipped, 0 failed。exit code 因 suite 結尾的 live-guard 環境檢查非零（偵測到 live session TX 在測試期間前進），但兩次重跑各自命中不同 session（COM0 vs COM1），研判是同機另一背景 agent（`.worktrees/reliability-plugin` 的 realhw 真機測試）並行占用實體 UART 造成，與本次純文件變更無關，且非新增的測試失敗。
- `python3 -m policy_check --repo .`：無 FAIL；僅既有 R-22 advisory warning（94 筆與本次變更無關的歷史 dangling reference）。

## Test plan
- [x] `tests/test_skill_cmd.py` 相關測試綠燈（含在全套 pytest 內）
- [x] policy_check 無新增 FAIL

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_018DTCNn2DTinQRAFqD6Z4xV