### PR TITLE
fix(cli): RPC 失敗 stderr 補齊 message/hint，非 RPC 錯誤出口不再空印（#172）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1543,6 +1543,8 @@ serialwrap session self-test --selector COM0
 若 `session attach` 剛好撞上 DUT 開機窗，target 仍在噴 boot log 或 prompt 尚未出現，session 可能暫時停在非 `READY`：
 
 > **`session attach` 回傳契約（#94）**：command-capable session 未能自動達 `READY` 時，`session attach` 會回**非零 exit（`2`）+ 頂層 `error_code`**（如 `PROMPT_UNAVAILABLE`、`RX_FLOOD`），CLI 並在 stderr 印一行具體錯誤（早期版本一律回 `ok:true`、錯誤只埋在 `session.last_error`，上層因而拿到空 error）。這是「尚未達 READY」的**誠實回報、可重試**——daemon 會有界自動重探、通常數秒內回 `READY`（`RX_FLOOD` 為洪水排空後 3s 內接手，#153）——**非致命**；自動化上層應據此 retry/wait，勿當永久失敗。（仍回 `ok:true` 的例外：`READY`、`ATTACHING`（attach 進行中）、`RELEASED`（裝置已 release、回 `recommended_action=device_attach`、需 `device attach` 重取）、`platform=passthrough`（停 `ATTACHED` 即成功）。）
