### PR TITLE
fix(regression): f7 工具探測 sentinel 誤判＋#166 根因翻案（兩板皆缺 base64）

### DIFF
--- a/docs/regression-plugin.md
+++ b/docs/regression-plugin.md
@@ -83,7 +83,7 @@ doctor 全綠、testbed 板卡 READY、tmux/minicom 存在、無殘留 throwaway
 | case | 狀態 | 原因 |
 |---|---|---|
 | `f4-background-result-tail-consistent` | **FAIL（刻意保留的紅燈哨兵）** | #159：background quiet-window 對快速完成命令整段吞輸出且回 `lost: False`——case 正確抓到產品缺陷，**勿改 oracle 遷就**；#159 修復即轉綠 |
-| `f7-binary-roundtrip-md5`／`f7-larger-file-not-truncated` | 逐板嘗試（prpl 環境性失敗→試 bcm；全板失敗才 SKIP `transfer_env_all_boards`） | #161 echo-ACK 已交付且安全網驗證正確（停滯即中止、命令未執行、`TRANSFER_ECHO_STALL` 可診斷）；prpl/COM0 仍在**固定的第 449–512 字元**停滯（調 timeout 2.0→5.0 位置不變＝回顯從未到達，屬傳輸層問題）→ **#166** 追蹤。COM1(bcm) 板端缺 `base64` applet，屬獨立板端限制 |
+| `f7-binary-roundtrip-md5`／`f7-larger-file-not-truncated` | 逐板嘗試；兩板皆 SKIP `target_tool_missing`（誠實判定） | **#166 根因翻案**：傳輸層無罪（手工 base64 往返 md5 完全一致），**兩塊 bench 板都沒有 `base64`**（PATH 與 busybox applet 皆無；`md5sum`／`openssl` 有）——協定硬依賴 `base64` 才是根因。先前 COM0「工具齊全」是探測 sentinel 誤判（命令本文含 `TOOLS_OK`、回顯即恆真，已改用 `TOOLS_$((6*7))`）。另附帶：prpl console 有 **505 字元單行上限**（超過即靜默截斷、status 仍 done），是 chunk 512 撞 `TRANSFER_ECHO_STALL` 的原因 |
 
 #156（recover CTRL_C 路徑不 flush 佇列）已修——根因＝`SessionManager` 無管道通知
 `CommandArbiter` flush，新增 `on_command_flush` callback 補上該分支（`session_manager.py`

