### PR TITLE
chore(policy): 遷移至 project-policy manifest

### DIFF
--- a/.github/workflows/policy-check.yml
+++ b/.github/workflows/policy-check.yml
@@ -6,8 +6,8 @@ permissions:
 
 jobs:
   policy:
-    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@ee87a6d5ed91209d944934a2559f4f2622fd1ac2 # v1.0.10
+    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@451c2680fb3a1f977fcbc8007baaa7dbe415cf03 # v1.0.14
     with:
       policy_profile: flat
-      policy_version: "1.0.10"
-      policy_engine_ref: ee87a6d5ed91209d944934a2559f4f2622fd1ac2
+      policy_version: "1.0.14"
+      policy_engine_ref: 451c2680fb3a1f977fcbc8007baaa7dbe415cf03

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,11 @@ permissions:
 
 jobs:
   project-policy:
-    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@ee87a6d5ed91209d944934a2559f4f2622fd1ac2 # v1.0.10
+    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@451c2680fb3a1f977fcbc8007baaa7dbe415cf03 # v1.0.14
     with:
       policy_profile: flat
-      policy_version: "1.0.10"
-      policy_engine_ref: ee87a6d5ed91209d944934a2559f4f2622fd1ac2
+      policy_version: "1.0.14"
+      policy_engine_ref: 451c2680fb3a1f977fcbc8007baaa7dbe415cf03
 
   publish:
     runs-on: ubuntu-latest

--- a/.project-policy.yml
+++ b/.project-policy.yml
@@ -1,5 +1,5 @@
 policy_profile: flat
-policy_version: "1.0.10"
+policy_version: "1.0.14"
 # 內容分類（R-21）：serialwrap 為通用序列工具、無雇主機密 → 維持 public
 tier: shareable
 secret_scan:
@@ -40,3 +40,16 @@ cli:
     help_args: ["--help"]
     reflected_in: "README.md"
     marker: "serialwrap-remote-help"
+preflight:
+  steps:
+    - name: openspec
+      kind: validation
+      argv: ["openspec", "validate", "--all", "--strict"]
+      when_path_exists: "openspec"
+      timeout_seconds: 300
+    - name: tests
+      kind: tests
+      argv: ["python3", "-m", "pytest", "-q", "tests/"]
+      timeout_seconds: 1800
+conventions_engine:
+  repo: hamanpaul/paulsha-conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,11 +40,11 @@ policy_version: 1.0.14
   ```bash
   python3 -m policy_check --repo .
   ```
-- policy engine pinned SHA：`ee87a6d5ed91209d944934a2559f4f2622fd1ac2`。
+- policy engine pinned SHA：`451c2680fb3a1f977fcbc8007baaa7dbe415cf03`（v1.0.14）。
 - 安裝命令：
   ```bash
   python3 -m pip install --user --disable-pip-version-check \
-    "git+https://github.com/hamanpaul/paulsha-conventions.git@ee87a6d5ed91209d944934a2559f4f2622fd1ac2"
+    "git+https://github.com/hamanpaul/paulsha-conventions.git@451c2680fb3a1f977fcbc8007baaa7dbe415cf03"
   ```
 
 ## Agent 檔案同步政策

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.10 -->
+<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.14 -->
 <!-- CLAUDE.md 為單一事實來源；AGENTS.md / GEMINI.md / .github/copilot-instructions.md 為指向本檔的 symlink，只需維護本檔 -->
-policy_version: 1.0.10
+policy_version: 1.0.14
 <!-- policy_version 為 policy_check R-14 machine-readable marker；需保持裸行格式，請勿移入 frontmatter 或 code block。 -->
 
 # serialwrap — AI Agent Policy Checklist
@@ -58,7 +58,7 @@ policy_version: 1.0.10
     ln -sf CLAUDE.md GEMINI.md
     ln -sf ../CLAUDE.md .github/copilot-instructions.md
     ```
-- 本檔首行保留 `<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.10 -->`，第 3 行保留裸行 `policy_version: 1.0.10`（R-14 machine-readable marker，勿移入 frontmatter 或 code block）。
+- 本檔首行保留 `<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.14 -->`，第 3 行保留裸行 `policy_version: 1.0.14`（R-14 machine-readable marker，勿移入 frontmatter 或 code block）。
 
 ## PR 政策
 


### PR DESCRIPTION
## 摘要

- 將 legacy `.paul-project.yml` rename 為 canonical `.project-policy.yml`。
- 同步 agent policy marker 與 reusable workflow／engine pin 至 paulsha-conventions v1.0.14。
- 宣告 repo-owned preflight，保留本 repo 自有 OpenSpec／測試 gate。

## 驗證

- [x] canonical manifest schema、agent marker、workflow version 與 engine attestation 對齊
- [x] repo-owned OpenSpec 與測試命令通過
- [x] 已自行檢視完整 diff，未改寫歷史 archive provenance

## 完成前 checklist

- [x] 變更範圍限於 manifest migration、active consumer／文件與 gate
- [x] code path 變更的 repo 已新增 `changelog.d` fragment
- [x] README／active docs 已同步 canonical manifest 名稱
- [x] 不需要 policy exemption label