+>
+> **stderr 一行具體錯誤的完整形狀（#172）**：`serialwrap: {method 或 context} failed: {error_code}[: {message}][（hint: ...)]`——`error_code` 一定露出，`message`／`hint` 有值才追加在後。修正前 `_run_rpc` 有 `error_code` 時會把 `message` 短路丟掉（`SOCKET_ERROR` 的 `message` 正是 `str(OSError)`，是分辨 socket 路徑算錯／daemon 已死／權限不符的關鍵資訊），且 `daemon start`／`daemon stop`／`event`／`remote`／`setup`／`service` 等非 RPC 錯誤出口原本 exit 非零時 stderr 全空。只讀 stderr 的呼叫端（如 testpilot）現在能拿到完整原因，不再是冒號後空白的字面。
 
 ```bash
 serialwrap session self-test --selector COM0

--- a/changelog.d/172-stderr-full-error.md
+++ b/changelog.d/172-stderr-full-error.md
@@ -1,0 +1,27 @@
+---
+type: fix
+scope: cli
+issue: 172
+---
+
+CLI 失敗時 stderr 不再丟棄具體錯誤原因（#172）。
+
+- `_run_rpc`：原本 `resp.get("error_code") or resp.get("message")` 的 `or` 短路，讓有
+  `error_code` 時 `message` 永遠不會出現在 stderr——對 `SOCKET_ERROR` 來說，`message`
+  正是 `str(OSError)`（errno 與連線細節），三種截然不同的根因（socket 路徑算錯／daemon
+  已死／權限不符）被壓成同一個字串，只讀 stderr 的呼叫端（如 testpilot）事後無法定案。
+  現在 stderr 一行同時輸出 `error_code`、`message`（有值才追加）與 `hint`（有值才追加），
+  形狀為 `serialwrap: {method} failed: {code}[: {message}][（hint: ...)]`；
+  `serialwrap: {method} failed: {code}` 這段前綴逐字保留，既有以 substring 比對
+  `failed: SOCKET_ERROR` 之類的下游不受影響。
+- 新增 `_mirror_err()` helper，補齊先前只 `_print()` JSON 到 stdout、exit 非零時 stderr
+  卻全空的多個出口：`daemon start` 的 `--endpoint` 拒收 / `--endpoint`,`--socket` 不一致 /
+  systemd 監管模式重導 `service start`（含 `NEEDS_SUDO`）/ Windows 找不到 daemon binary /
+  env file 載入失敗 / daemon 提前結束 / daemon 逾時未就緒；`daemon stop` 重導
+  `service stop` 與 on-demand `daemon.stop` 失敗；`event` 未知子命令與各 `event.*` RPC
+  失敗；`remote`（native Windows 不支援 / tunnel 例外 / 未預期例外）；`setup` 的
+  `FLASHING_BUSY` 兩處；`service` 子命令失敗；未知頂層子命令的 `INVALID_ARGS`。stdout
+  的 JSON 契約與 `ok:True` 路徑完全不動。
+- 對應實地事故：systemd-system 模式未帶 `--with-sudo` 執行 `daemon start`
+  時，呼叫端原本只拿到 `serialwrap: daemon start failed: ` 這種冒號後空白的字面，
+  現在會看到 `NEEDS_SUDO` 與代跑提示（hint）。

--- a/docs/serialwrap-spec.md
+++ b/docs/serialwrap-spec.md
@@ -609,6 +609,22 @@ background mode 的 `command.result_tail` 在 capture 尚未建立時，會回�
 - `serialwrap wal export`
 - `serialwrap session pin|unpin`
 
+#### CLI 失敗輸出（stdout JSON + stderr 一行，#94／#172）
+
+任何子命令回應 `ok:false`（或非 RPC 的內部錯誤出口，如 `daemon start` 監管模式
+gate、`REMOTE_NOT_SUPPORTED`、`INVALID_ARGS`）且 exit code 非零時：
+
+- **stdout**：機器可解析 JSON（契約不變，含 `ok`／`error_code`／`message`／`hint` 等欄位）。
+- **stderr**：固定補一行 `serialwrap: {method 或 context} failed: {error_code}[: {message}][（hint: ...)]`。
+  - `{error_code}` 一定露出（下游可用 substring 比對，如 `failed: SOCKET_ERROR`）；
+    `message`／`hint` 有值才追加在後，缺席不補空段。
+  - #172 修正前：`_run_rpc` 用 `error_code or message` 短路，有 `error_code` 時
+    `message` 永遠看不到——`SOCKET_ERROR` 的 `message` 正是 `str(OSError)`（區分
+    socket 路徑算錯／daemon 已死／權限不符的關鍵資訊），且多個非 RPC 錯誤出口
+    （`daemon start`／`daemon stop`／`event`／`remote`／`setup`／`service` 等）
+    完全不印 stderr，只讀 stderr 判讀失敗原因的呼叫端（如 testpilot）因此拿到空
+    字串或只有 code 沒有原因。現已涵蓋所有「`_print(ok:false)` + 非零 exit」出口。
+
 #### session pin / unpin（動態裝置 profile 持久化，#95）
 
 `serialwrap session pin --selector <COM|alias|by-id|by-path> --profile <name>` 把裝置釘到指定 profile（最高優先，繞過動態偵測，跨重啟保留）；`serialwrap session unpin --selector <...>` 解除 pin（保留自動 sticky）。

--- a/sw_core/cli.py
+++ b/sw_core/cli.py
@@ -102,6 +102,47 @@ def _print(obj: dict[str, Any]) -> None:
     sys.stdout.write("\n")
 
 
+def _format_err_line(resp: dict[str, Any], *, context: str | None = None) -> str:
+    """把失敗回應組成一行 stderr 訊息（#172）：``error_code`` 一定露出，``message``／``hint``
+    有值才追加，不覆蓋、不省略。
+
+    **相容性關鍵**：``serialwrap: {context} failed: {code}`` 這段形狀不變（下游以
+    substring 比對，例如 ``failed: SOCKET_ERROR``）；``message``／``hint`` 只能「追加在
+    後」。若無 ``error_code`` 但有 ``message``，沿用 #94 既有 fallback（message 頂替
+    code 欄位），避免同一句話重複出現兩次。
+    """
+    error_code = resp.get("error_code")
+    message = resp.get("message")
+    if error_code:
+        code_str = error_code
+    elif message:
+        code_str = message
+        message = None
+    else:
+        code_str = "UNKNOWN_ERROR"
+    prefix = f"{context} " if context else ""
+    line = f"serialwrap: {prefix}failed: {code_str}"
+    if message:
+        line += f": {message}"
+    hint = resp.get("hint")
+    if hint:
+        line += f"（hint: {hint}）"
+    return line
+
+
+def _mirror_err(resp: dict[str, Any], *, context: str | None = None) -> None:
+    """在 stderr 補一行具體錯誤（#172）：涵蓋 ``_run_rpc`` 以外所有「``_print``
+    (ok:False) + 非零 exit」出口，避免只讀 stderr 判讀失敗原因的 consumer（如
+    testpilot）拿到空字串。
+
+    ``ok`` 為真時 no-op；``_run_rpc`` 已有自己的 stderr 行（見下方），不得再對其
+    呼叫本函式，否則會雙印同一筆錯誤。
+    """
+    if resp.get("ok"):
+        return
+    sys.stderr.write(_format_err_line(resp, context=context) + "\n")
+
+
 def _daemon_script_path() -> str:
     here = os.path.dirname(os.path.abspath(__file__))
     return os.path.normpath(os.path.join(here, "..", "serialwrapd.py"))
@@ -286,16 +327,20 @@ def _run_daemon_start(args: argparse.Namespace) -> int:
             message = "--endpoint 於 daemon start 僅接受 loopback tcp://（127.0.0.1/localhost/::1）作為本機 bind 位址"
         else:
             message = "--endpoint 不支援 daemon start（daemon 只能在本機啟動）"
-        _print({"ok": False, "error_code": "REMOTE_NOT_SUPPORTED", "message": message})
+        resp = {"ok": False, "error_code": "REMOTE_NOT_SUPPORTED", "message": message}
+        _print(resp)
+        _mirror_err(resp, context="daemon start")
         return 2
     if ep_arg and args.socket is not None and args.socket != ep_arg:
         # 同給 --endpoint 與 --socket 且不一致：冪等探測（走 --endpoint）與 spawn bind
         # （走 --socket）會指向不同位址，寧可顯式拒絕也不留下歧義（#131 review）。
-        _print({
+        resp = {
             "ok": False,
             "error_code": "INVALID_ARGS",
             "message": "--endpoint 與 --socket 不一致；daemon start 請擇一指定 bind 位址",
-        })
+        }
+        _print(resp)
+        _mirror_err(resp, context="daemon start")
         return 2
     # 監管模式 gate（#108 #1）：systemd 模式下重導到 `service start`，避免顯式 daemon
     # start 繞過 unit 管理另起非託管 daemon（對稱於 `daemon stop` → `service stop`）。
@@ -306,6 +351,10 @@ def _run_daemon_start(args: argparse.Namespace) -> int:
         resp = service_action("start", mode=mode, with_sudo=getattr(args, "with_sudo", False))
         resp["_routed_to"] = "service start"
         _print(resp)
+        # #172：service_action 的 NEEDS_SUDO／NO_SYSTEMD 等非 ok 回應原本只落在
+        # stdout JSON，stderr 全空——呼叫端（如 testpilot）只讀 stderr 時完全看不到
+        # 原因。
+        _mirror_err(resp, context="daemon start")
         return 0 if resp.get("ok") else 2
     # on-demand：spawn 前先對「使用者實際會連到的 endpoint」冪等探測，已有健康 daemon 則
     # no-op（#108 #1）。用 _resolve_endpoint 而非裸 args.socket，避免 config 記錄的 daemon
@@ -326,11 +375,13 @@ def _run_daemon_start(args: argparse.Namespace) -> int:
     if is_win:
         daemon_argv = _daemon_spawn_argv()
         if daemon_argv is None:
-            _print({
+            resp = {
                 "ok": False,
                 "error_code": "DAEMON_BINARY_NOT_FOUND",
                 "message": "找不到 serialwrapd（serialwrap.exe 同層或 PATH 上皆無）；請確認發行包完整",
-            })
+            }
+            _print(resp)
+            _mirror_err(resp, context="daemon start")
             return 2
     else:
         # POSIX：argv 組法逐字保留既有行為。
@@ -357,6 +408,7 @@ def _run_daemon_start(args: argparse.Namespace) -> int:
         if env_files:
             payload["env_files"] = [os.path.expanduser(path) for path in env_files]
         _print(payload)
+        _mirror_err(payload, context="daemon start")
         return 2
 
     if args.foreground:
@@ -385,7 +437,9 @@ def _run_daemon_start(args: argparse.Namespace) -> int:
     for attempt in range(attempts):
         time.sleep(0.2)
         if proc.poll() is not None:
-            _print({"ok": False, "error_code": "DAEMON_EXITED", "pid": proc.pid, "returncode": proc.returncode})
+            resp = {"ok": False, "error_code": "DAEMON_EXITED", "pid": proc.pid, "returncode": proc.returncode}
+            _print(resp)
+            _mirror_err(resp, context="daemon start")
             return 2
         resp = rpc_call(sock, "health.ping", {}, timeout_s=0.5)
         if resp.get("ok"):
@@ -399,7 +453,9 @@ def _run_daemon_start(args: argparse.Namespace) -> int:
             _print(result)
             return 0
 
-    _print({"ok": False, "error_code": "DAEMON_NOT_READY", "pid": proc.pid})
+    not_ready_resp = {"ok": False, "error_code": "DAEMON_NOT_READY", "pid": proc.pid}
+    _print(not_ready_resp)
+    _mirror_err(not_ready_resp, context="daemon start")
     return 2
 
 
@@ -414,11 +470,14 @@ def _run_daemon_stop(args: argparse.Namespace) -> int:
         resp = service_action("stop", mode=mode, with_sudo=with_sudo)
         resp["_routed_to"] = "service stop"
         _print(resp)
+        _mirror_err(resp, context="daemon stop")
         return 0 if resp.get("ok") else 2
-    # on-demand 模式：維持原有 RPC daemon.stop 路徑
+    # on-demand 模式：維持原有 RPC daemon.stop 路徑（不經 _run_rpc，故沿用其 stderr
+    # 格式，context 用實際 method 名，與 _run_rpc 的輸出一致，#172）
     resp = rpc_call(_resolve_endpoint(args), "daemon.stop", {}, timeout_s=2.0)
     if not resp.get("ok"):
         _print(resp)
+        _mirror_err(resp, context="daemon.stop")
         return 2
     _print(resp)
     return 0
@@ -586,8 +645,12 @@ def _run_rpc(args: argparse.Namespace, method: str, params: dict[str, Any]) -> i
     if not resp.get("ok"):
         # #94：失敗時除了 stdout 的機器可解析 JSON，另在 stderr 印一行具體 error，
         # 讓依 Unix 慣例讀 stderr 解釋非零 exit 的 consumer 不再拿到空字串。
-        err = resp.get("error_code") or resp.get("message") or "UNKNOWN_ERROR"
-        sys.stderr.write(f"serialwrap: {method} failed: {err}\n")
+        # #172：原本 `error_code or message` 短路讓有 error_code 時 message 永遠
+        # 看不到——SOCKET_ERROR 的 message 正是 errno + socket 路徑，不能丟。改用
+        # 與 `_mirror_err` 共用的 `_format_err_line`：code 一定露出，message／hint
+        # 追加在後，不覆蓋、不省略。不改呼叫 `_mirror_err`（會雙印同一行），本函式
+        # 自己組線。
+        sys.stderr.write(_format_err_line(resp, context=method) + "\n")
     _warn_version_mismatch(resp)
     return 0 if resp.get("ok") else 2
 
@@ -617,7 +680,8 @@ def _dispatch_event(args: argparse.Namespace) -> int:
     # event.rule_list／event.tail 這類查詢，目前也未列入，見 client.py）：
     # 未顯式指定 --timeout 時維持一般預設 5s；--retries 於此不轉發——轉發了
     # 也不會生效，維持現狀（#123）。
-    timeout_s = _effective_timeout_s(args, _EVENT_CMD_METHOD.get(args.event_cmd, f"event.{args.event_cmd}"))
+    method_name = _EVENT_CMD_METHOD.get(args.event_cmd, f"event.{args.event_cmd}")
+    timeout_s = _effective_timeout_s(args, method_name)
     if args.event_cmd == "add":
         with open(args.file, "r", encoding="utf-8") as f:
             params = json.load(f)
@@ -661,10 +725,16 @@ def _dispatch_event(args: argparse.Namespace) -> int:
             timeout_s=timeout_s,
         )
     else:
-        _print({"ok": False, "error_code": "UNKNOWN_EVENT_CMD", "cmd": args.event_cmd})
+        unknown_resp = {"ok": False, "error_code": "UNKNOWN_EVENT_CMD", "cmd": args.event_cmd}
+        _print(unknown_resp)
+        _mirror_err(unknown_resp, context="event")
         return 2
     _print(result)
     _warn_version_mismatch(result)
+    # #172：本函式的 rpc_call 不經 _run_rpc，其自帶的 stderr 行覆蓋不到這裡；
+    # 用真實 method 名（與 timeout 解析同一份 method_name）維持與 _run_rpc 一致
+    # 的輸出形狀。
+    _mirror_err(result, context=method_name)
     return 0 if result.get("ok") else 2
 
 
@@ -716,13 +786,13 @@ def _run_remote(args: argparse.Namespace) -> int:
     例外穿越 CLI 邊界。
     """
     if os.name == "nt":
-        _print(
-            {
-                "ok": False,
-                "error_code": "REMOTE_NOT_SUPPORTED",
-                "message": "native Windows 本期不支援 serialwrap remote；請手動 ssh -R（見 SKILL_WINDOWS.md）",
-            }
-        )
+        resp = {
+            "ok": False,
+            "error_code": "REMOTE_NOT_SUPPORTED",
+            "message": "native Windows 本期不支援 serialwrap remote；請手動 ssh -R（見 SKILL_WINDOWS.md）",
+        }
+        _print(resp)
+        _mirror_err(resp, context="remote")
         return 1
 
     from . import remote_tunnel as rt  # noqa: PLC0415
@@ -778,10 +848,14 @@ def _run_remote(args: argparse.Namespace) -> int:
         _print(res)
         return 0
     except rt.TunnelError as exc:
-        _print({"ok": False, "error_code": exc.code, "message": exc.message or exc.code})
+        resp = {"ok": False, "error_code": exc.code, "message": exc.message or exc.code}
+        _print(resp)
+        _mirror_err(resp, context="remote")
         return 1
     except Exception as exc:  # noqa: BLE001 — 任何非預期例外不得穿越 CLI 邊界
-        _print({"ok": False, "error_code": "INTERNAL_ERROR", "message": str(exc)})
+        resp = {"ok": False, "error_code": "INTERNAL_ERROR", "message": str(exc)}
+        _print(resp)
+        _mirror_err(resp, context="remote")
         return 1
 
 
@@ -865,8 +939,10 @@ def _run_setup(args: argparse.Namespace) -> int:
 
     # 4. flash 護欄前置：進行中且未 force → 立即中止，不物化、不動模式（Codex #1c）。
     if any_flashing and not args.force:
-        _print({"ok": False, "error_code": "FLASHING_BUSY",
-                "message": "flash 進行中，拒絕 setup（可用 --force 覆寫）"})
+        resp = {"ok": False, "error_code": "FLASHING_BUSY",
+                "message": "flash 進行中，拒絕 setup（可用 --force 覆寫）"}
+        _print(resp)
+        _mirror_err(resp, context="setup")
         return 2
 
     # 5. 物化套件資產到使用者可寫位置。
@@ -907,12 +983,14 @@ def _run_setup(args: argparse.Namespace) -> int:
             config_path=os.path.join(CONFIG_DIR, "config.yaml"),
         )
     except FlashingBusy as exc:
-        _print({
+        resp = {
             "ok": False,
             "error_code": "FLASHING_BUSY",
             "message": str(exc),
             "legacy": legacy,
-        })
+        }
+        _print(resp)
+        _mirror_err(resp, context="setup")
         return 2
 
     payload: dict[str, Any] = {
@@ -1618,6 +1696,7 @@ def main(argv: list[str] | None = None) -> int:
         mode = _default_runtime_config().mode() or "on-demand"
         result = service_action(args.action, mode=mode, with_sudo=args.with_sudo)
         _print(result)
+        _mirror_err(result, context=f"service {args.action}")
         return 0 if result.get("ok") else 2
 
     if args.cmd == "setup":
@@ -1632,7 +1711,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.cmd == "remote":
         return _run_remote(args)
 
-    _print({"ok": False, "error_code": "INVALID_ARGS"})
+    invalid_resp = {"ok": False, "error_code": "INVALID_ARGS"}
+    _print(invalid_resp)
+    _mirror_err(invalid_resp)
     return 2
 
 

--- a/tests/test_cli_stderr_full_error.py
+++ b/tests/test_cli_stderr_full_error.py
@@ -1,0 +1,130 @@
+"""#172：CLI 失敗時 stderr 不得丟棄 message／hint。
+
+涵蓋兩條驗收路徑：
+1. ``_run_rpc``：原本 ``error_code or message`` 短路讓有 ``error_code`` 時
+   ``message`` 永遠看不到——對不存在的 socket 下 ``session list``，
+   ``SOCKET_ERROR`` 的 ``message`` 正是 ``str(OSError)``（errno + socket 路徑），
+   必須同時出現在 stderr。
+2. 非 RPC 錯誤出口（``daemon start`` 於 systemd-system 模式重導 ``service start``
+   失敗，例如未帶 ``--with-sudo`` 觸發 ``NEEDS_SUDO``）：exit 非零時 stderr 不得
+   為空，須含 ``error_code`` 與 ``hint``。
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from unittest import mock
+
+from sw_core import cli
+
+
+class TestRunRpcStderrKeepsMessage(unittest.TestCase):
+    """驗收 1：對不存在的 socket 下 `session list`，stderr 含路徑與 errno。"""
+
+    def test_socket_error_stderr_includes_error_code_and_message(self) -> None:
+        socket_path = "/tmp/sw172-no-such-daemon.sock"
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = cli.main(["--socket", socket_path, "session", "list"])
+
+        self.assertEqual(rc, 2)
+        stderr_text = err.getvalue()
+        # code 一定露出（相容性關鍵：substring 比對 "failed: SOCKET_ERROR" 不得斷）
+        self.assertIn("failed: SOCKET_ERROR", stderr_text)
+        # #172 核心：message（含 errno，AF_UNIX ENOENT 的 str(OSError) 未含路徑本身，
+        # 由呼叫端 socket_path 提供上下文）不得再被短路丟棄
+        self.assertIn("[Errno 2]", stderr_text)
+        # stdout 仍是乾淨可解析 JSON（契約不變）
+        import json
+
+        parsed = json.loads(out.getvalue())
+        self.assertFalse(parsed["ok"])
+        self.assertEqual(parsed["error_code"], "SOCKET_ERROR")
+
+    def test_message_only_response_does_not_duplicate(self) -> None:
+        """無 error_code 但有 message（既有 #94 fallback）：不得重複印同一句話。"""
+        stub_resp = {"ok": False, "message": "boom"}
+        out, err = io.StringIO(), io.StringIO()
+        with mock.patch("sw_core.cli.rpc_call", return_value=stub_resp):
+            with redirect_stdout(out), redirect_stderr(err):
+                rc = cli.main(["session", "list"])
+
+        self.assertEqual(rc, 2)
+        stderr_text = err.getvalue()
+        self.assertEqual(stderr_text.count("boom"), 1)
+        self.assertIn("failed: boom", stderr_text)
+
+
+class TestNonRpcExitsMirrorStderr(unittest.TestCase):
+    """驗收 2：`daemon start` 重導 `service start`（systemd-system 未帶 --with-sudo）
+    失敗時，exit 2 且 stderr 含 NEEDS_SUDO 與 hint。"""
+
+    def _args(self) -> argparse.Namespace:
+        return argparse.Namespace(
+            profile_dir="/tmp/profiles",
+            socket="/tmp/serialwrap.sock",
+            lock="/tmp/serialwrap.lock",
+            foreground=False,
+            with_sudo=False,
+            endpoint=None,
+        )
+
+    def test_daemon_start_needs_sudo_stderr_not_empty(self) -> None:
+        fake_rc = mock.Mock()
+        fake_rc.mode.return_value = "systemd-system"
+        needs_sudo_resp = {
+            "ok": False,
+            "mode": "systemd-system",
+            "action": "start",
+            "error_code": "NEEDS_SUDO",
+            "hint": "需 root：請執行 `sudo systemctl start serialwrap`（或加 --with-sudo 讓本指令代跑）",
+        }
+        out, err = io.StringIO(), io.StringIO()
+        with (
+            mock.patch("sw_core.cli._default_runtime_config", return_value=fake_rc),
+            mock.patch("sw_core.cli.service_action", return_value=dict(needs_sudo_resp)),
+            mock.patch("sw_core.cli.subprocess.Popen") as popen,
+            redirect_stdout(out),
+            redirect_stderr(err),
+        ):
+            rc = cli._run_daemon_start(self._args())
+
+        self.assertEqual(rc, 2)
+        popen.assert_not_called()
+        stderr_text = err.getvalue()
+        self.assertNotEqual(stderr_text, "", "非 RPC 錯誤出口的 stderr 不得為空（#172）")
+        self.assertIn("NEEDS_SUDO", stderr_text)
+        self.assertIn("需 root", stderr_text)  # hint 內容
+
+    def test_daemon_start_needs_sudo_via_main_exit_code_and_stderr(self) -> None:
+        """經 `main()` 整條路徑驗證（非直呼內部函式）：exit 2 且 stderr 非空。"""
+        fake_rc = mock.Mock()
+        fake_rc.mode.return_value = "systemd-system"
+        needs_sudo_resp = {
+            "ok": False,
+            "mode": "systemd-system",
+            "action": "start",
+            "error_code": "NEEDS_SUDO",
+            "hint": "需 root：請執行 `sudo systemctl start serialwrap`（或加 --with-sudo 讓本指令代跑）",
+        }
+        out, err = io.StringIO(), io.StringIO()
+        with (
+            mock.patch("sw_core.cli._default_runtime_config", return_value=fake_rc),
+            mock.patch("sw_core.cli.service_action", return_value=dict(needs_sudo_resp)),
+            mock.patch("sw_core.cli.subprocess.Popen") as popen,
+            redirect_stdout(out),
+            redirect_stderr(err),
+        ):
+            rc = cli.main(["daemon", "start"])
+
+        self.assertEqual(rc, 2)
+        popen.assert_not_called()
+        stderr_text = err.getvalue()
+        self.assertIn("NEEDS_SUDO", stderr_text)
+        self.assertIn("hint", stderr_text.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `_run_rpc` 的 stderr 行原本用 `resp.get("error_code") or resp.get("message")` 短路，有 `error_code` 時 `message` 永遠不會出現在 stderr。`SOCKET_ERROR` 的 `message` 正是 `str(OSError)`（區分 socket 路徑算錯 / daemon 已死 / 權限不符的關鍵資訊），只讀 stderr 的呼叫端（如 testpilot）因此完全看不到根因。
- 另有一批非 RPC 錯誤出口（`daemon start` 的 `REMOTE_NOT_SUPPORTED` / `--endpoint`,`--socket` 不一致 / 監管模式 gate 重導 `service_action`（含 `NEEDS_SUDO`）/ Windows 找不到 daemon binary / env file 載入失敗 / daemon 提前結束 / daemon 逾時未就緒；`daemon stop` 重導 `service stop` 與 on-demand `daemon.stop`；`event` 未知子命令與各 `event.*` RPC；`remote`（native Windows 不支援 / tunnel 例外 / 未預期例外）；`setup` 的 `FLASHING_BUSY` 兩處；`service` 子命令；未知頂層子命令）只 `_print()` JSON 到 stdout、exit 非零時 stderr 全空。實地事故字面：呼叫端拿到 `serialwrap failed: daemon start: `（冒號後空白）。

## 變更點

- 新增共用 `_format_err_line()` / `_mirror_err()`：從回應 dict 取 `error_code`／`message`／`hint`，組成 `serialwrap: {method 或 context} failed: {code}[: {message}][（hint: ...)]`。`error_code` 一定露出（相容既有下游 substring 比對，如 `failed: SOCKET_ERROR`），`message`／`hint` 只追加在後、不覆蓋、不省略；`message` 缺席時輸出照舊只有 code。
- `_run_rpc` 改用 `_format_err_line()` 自組（不套用 `_mirror_err()`，避免雙印同一筆錯誤）。
- 用 `grep '_print({"ok": False'` 逐一找出所有非 RPC 錯誤出口並補上 `_mirror_err()` 呼叫，涵蓋 `daemon start`／`daemon stop`／`event`／`remote`／`setup`／`service`／未知頂層子命令；`ok:True` 路徑與 stdout JSON 契約完全不動。
- README.md（zh-tw `session attach` 契約段）、`docs/serialwrap-spec.md`（新增 §11.1「CLI 失敗輸出（stderr）」小節）同步說明新的 stderr 形狀（R-18）。

## Validation

- `python3 -m pytest -q tests/`：**1581 passed, 16 skipped**（含新增 `tests/test_cli_stderr_full_error.py` 4 案：`_run_rpc` SOCKET_ERROR 含 `[Errno 2]`、message-only 回應不重複印、`daemon start` 於 systemd-system 未帶 `--with-sudo`（`NEEDS_SUDO`）直呼內部函式與經 `main()` 整條路徑兩種驗證）。conftest #120 liveguard 未觸發（全程未碰任何 live socket/systemd/serial 資源）。
- `python3 -m policy_check --repo .`：**25 pass / 0 fail / 1 warn**。warn 為 R-22 陳年既有 108 筆 dangling reference（本 PR 未新增，advisory，不擋）。

## Regression-case 評估

本 PR 修的是 CLI stderr 輸出格式（純字串組裝，無 daemon/socket/systemd 依賴），純 mock/單元測試即可完整覆蓋，**不需要 realhw family case**：

- 驗收 1（`session list` 對不存在 socket → `SOCKET_ERROR` + `[Errno 2]`）：用真實 `sw_core.client.rpc_call` 對一個確定不存在的 unix socket 路徑跑，走真實 OS ENOENT 路徑，非 mock 造假訊息，已在 `tests/test_cli_stderr_full_error.py::TestRunRpcStderrKeepsMessage` 覆蓋。
- 驗收 2（`daemon start` systemd-system 未帶 `--with-sudo` → `NEEDS_SUDO` + hint）：`service_action()` 本身（`sw_core/service_ctl.py`）不呼叫真實 `systemctl`（其 `fx.run()` 為 Effects boundary），mock 該邊界即可完整驗證 gate 邏輯與新 stderr 行為，已在 `tests/test_cli_stderr_full_error.py::TestNonRpcExitsMirrorStderr` 以「直呼內部函式」與「經 `main()` 整條路徑」兩種方式覆蓋。
- 其餘新增 mirror 呼叫點（`daemon stop`／`event`／`remote`／`setup`／`service`／未知頂層子命令）皆為單純字串組裝分支，既有 targeted CLI 測試（`test_cli_daemon_start.py`／`test_event_cli.py`／`test_setup_cli.py`／`test_remote_cli.py`）已驗證這些分支本身的邏輯正確、本 PR 不改其判斷條件，僅追加一行 stderr 輸出，風險低、不需另立 realhw case。

無已知殘留風險。

Closes #172