--- a/regression/serialwrap_regression/cases/f07_file_transfer.py
+++ b/regression/serialwrap_regression/cases/f07_file_transfer.py
@@ -68,14 +68,20 @@ def _probe_target_tools(ctx: Any, com: str) -> bool | None:
     既可能是板端缺工具（環境、SKIP），也可能是工具都在但傳輸真的壞掉（#32 類回歸、FAIL）。
     先探測工具存在性，後續判定才能分流。
     """
-    # 用 which 而非 command -v（聚焦複驗實證：bcm 板 shell 無 `command` builtin，
-    # `command -v` 回 'sh: command: not found' 被誤判成工具缺失）。busybox which 皆備。
+    # 用 which 而非 command -v（bcm 板 shell 無 `command` builtin，`command -v` 回
+    # 'sh: command: not found' 被誤判成工具缺失）。busybox which 皆備。
+    #
+    # sentinel 必須是**命令本文裡不會出現的字串**（#166 實證）：舊版用
+    # `... && echo TOOLS_OK` 再判 `"TOOLS_OK" in stdout`，但命令回顯本身就含
+    # 該字面，只要板端有回顯就恆為真——COM0(prpl) 因此被誤判成「工具齊全」，
+    # 走進 push 後才在傳輸尾端以 CHECKSUM_MISMATCH 收場。改用算式讓期望輸出
+    # （TOOLS_42）只可能來自實際執行結果。
     probe = ctx.sw.submit_and_wait(
-        com, "which base64 >/dev/null 2>&1 && which md5sum >/dev/null 2>&1 && echo TOOLS_OK")
+        com, "which base64 >/dev/null 2>&1 && which md5sum >/dev/null 2>&1 && echo TOOLS_$((6*7))")
     ctx.note(f"{com}-tools-probe.json", str(probe))
     if probe.get("status") != "done":
         return None
-    return "TOOLS_OK" in (probe.get("stdout") or "")
+    return "TOOLS_42" in (probe.get("stdout") or "")
 
 
 def _transfer_failure_verdict(resp: dict[str, Any], *, verb: str,


### PR DESCRIPTION
## Summary

追 #166 時逐層拆解，**推翻了原本「無流控節流掉字」的假說**，並揪出一個 regression case 的探測 bug。本 PR 修 case 側（產品側修法留在 #166）。

### 逐層實驗與結論

1. **傳輸層無罪**：手工送 172 字元 base64 到 COM0，板端 `wc -c` 回 172＝送出量，**板端檔案 md5 與本地完全一致**（`7ca5bce7…`）——一個字元都沒掉、沒改。
2. **真根因**：`base64 -d` 解碼對不上，直接看錯誤是 `/bin/ash: base64: not found`；盤點後 **COM0(prpl)／COM1(bcm) 兩板都沒有 `base64`**（PATH 與 busybox applet 皆無），`md5sum`／`openssl` 則都有。協定硬依賴 `base64` 才是根因；先前的 `TRANSFER_ECHO_STALL`／`CHECKSUM_MISMATCH` 都是它的下游。
3. **case 探測 bug（本 PR 修）**：`_probe_target_tools` 用 `... && echo TOOLS_OK` 再判 `"TOOLS_OK" in stdout`，但**命令本文自身就含該字面**——板端有回顯就恆為真。COM0 因此被誤判成「工具齊全」而走進 push；COM1 剛好 stdout 為空才判對。改用算式 sentinel（`echo TOOLS_$((6*7))` → 比對 `TOOLS_42`），期望輸出只可能來自實際執行。
4. **附帶發現（已記入 #166 與 docs）**：prpl console 有 **505 字元單行上限**——`echo A*n` 的 stdout 應為 2n，n≤505 完全正確、n≥520 封頂在 1010 且 `status=done` **靜默截斷**；bcm 無此限制。這正是 chunk 512（base64 684 字元）撞 `TRANSFER_ECHO_STALL` 的原因。

修完之後 F7 兩案會在兩塊板上都如實 SKIP `target_tool_missing`（誠實判定），不再誤入 push 路徑產生誤導性的傳輸層失敗訊號。

### 回歸 case 評估（CLAUDE.md 政策）

本 PR 修的就是 regression case 自身的探測邏輯＋文件；產品側（協定改用工具偵測鏈／`openssl base64 -d` fallback／單行長度納入 profile）留在 **#166** 追蹤，屆時 F7 兩案即為其驗證面。

## Test Plan

- [x] `python3 -m pytest -q tests/` — 1577 passed（一次跑到既知 PTY flaky，重跑全綠）
- [x] `python3 -m policy_check --repo .` — exit 0
- [x] 實機盤點：兩板 `which base64` → MISSING、`busybox base64` → MISSING、`md5sum`／`openssl` → HAVE；舊 sentinel 在 COM0 恆真（`TOOLS_OK in stdout = True`，raw 為命令回顯）

## Policy Checklist (R-11)

- [x] 分支不是 `main`
- [x] 變更已記錄（純 regression case／docs 修正，無 production code 變更）
- [x] `VERSION` 已更新（不適用）
- [x] `python3 -m pytest -q tests/` 通過
- [x] `python3 -m policy_check --repo .` 通過
- [x] 四份 agent 檔案已同步（symlink 單一來源）
- [x] 已標記適用 label（不適用）
- [x] 回歸 case 評估已記錄（見上）

## Issue Reference

Refs #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEFeCNDVoCG3tZKtDgbxY1