### PR TITLE
chore(policy): 同步 project policy 1.0.14 → 1.0.15

### DIFF
--- a/.github/workflows/policy-check.yml
+++ b/.github/workflows/policy-check.yml
@@ -6,8 +6,8 @@ permissions:
 
 jobs:
   policy:
-    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@451c2680fb3a1f977fcbc8007baaa7dbe415cf03 # v1.0.14
+    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@a764806046c410eb4f254ac0b6a8aec8b7559dab # v1.0.15
     with:
       policy_profile: flat
-      policy_version: "1.0.14"
-      policy_engine_ref: 451c2680fb3a1f977fcbc8007baaa7dbe415cf03
+      policy_version: "1.0.15"
+      policy_engine_ref: a764806046c410eb4f254ac0b6a8aec8b7559dab

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,11 @@ permissions:
 
 jobs:
   project-policy:
-    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@451c2680fb3a1f977fcbc8007baaa7dbe415cf03 # v1.0.14
+    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@a764806046c410eb4f254ac0b6a8aec8b7559dab # v1.0.15
     with:
       policy_profile: flat
-      policy_version: "1.0.14"
-      policy_engine_ref: 451c2680fb3a1f977fcbc8007baaa7dbe415cf03
+      policy_version: "1.0.15"
+      policy_engine_ref: a764806046c410eb4f254ac0b6a8aec8b7559dab
 
   publish:
     runs-on: ubuntu-latest

--- a/.project-policy.yml
+++ b/.project-policy.yml
@@ -1,5 +1,5 @@
 policy_profile: flat
-policy_version: "1.0.14"
+policy_version: "1.0.15"
 # 內容分類（R-21）：serialwrap 為通用序列工具、無雇主機密 → 維持 public
 tier: shareable
 secret_scan:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.14 -->
+<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.15 -->
 <!-- CLAUDE.md 為單一事實來源；AGENTS.md / GEMINI.md / .github/copilot-instructions.md 為指向本檔的 symlink，只需維護本檔 -->
-policy_version: 1.0.14
+policy_version: 1.0.15
 <!-- policy_version 為 policy_check R-14 machine-readable marker；需保持裸行格式，請勿移入 frontmatter 或 code block。 -->
 
 # serialwrap — AI Agent Policy Checklist
@@ -40,11 +40,11 @@ policy_version: 1.0.14
   ```bash
   python3 -m policy_check --repo .
   ```
-- policy engine pinned SHA：`451c2680fb3a1f977fcbc8007baaa7dbe415cf03`（v1.0.14）。
+- policy engine pinned SHA：`a764806046c410eb4f254ac0b6a8aec8b7559dab`（v1.0.15）。
 - 安裝命令：
   ```bash
   python3 -m pip install --user --disable-pip-version-check \
-    "git+https://github.com/hamanpaul/paulsha-conventions.git@451c2680fb3a1f977fcbc8007baaa7dbe415cf03"
+    "git+https://github.com/hamanpaul/paulsha-conventions.git@a764806046c410eb4f254ac0b6a8aec8b7559dab"
   ```
 
 ## Agent 檔案同步政策
@@ -58,7 +58,7 @@ policy_version: 1.0.14
     ln -sf CLAUDE.md GEMINI.md
     ln -sf ../CLAUDE.md .github/copilot-instructions.md
     ```
-- 本檔首行保留 `<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.14 -->`，第 3 行保留裸行 `policy_version: 1.0.14`（R-14 machine-readable marker，勿移入 frontmatter 或 code block）。
+- 本檔首行保留 `<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.15 -->`，第 3 行保留裸行 `policy_version: 1.0.15`（R-14 machine-readable marker，勿移入 frontmatter 或 code block）。
 
 ## PR 政策
 

--- a/changelog.d/policy-1.0.15-sync.md
+++ b/changelog.d/policy-1.0.15-sync.md
@@ -1,0 +1,5 @@
+---
+type: change
+scope: policy
+---
+同步 hamanpaul project policy 1.0.14 → 1.0.15：`.project-policy.yml`、`Policy Check` workflow **與** `Publish Release` workflow（`uses:` 與 `policy_engine_ref` 雙重釘選至 `a764806046c410eb4f254ac0b6a8aec8b7559dab`）、canonical `CLAUDE.md`（symlink `AGENTS.md` / `GEMINI.md` / `.github/copilot-instructions.md` 自動跟隨，含內文兩處內嵌 pinned SHA 安裝指令引用）全數同步至 v1.0.15。


### PR DESCRIPTION
## 摘要

- 同步 hamanpaul project policy 1.0.14 → 1.0.15：`.project-policy.yml`、`Policy Check` workflow **與** `Publish Release` workflow（兩支 workflow 都帶 policy 引用，`uses:` / `policy_engine_ref` 雙重釘選至新 SHA）、canonical `CLAUDE.md`（symlink 三檔自動跟隨，含內文兩處內嵌 pinned SHA 安裝指令）。
- 新增 `changelog.d/policy-1.0.15-sync.md` fragment 描述本次升級（本 repo 原無 `changelog.d/` 目錄，已全數收斂進歷史 CHANGELOG）。

## 測試

- `python3 -m pytest -q tests/`
- collate 乾跑：1 個 fragment 通過。
