### PR TITLE
fix(daemon): POSIX 也寫入 config.yaml endpoint，補 doctor 診斷與 spawn 防線（#173）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1585,7 +1585,16 @@ serialwrap daemon status   # multi_open / foreign_holders 欄位
 - **`serialwrap daemon status`**：回應加三個欄位：
   - `multi_open`（bool）：是否偵測到一個以上 `serialwrapd`。
   - `foreign_holders`（`{tty_real_path: pid}`）：哪個 pid 持有目前 attach 中的 tty。
-  - `multi_open_detail`：`{"daemons": [{"pid": N}, ...], "holders_status": "ok" | "permission" | "unknown"}`。`holders_status` 在跨 uid 讀不到 `/proc/<pid>/fd` 時降級為 `permission`（仍確認另有 daemon 存在，但無法判定持有哪條 tty）；procfs 不可用時為 `unknown`。
+  - `multi_open_detail`：`{"daemons": [{"pid": N, "socket": "<path>" | null}, ...], "holders_status": "ok" | "permission" | "unknown"}`。`holders_status` 在跨 uid 讀不到 `/proc/<pid>/fd` 時降級為 `permission`（仍確認另有 daemon 存在，但無法判定持有哪條 tty）；procfs 不可用時為 `unknown`。`socket`（#173）是從各 daemon 的 `--socket` 引數擷取的值，讀不到時為 `null`。
+
+#### 自訂安裝路徑與 config.yaml 同步（#173）
+
+`serialwrapd` 啟動成功後一律把有效 bind endpoint 寫回 `config.yaml::socket_path`（POSIX／Windows 皆同）；任何未帶 `--socket`/`--endpoint` 的 client 都靠這個欄位發現 daemon 實際在哪。**若你的部署 wrapper 用環境變數（如 `SERIALWRAP_STATE_DIR`）把 socket 搬離 XDG 預設路徑，不需要再手動同步——daemon 自己會把實際生效的路徑寫進 `config.yaml`**。唯一要注意的是：不同的 wrapper／呼叫方之間 `SERIALWRAP_CONFIG_DIR`（或 `XDG_CONFIG_HOME`）必須解析到同一份 `config.yaml`，否則各自讀寫互不相干的檔案，等同沒有同步。
+
+兩個防線可提早抓到落差：
+
+- `serialwrap doctor` 的 `endpoint_reachable` 檢查：無 `serialwrapd` 行程在跑時為 advisory ok（on-demand 模式尚未啟動不是異常）；有行程在跑但本 client 解析到的 endpoint 連不上時判定 `not ok`，`detail` 同時列出本 client 解析到的路徑（含來源：`config.yaml` 或平台預設）與實際執行中 daemon 綁定的路徑。
+- `serialwrap daemon start` 的 on-demand spawn 防線：spawn 新 daemon 前先掃 `/proc`，若已有 `serialwrapd` 綁在與本次目標不同的 socket，預設拒絕（`error_code=DAEMON_ALREADY_RUNNING_ELSEWHERE`），避免同一批裝置被兩個 daemon 同時開啟（two-reader）；確認要另起一個獨立 daemon 才加 `--force-spawn`。同一個 socket 的既有冪等探測（已有健康 daemon 時 no-op）不受影響。
 
 ### Recover
 
@@ -1753,7 +1762,7 @@ serialwrap wal current-seq
 
 Windows daemon 以 **TCP loopback** 取代 AF_UNIX 做 RPC 控制通道，使 serialwrap CLI/agent 在 Windows 擁有完整指令路徑：
 
-- **RPC endpoint**：預設 `tcp://127.0.0.1:48700`，可以 `--socket` 參數或環境變數 `SERIALWRAP_ENDPOINT`（覆寫整個 endpoint，如 `tcp://127.0.0.1:50000`）、`SERIALWRAP_TCP_PORT`（僅覆寫 port 部分）覆寫。daemon 啟動後會把有效 endpoint 寫入 `config.yaml::socket_path`，CLI `_resolve_endpoint` 自動讀取。
+- **RPC endpoint**：預設 `tcp://127.0.0.1:48700`，可以 `--socket` 參數或環境變數 `SERIALWRAP_ENDPOINT`（覆寫整個 endpoint，如 `tcp://127.0.0.1:50000`）、`SERIALWRAP_TCP_PORT`（僅覆寫 port 部分）覆寫。daemon 啟動後會把有效 endpoint 寫入 `config.yaml::socket_path`，CLI `_resolve_endpoint` 自動讀取（#173 起 POSIX daemon 亦同，見下方「自訂安裝路徑與 config.yaml 同步」）。
 - **Singleton 鎖**：`msvcrt.locking`（`LK_NBLCK`）+ TCP connect 探測（`WindowsSingletonLock`，`sw_core/lock_win.py`）。語意與 POSIX `SingletonLock`（flock + Unix socket probe）對齊：endpoint 可連 → `DAEMON_ALREADY_RUNNING`；stale → 取得 msvcrt 檔鎖。
 - **COM 列舉與藍牙排除**：從 Windows registry `HKLM\HARDWARE\DEVICEMAP\SERIALCOMM` 列舉所有 COM port（`WindowsDeviceSource`，`sw_core/device_source.py`）；雙重排除藍牙——BTHENUM PortName 掃描（主判據）+ `bthmodem` device path 啟發式（兜底），確保藍牙裝置**永不被接管**。額外手動排除清單：`config.yaml::windows.exclude_coms`（如 `["COM3"]`）。
 - **閒置非藍牙 COM 自動接管**：偵測到不在排除清單的 COM 時，daemon 以 `passthrough` profile 自動建立 session（可觀察 UART 輸出；需要下命令請先 pin 適當 profile 並 attach）。已持續被外部程序佔用的 COM **不會每輪自動輪詢重試**（與 POSIX dynamic-session 同語意；需拔插或手動 `session bind`/`session clear` 觸發）。

--- a/changelog.d/173-endpoint-discovery.md
+++ b/changelog.d/173-endpoint-discovery.md
@@ -1,0 +1,44 @@
+---
+type: fix
+issue: 173
+---
+
+修正 daemon endpoint 無法被非 wrapper client 發現的問題（#173）：POSIX 上
+`serialwrapd` 過去只有 Windows 後端才會把實際 bind 的 socket 寫回
+`config.yaml`（理由是「POSIX on-demand 模式下 CLI 一定算得出同一個
+`SOCKET_PATH` 預設值」），但部署 wrapper 若以 `SERIALWRAP_STATE_DIR` 把 socket
+搬離 XDG 預設路徑，任何不經過該 wrapper 的 client（例如其他工具內嵌的
+venv、CI runner）就永遠連不到健康運作中的 daemon，只會拿到
+`SOCKET_ERROR`，且沒有任何診斷指出真正原因；更危險的是，這類「探測失敗」
+的 client 若接著自己觸發 on-demand `daemon start`，會在 XDG 預設路徑另外
+spawn 出第二個 daemon，兩個 daemon 同時開同一批裝置（two-reader）。
+
+三處修法：
+
+1. **daemon.py**：拿掉 `_write_config_endpoint()` 呼叫外層「僅 Windows」的
+   gate，改為 server 啟動成功後全平台無條件寫入 `config.yaml` 的
+   `socket_path`（`_write_config_endpoint` 本身不變，仍是 best-effort、失敗
+   只記 stderr、不影響 daemon 運行）。讓「daemon 實際綁在哪」有一個與呼叫端
+   環境變數無關的單一事實來源。
+2. **doctor**：新增 `endpoint_reachable` 檢查（非 advisory，會拉低整體
+   `ok`）。以與 CLI 相同的解析 seam 得出本 client 會連上的 endpoint 與其來源
+   （`config.yaml` 或平台預設），並掃 `/proc` 找出實際執行中的 `serialwrapd`
+   行程與其 `--socket` 引數：沒有任何 daemon 行程時視為 on-demand 模式正常
+   （advisory ok）；有行程但本 client 解析到的 endpoint 連不上時明確判定
+   `not ok`，`detail` 同時列出本 client 解析到的路徑（含來源）與實際執行中
+   daemon 綁定的路徑，方便一分鐘內定位落差，而不是像本次事故那樣耗掉一整個
+   下午。
+3. **`serialwrap daemon start`（on-demand spawn 防線）**：spawn 新 daemon
+   前先掃 `/proc`，若已有 `serialwrapd` 行程且其 `--socket` 與本次 spawn
+   目標不同，預設拒絕（`error_code=DAEMON_ALREADY_RUNNING_ELSEWHERE`，訊息
+   帶出兩個路徑與修復提示），避免同一批裝置被兩個 daemon 同時開啟；新增
+   `--force-spawn` 供已確認情境下跳過此防線。既有「同一個 socket」的冪等
+   探測路徑不受影響。
+
+`sw_core/multi_open.py` 的 `detect_multi_open()` 同步擴充：每個偵測到的
+daemon 項目現在附帶從 cmdline 擷取到的 `socket`（供上述 doctor 檢查與 spawn
+防線共用；擷取不到時為 `None`，呼叫端須視為「無法判定、保守處理」）。
+
+README.md 與 `docs/serialwrap-spec.md` 補充「自訂 wrapper 若以
+`SERIALWRAP_STATE_DIR` 搬移 socket，必須讓 config.yaml 同步（本修正後
+daemon 啟動即自動寫入，不需再手動處理）」的說明。

--- a/docs/serialwrap-spec.md
+++ b/docs/serialwrap-spec.md
@@ -418,7 +418,44 @@ dynamic 自動偵測 session 的 COM 編號**依裝置 by-id 字典序確定性�
 - **`serialwrap daemon status`**（RPC `health.status`）→ 回應加欄位：
   - `multi_open`（bool）。
   - `foreign_holders`（`{tty_real_path: pid}`）：持有目前 attach 中 tty 的 pid。
-  - `multi_open_detail`：`{"daemons": [{"pid": N}, ...], "holders_status": "ok" | "permission" | "unknown"}`。`holders_status` 在跨 uid 讀不到 `/proc/<pid>/fd` 時降級為 `permission`、procfs 不可用時為 `unknown`，此降級資訊本身即為輸出契約的一部分。
+  - `multi_open_detail`：`{"daemons": [{"pid": N, "socket": "<path>" | null}, ...], "holders_status": "ok" | "permission" | "unknown"}`。`holders_status` 在跨 uid 讀不到 `/proc/<pid>/fd` 時降級為 `permission`、procfs 不可用時為 `unknown`，此降級資訊本身即為輸出契約的一部分。`socket`（#173）為從各 daemon `--socket` 引數擷取的值（`sw_core/multi_open.py` 的 `_extract_socket_arg`），擷取不到時為 `null`。
+
+### 8.5a Endpoint 發現與跨進程一致性（#173）
+
+**根因**：POSIX `serialwrapd` 過去只有 Windows 後端會把有效 bind endpoint 寫回
+`config.yaml::socket_path`（`sw_core/daemon.py` `_write_config_endpoint`，理由是「POSIX
+on-demand 模式 CLI 一定算得出同一個 `SOCKET_PATH` 預設值」）。當部署 wrapper 以
+`SERIALWRAP_STATE_DIR` 之類的環境變數把 socket 搬離 XDG 預設路徑時，這個假設不成立：
+任何不經過該 wrapper 的 client 永遠解析不到 daemon 實際綁定的路徑，只會拿到
+`SOCKET_ERROR`，且沒有任何診斷指出真正原因；若該 client 進一步觸發 on-demand
+`daemon start`，還可能在 XDG 預設路徑另外 spawn 出第二個 daemon（two-reader）。
+
+**修法**（三個獨立防線）：
+
+1. **無條件寫入**：`_run_async` 於 `server.start()` 成功後呼叫
+   `_write_effective_endpoint(args)`（薄 wrapper，逕呼 `_write_config_endpoint`），全平台
+   一律寫入，不再有 `select_rpc_backend() == "win"` 的 gate。POSIX／Windows 現在行為對稱。
+2. **doctor `endpoint_reachable` 檢查**（`sw_core/doctor_cmd.py`，非 advisory）：
+   - 以與 CLI 相同的解析 seam（`cli._resolve_default_endpoint_with_source`，本質是
+     `_resolve_endpoint` 套一個「未帶 `--endpoint`/`--socket`」的 args 替身）得出本 client
+     會連上的 endpoint 與其來源（`config.yaml` 或平台預設）。
+   - 掃 `/proc` 找執行中的 `serialwrapd` 行程（沿用 `detect_multi_open`）。
+   - 判定：無 daemon 行程 → `ok=True`（on-demand 模式正常，不掛入
+     `DOCTOR_ADVISORY_CHECKS` 是因為「有行程但連不上」這個真正異常必須拉低整體 `ok`，
+     而非被 advisory 吞掉）；有行程且本 client 解析到的 endpoint 連不上 → `ok=False`，
+     `detail` 同時列出本 client 解析到的路徑（含來源）與實際執行中 daemon 綁定的路徑。
+3. **`daemon start` on-demand spawn 防線**（`cli._run_daemon_start`）：既有的「探測
+   `_resolve_endpoint(args)` 是否已有健康 daemon」冪等路徑之後、實際 `subprocess.Popen`
+   spawn 之前，新增 `cli._find_conflicting_daemon(sock)`——ground-truth 直接掃 `/proc`
+   （不依賴 `config.yaml`，因為後者正是本 issue 想修的東西，暫時失準時不能拿來當唯一防線）：
+   若找到「行程存在且其 `--socket` 與本次 spawn 目標 `sock` 不同」的 `serialwrapd`，回傳
+   `error_code=DAEMON_ALREADY_RUNNING_ELSEWHERE`（訊息帶出兩個路徑與修復提示），
+   `rc=2`、不 spawn。新增 CLI flag `--force-spawn` 可跳過此防線；與目標 `sock` 相同的既有
+   daemon 不算衝突（既有冪等探測已經處理）。
+
+**已知邊界**：`--force-spawn` 是使用者顯式的逃生門，不做進一步限制；`_find_conflicting_daemon`
+在找到第一個 socket 不同的行程即回傳，多個既有 daemon 並存時只回報其中一個（診斷已足夠指向
+「有衝突」，逐一列舉留給 `serialwrap daemon status` 的 `multi_open_detail`）。
 
 ### 8.6 human console 就緒檢查組（#149）
 

--- a/sw_core/cli.py
+++ b/sw_core/cli.py
@@ -276,6 +276,28 @@ def _probe_healthy_daemon(endpoint: str) -> bool:
     return bool(resp.get("ok"))
 
 
+def _find_conflicting_daemon(sock: str, proc_root: str = "/proc") -> dict[str, Any] | None:
+    """POSIX：掃 /proc 找是否已有 serialwrapd 綁在與 ``sock`` 不同的 socket（#173）。
+
+    ground-truth 來自 /proc（實際 argv），不依賴 config.yaml——後者在本 issue 修正前可能
+    從未寫入，修正後也可能因為多份安裝／舊 daemon 尚未重啟而暫時失準。
+
+    Returns:
+        第一個「行程存在且其 ``--socket`` 與 ``sock`` 不同」的 daemon 資訊
+        （``{"pid": int, "socket": str | None}``）；沒有 daemon，或既有 daemon 就綁在
+        同一個 ``sock``（既有冪等探測路徑已處理），回傳 ``None``。socket 從 cmdline 擷取
+        不到時（``None``，可能是舊版 daemon 或非典型 argv）仍視為衝突，因為無法排除是
+        同機另一個 daemon 佔用中。
+    """
+    from .multi_open import detect_multi_open  # noqa: PLC0415
+
+    mo = detect_multi_open(proc_root=proc_root)
+    for d in mo["daemons"]:
+        if d.get("socket") != sock:
+            return d
+    return None
+
+
 def _run_daemon_start(args: argparse.Namespace) -> int:
     is_win = _rpc_backend_is_win()  # backend 不會於呼叫中途改變，一次判定全函式共用
     ep_arg = getattr(args, "endpoint", None)
@@ -323,6 +345,29 @@ def _run_daemon_start(args: argparse.Namespace) -> int:
         sock = ep_arg
     else:
         sock = _local_default_endpoint()
+    # POSIX spawn 防線（#173）：冪等探測（上方 endpoint probe）只看「本 client 解析到的
+    # endpoint 是否健康」，config.yaml 記錄與實際 daemon 綁定的 socket 可能分歧（本 issue
+    # 根因）。直接掃 /proc 找 ground-truth：若已有 serialwrapd 綁在與本次 spawn 目標不同的
+    # socket，預設拒絕再開一個，避免同一批裝置被兩個 daemon 同時開啟（two-reader）。
+    # --force-spawn 可跳過；win backend 無 /proc 可掃，不適用。
+    if not is_win and not getattr(args, "force_spawn", False):
+        conflict = _find_conflicting_daemon(sock)
+        if conflict is not None:
+            existing_socket = conflict.get("socket") or "未知（無法從 /proc 讀出 --socket，可能是舊版 daemon）"
+            _print({
+                "ok": False,
+                "error_code": "DAEMON_ALREADY_RUNNING_ELSEWHERE",
+                "message": (
+                    f"偵測到另一個 serialwrapd（pid={conflict['pid']}）綁在 {existing_socket}，"
+                    f"與本次 daemon start 目標 {sock} 不同；為避免同一批裝置被兩個 daemon "
+                    "同時開啟（two-reader），預設拒絕再 spawn 一個。"
+                ),
+                "hint": f"改用 --socket {existing_socket} 指向現有 daemon；確認後要強制另起才加 --force-spawn",
+                "existing_socket": conflict.get("socket"),
+                "existing_pid": conflict["pid"],
+                "target_socket": sock,
+            })
+            return 2
     if is_win:
         daemon_argv = _daemon_spawn_argv()
         if daemon_argv is None:
@@ -532,6 +577,33 @@ def _resolve_endpoint(args: argparse.Namespace) -> str:
             )
             return canonical
     return chosen
+
+
+class _NoOverrideArgs:
+    """最小 args 替身：模擬『未帶 --endpoint/--socket』的一般 client 呼叫（#173 doctor 用）。"""
+
+    endpoint = None
+    socket = None
+
+
+def _resolve_default_endpoint_with_source() -> tuple[str, str]:
+    """比照一般未帶 ``--endpoint``/``--socket`` 的 client，解析其會連上的 endpoint，並回傳來源標籤。
+
+    來源標籤：``"config.yaml"``（讀到 config.yaml 記錄的 ``socket_path``）或
+    ``"預設"``（config.yaml 缺席／不可讀，落到 ``SOCKET_PATH``／``DEFAULT_ENDPOINT`` 平台
+    預設，可受 ``SERIALWRAP_STATE_DIR``／``SERIALWRAP_RUN_DIR`` 等環境變數影響）。
+    endpoint 本身透過 :func:`_resolve_endpoint` 解析（含 #108 dangling fallback），
+    故 doctor 據此得出的診斷與 CLI 實際行為不會分歧（#173）。
+    """
+    rc = _safe_runtime_config()
+    cfg_sock = None
+    if rc is not None:
+        try:
+            cfg_sock = rc.socket_path()
+        except Exception:  # noqa: BLE001
+            cfg_sock = None
+    source = "config.yaml" if cfg_sock else "預設（SOCKET_PATH，受 SERIALWRAP_STATE_DIR/XDG 環境變數影響）"
+    return _resolve_endpoint(_NoOverrideArgs()), source
 
 
 def _effective_timeout_s(args: argparse.Namespace, method: str) -> float:
@@ -985,6 +1057,16 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help="systemd-system 模式下，daemon start 重導至 service start 時以 sudo 執行",
+    )
+    p_ds.add_argument(
+        "--force-spawn",
+        dest="force_spawn",
+        action="store_true",
+        default=False,
+        help=(
+            "跳過『已有其他 socket 的 serialwrapd 在跑』防線，強制在本次目標 socket "
+            "另外 spawn（#173；預設拒絕，避免同機誤開第二個 daemon 造成 two-reader）"
+        ),
     )
 
     p_dstop = daemon_sub.add_parser("stop", help="停止執行中的 daemon")

--- a/sw_core/cli.py
+++ b/sw_core/cli.py
@@ -353,7 +353,20 @@ def _run_daemon_start(args: argparse.Namespace) -> int:
     if not is_win and not getattr(args, "force_spawn", False):
         conflict = _find_conflicting_daemon(sock)
         if conflict is not None:
-            existing_socket = conflict.get("socket") or "未知（無法從 /proc 讀出 --socket，可能是舊版 daemon）"
+            known_socket = conflict.get("socket")
+            existing_socket = known_socket or "未知（無法從 /proc 讀出 --socket，可能是舊版 daemon）"
+            # review：socket 讀不出來時不可把佔位字串塞進 --socket 建議（不可用且誤導），
+            # 改建議先以 daemon status / multi_open_detail 確認，逃生門只剩 --force-spawn。
+            if known_socket:
+                hint = (
+                    f"改用 --socket {known_socket} 指向現有 daemon；"
+                    "確認後要強制另起才加 --force-spawn"
+                )
+            else:
+                hint = (
+                    "先用 `serialwrap daemon status`（看 multi_open_detail）確認現有 daemon 的 "
+                    "socket；確認後要強制另起才加 --force-spawn"
+                )
             _print({
                 "ok": False,
                 "error_code": "DAEMON_ALREADY_RUNNING_ELSEWHERE",
@@ -362,7 +375,7 @@ def _run_daemon_start(args: argparse.Namespace) -> int:
                     f"與本次 daemon start 目標 {sock} 不同；為避免同一批裝置被兩個 daemon "
                     "同時開啟（two-reader），預設拒絕再 spawn 一個。"
                 ),
-                "hint": f"改用 --socket {existing_socket} 指向現有 daemon；確認後要強制另起才加 --force-spawn",
+                "hint": hint,
                 "existing_socket": conflict.get("socket"),
                 "existing_pid": conflict["pid"],
                 "target_socket": sock,
@@ -602,8 +615,20 @@ def _resolve_default_endpoint_with_source() -> tuple[str, str]:
             cfg_sock = rc.socket_path()
         except Exception:  # noqa: BLE001
             cfg_sock = None
-    source = "config.yaml" if cfg_sock else "預設（SOCKET_PATH，受 SERIALWRAP_STATE_DIR/XDG 環境變數影響）"
-    return _resolve_endpoint(_NoOverrideArgs()), source
+    resolved = _resolve_endpoint(_NoOverrideArgs())
+    if cfg_sock:
+        # review：_resolve_endpoint 可能因 #108 dangling fallback 改連 canonical
+        # endpoint（回傳值 ≠ config.yaml 記錄）；來源標籤必須如實區分，否則 doctor
+        # 顯示「來源：config.yaml」但實際連線位址不是，診斷會誤導。
+        if resolved == cfg_sock:
+            source = "config.yaml"
+        else:
+            source = (
+                f"config.yaml（記錄 {cfg_sock} 不可連，#108 dangling fallback 改用 canonical）"
+            )
+    else:
+        source = "預設（SOCKET_PATH，受 SERIALWRAP_STATE_DIR/XDG 環境變數影響）"
+    return resolved, source
 
 
 def _effective_timeout_s(args: argparse.Namespace, method: str) -> float:

--- a/sw_core/daemon.py
+++ b/sw_core/daemon.py
@@ -87,6 +87,19 @@ def _write_config_endpoint(endpoint: str) -> None:
         sys.stderr.write(f"serialwrapd: 寫入 config.yaml endpoint 失敗（非致命）: {exc}\n")
 
 
+def _write_effective_endpoint(args: argparse.Namespace) -> None:
+    """server 啟動成功後，把有效 bind endpoint 寫入 config.yaml（全平台，#173）。
+
+    先前僅 Windows（``select_rpc_backend() == "win"``）呼叫 :func:`_write_config_endpoint`，
+    理由是「POSIX on-demand 模式下 CLI 一定算得出同一個 SOCKET_PATH 預設值，不需要
+    config.yaml 記錄」。這個假設在部署 wrapper 以 ``SERIALWRAP_STATE_DIR`` 搬移 socket
+    位置時不成立：任何不經過該 wrapper 的 client（如其他工具內嵌的 venv）永遠連不到
+    daemon，且沒有任何診斷機制能指出這件事（#173 根因）。改為全平台無條件寫入，讓
+    「daemon 實際綁在哪」有一個與呼叫端 env 無關的單一事實來源。
+    """
+    _write_config_endpoint(args.socket)
+
+
 def _make_windows_passthrough_templates(
     templates: list[ProfileTemplate],
 ) -> list[ProfileTemplate]:
@@ -172,11 +185,10 @@ async def _run_async(args: argparse.Namespace) -> int:
     try:
         service.start()
         await server.start()
-        # Windows：server 啟動後寫入有效 tcp endpoint，CLI _resolve_endpoint 靠此發現 daemon（#84 PORT-4）。
-        # POSIX 不需要：systemd setup 已寫 config，on-demand 模式 CLI 直接 fallback 到 SOCKET_PATH 預設值。
-        from sw_core.platform_backends import select_rpc_backend  # noqa: PLC0415
-        if select_rpc_backend() == "win":
-            _write_config_endpoint(args.socket)
+        # server 啟動後寫入有效 endpoint，CLI _resolve_endpoint 靠此發現 daemon
+        # （#84 PORT-4 起 Windows 皆如此；#173 起 POSIX 也無條件寫入，理由見
+        # _write_effective_endpoint docstring）。
+        _write_effective_endpoint(args)
         await stop_event.wait()
     finally:
         await server.stop()

--- a/sw_core/doctor_cmd.py
+++ b/sw_core/doctor_cmd.py
@@ -348,6 +348,75 @@ def _check_wal_dir() -> dict:
     }
 
 
+def _check_endpoint_reachable(proc_root: str = "/proc") -> dict:
+    """本 client 解析到的 endpoint 是否與實際執行中的 daemon 一致且可連（#173）。
+
+    根因：POSIX daemon 過去不寫 config.yaml 的 socket_path，加上部署 wrapper 常以
+    ``SERIALWRAP_STATE_DIR`` 搬移 socket，使『daemon 實際在哪』與『本 client 會解析到
+    哪』可能永久分歧，且此前沒有任何診斷指出這件事。
+
+    判定（與 CLI 相同的解析 seam，見 :func:`sw_core.cli._resolve_default_endpoint_with_source`）：
+
+    - ``/proc`` 掃不到任何 serialwrapd 行程 → advisory ok（on-demand 模式尚未啟動
+      daemon 本身不是異常）。
+    - 有 daemon 行程，本 client 解析到的 endpoint 可連 → ok。
+    - 有 daemon 行程，但本 client 解析到的 endpoint 連不上 → **not ok**，detail 同時
+      點出本 client 解析到的路徑（含來源）與實際執行中 daemon 綁定的路徑，方便 operator
+      在一分鐘內對照 SERIALWRAP_STATE_DIR／config.yaml 是否同步（而非像事故現場那樣
+      耗掉一整個下午）。
+    """
+    from sw_core.cli import _endpoint_alive, _resolve_default_endpoint_with_source  # 延遲匯入避免循環
+    from .multi_open import detect_multi_open
+
+    try:
+        resolved, source = _resolve_default_endpoint_with_source()
+    except Exception as exc:  # pragma: no cover - 探測永不拋
+        return {
+            "check": "endpoint_reachable",
+            "ok": True,
+            "detail": f"無法解析本 client 的 endpoint（{exc}），略過",
+            "fix": "",
+        }
+
+    mo = detect_multi_open(proc_root=proc_root)
+    daemons = mo["daemons"]
+    if not daemons:
+        return {
+            "check": "endpoint_reachable",
+            "ok": True,
+            "detail": f"未偵測到執行中的 serialwrapd（on-demand 模式正常）；本 client 解析到 {resolved}（來源：{source}）",
+            "fix": "",
+        }
+
+    try:
+        reachable = _endpoint_alive(resolved)
+    except Exception:  # pragma: no cover - 探測永不拋
+        reachable = False
+    if reachable:
+        return {
+            "check": "endpoint_reachable",
+            "ok": True,
+            "detail": f"本 client 解析到 {resolved}（來源：{source}），可連上執行中 daemon",
+            "fix": "",
+        }
+
+    daemon_sockets = sorted({d.get("socket") or "未知（無法從 /proc 讀出 --socket）" for d in daemons})
+    daemon_desc = "、".join(daemon_sockets)
+    return {
+        "check": "endpoint_reachable",
+        "ok": False,
+        "detail": (
+            f"本 client 解析到 {resolved}（來源：{source}）連不上；"
+            f"目前執行中 daemon 綁在 {daemon_desc}"
+        ),
+        "fix": (
+            "確認本 client 的 SERIALWRAP_STATE_DIR/config.yaml 是否與該 daemon 一致"
+            "（可用 --socket/--endpoint 明確指定該路徑繞過解析；"
+            "daemon 若為 #173 修正後版本，重啟一次即會把實際 socket 同步寫回 config.yaml）"
+        ),
+    }
+
+
 def _profile_templates_missing_bootloader_prompts(
     asset_text: str, live_text: str
 ) -> list[str]:
@@ -507,6 +576,7 @@ def run_doctor(fx=None, home=None, *, platform: str | None = None) -> list[dict]
         _check_systemd(fx),
         _check_supervision_mode(home),
         _check_single_daemon(),
+        _check_endpoint_reachable(),
         _check_wal_dir(),
         _check_profile_bootloader_prompts(),
         _check_devices(),

--- a/sw_core/multi_open.py
+++ b/sw_core/multi_open.py
@@ -62,6 +62,27 @@ def _is_serialwrapd(proc_root: str, pid: int) -> bool:
     return False
 
 
+def _extract_socket_arg(proc_root: str, pid: int) -> str | None:
+    """讀 ``/proc/<pid>/cmdline`` 擷取 ``--socket`` 參數值（#173）。
+
+    支援 ``--socket X``（分開兩個 argv）與 ``--socket=X``（單一 argv）兩種形式，
+    對應 :func:`sw_core.daemon.build_parser` 用 argparse 產生的 argv。讀不到 cmdline
+    或找不到 ``--socket`` 一律回傳 ``None``（呼叫端須視為「無法判定，保守當作衝突」）。
+    """
+    try:
+        with open(f"{proc_root}/{pid}/cmdline", "rb") as fh:
+            raw = fh.read()
+    except OSError:
+        return None
+    parts = [p.decode("utf-8", "surrogateescape") for p in raw.split(b"\0") if p]
+    for i, part in enumerate(parts):
+        if part == "--socket" and i + 1 < len(parts):
+            return parts[i + 1]
+        if part.startswith("--socket="):
+            return part[len("--socket="):]
+    return None
+
+
 def detect_multi_open(proc_root: str = "/proc", tty_paths: list[str] | None = None) -> dict:
     """偵測同機多開與 tty 持有者。
 
@@ -70,7 +91,10 @@ def detect_multi_open(proc_root: str = "/proc", tty_paths: list[str] | None = No
         tty_paths: 要比對持有者的 tty real_path 清單（daemon status 帶入已 attach 的裝置）。
 
     Returns:
-        ``{multi_open, daemons:[{pid}], holders:{tty:pid}, holders_status}``。
+        ``{multi_open, daemons:[{pid, socket}], holders:{tty:pid}, holders_status}``。
+        每個 daemon 的 ``socket``（#173）為從其 cmdline 擷取的 ``--socket`` 參數值，
+        擷取不到時為 ``None``（呼叫端如 ``serialwrap daemon start`` 的 spawn 防線、
+        doctor 的 ``endpoint_reachable`` 須視為「無法判定，保守處理」）。
         ``holders_status``：
 
         - ``ok``：所有 daemon 的 fd 都讀得到。
@@ -83,7 +107,11 @@ def detect_multi_open(proc_root: str = "/proc", tty_paths: list[str] | None = No
     except OSError:
         return {"multi_open": False, "daemons": [], "holders": {}, "holders_status": "unknown"}
 
-    daemons = [{"pid": pid} for pid in pids if _is_serialwrapd(proc_root, pid)]
+    daemons = [
+        {"pid": pid, "socket": _extract_socket_arg(proc_root, pid)}
+        for pid in pids
+        if _is_serialwrapd(proc_root, pid)
+    ]
 
     holders: dict[str, int] = {}
     status = "ok"

--- a/tests/test_cli_daemon_start.py
+++ b/tests/test_cli_daemon_start.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from sw_core import cli
@@ -73,6 +74,8 @@ targets:
         with (
             mock.patch("sw_core.cli.should_auto_spawn", return_value=True),
             mock.patch("sw_core.cli._probe_healthy_daemon", return_value=False),
+            # #173：spawn 防線掃真實 /proc，固定回報「無衝突」避免測到本機真實 daemon。
+            mock.patch("sw_core.cli._find_conflicting_daemon", return_value=None),
             mock.patch("sw_core.cli._resolve_daemon_start_env_files", return_value=["/tmp/OPI.env"]),
             mock.patch("sw_core.cli._load_daemon_start_env_files", return_value=({"SW_OPI_U": "haman"}, ["/tmp/OPI.env"])),
             mock.patch("sw_core.cli.subprocess.Popen", return_value=proc) as popen,
@@ -101,6 +104,8 @@ targets:
         with (
             mock.patch("sw_core.cli.should_auto_spawn", return_value=True),
             mock.patch("sw_core.cli._probe_healthy_daemon", return_value=False),
+            # #173：spawn 防線掃真實 /proc，固定回報「無衝突」避免測到本機真實 daemon。
+            mock.patch("sw_core.cli._find_conflicting_daemon", return_value=None),
             mock.patch("sw_core.cli._resolve_daemon_start_env_files", return_value=["/tmp/OPI.env"]),
             mock.patch("sw_core.cli._load_daemon_start_env_files", side_effect=cli.EnvFileSourceError("/tmp/OPI.env", "bad env")),
             mock.patch("sw_core.cli._print") as printer,
@@ -128,6 +133,8 @@ targets:
         with (
             mock.patch("sw_core.cli._safe_runtime_config", return_value=None),
             mock.patch("sw_core.cli._probe_healthy_daemon", return_value=False) as probe,
+            # #173：spawn 防線掃真實 /proc，固定回報「無衝突」避免測到本機真實 daemon。
+            mock.patch("sw_core.cli._find_conflicting_daemon", return_value=None),
             mock.patch("sw_core.cli._resolve_daemon_start_env_files", return_value=[]),
             mock.patch("sw_core.cli._load_daemon_start_env_files", return_value=({}, [])),
             mock.patch("sw_core.cli.subprocess.Popen", return_value=proc) as popen,
@@ -263,6 +270,137 @@ class TestDaemonStartSupervision(unittest.TestCase):
         self.assertTrue(printer.call_args.args[0]["ok"])
         # 確認走 on-demand RPC daemon.stop（非 systemd 重導），且未 traceback
         self.assertEqual(rpc.call_args.args[1], "daemon.stop")
+
+
+def _make_fake_proc(proc_root, spec: dict) -> None:
+    """依 spec 佈置 fake /proc：{pid: {"cmdline": str}}（鏡射 test_multi_open_detect）。"""
+    proc_root.mkdir(parents=True, exist_ok=True)
+    for pid, info in spec.items():
+        pdir = proc_root / str(pid)
+        pdir.mkdir()
+        (pdir / "cmdline").write_bytes(info.get("cmdline", "").encode())
+        (pdir / "fd").mkdir()
+
+
+class TestFindConflictingDaemon(unittest.TestCase):
+    """`cli._find_conflicting_daemon`（#173 spawn 防線的純函式部分，掃 fake /proc）。"""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.proc = Path(self._tmp.name) / "proc"
+
+    def test_no_daemons_returns_none(self) -> None:
+        _make_fake_proc(self.proc, {"3000": {"cmdline": "bash\0"}})
+        self.assertIsNone(cli._find_conflicting_daemon("/tmp/target.sock", proc_root=str(self.proc)))
+
+    def test_same_socket_returns_none(self) -> None:
+        """既有 daemon 就綁在同一個 sock：既有冪等探測路徑已處理，本防線不重複擋。"""
+        _make_fake_proc(
+            self.proc,
+            {"2114": {"cmdline": "python\0serialwrapd.py\0--socket\0/tmp/target.sock\0"}},
+        )
+        self.assertIsNone(cli._find_conflicting_daemon("/tmp/target.sock", proc_root=str(self.proc)))
+
+    def test_different_socket_returns_conflict(self) -> None:
+        _make_fake_proc(
+            self.proc,
+            {"2114": {"cmdline": "python\0serialwrapd.py\0--socket\0/run/serialwrap/serialwrapd.sock\0"}},
+        )
+        conflict = cli._find_conflicting_daemon("/tmp/target.sock", proc_root=str(self.proc))
+        self.assertIsNotNone(conflict)
+        self.assertEqual(conflict["pid"], 2114)
+        self.assertEqual(conflict["socket"], "/run/serialwrap/serialwrapd.sock")
+
+    def test_unknown_socket_returns_conflict(self) -> None:
+        """--socket 擷取不到（None）仍視為衝突——無法排除是同機另一個 daemon 佔用中。"""
+        _make_fake_proc(self.proc, {"2114": {"cmdline": "python\0serialwrapd.py\0"}})
+        conflict = cli._find_conflicting_daemon("/tmp/target.sock", proc_root=str(self.proc))
+        self.assertIsNotNone(conflict)
+        self.assertIsNone(conflict["socket"])
+
+
+class TestDaemonStartSpawnGuard(unittest.TestCase):
+    """`daemon start` on-demand spawn 前的『同機已有其他 socket 的 daemon』防線（#173）。"""
+
+    def _args(self, **overrides) -> argparse.Namespace:
+        base = dict(
+            profile_dir="/tmp/profiles",
+            socket="/tmp/target.sock",
+            lock="/tmp/serialwrap.lock",
+            foreground=False,
+            with_sudo=False,
+            endpoint=None,
+            force_spawn=False,
+        )
+        base.update(overrides)
+        return argparse.Namespace(**base)
+
+    def test_rejects_spawn_when_conflicting_daemon_found(self) -> None:
+        conflict = {"pid": 2114, "socket": "/run/serialwrap/serialwrapd.sock"}
+        with (
+            mock.patch("sw_core.cli.should_auto_spawn", return_value=True),
+            mock.patch("sw_core.cli._probe_healthy_daemon", return_value=False),
+            mock.patch("sw_core.cli._find_conflicting_daemon", return_value=conflict) as finder,
+            mock.patch("sw_core.cli.subprocess.Popen") as popen,
+            mock.patch("sw_core.cli._print") as printer,
+        ):
+            rc = cli._run_daemon_start(self._args())
+
+        self.assertEqual(rc, 2)
+        popen.assert_not_called()
+        finder.assert_called_once_with("/tmp/target.sock")
+        payload = printer.call_args.args[0]
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error_code"], "DAEMON_ALREADY_RUNNING_ELSEWHERE")
+        self.assertEqual(payload["existing_socket"], "/run/serialwrap/serialwrapd.sock")
+        self.assertEqual(payload["existing_pid"], 2114)
+        self.assertEqual(payload["target_socket"], "/tmp/target.sock")
+        self.assertIn("/run/serialwrap/serialwrapd.sock", payload["message"])
+        self.assertIn("--force-spawn", payload["hint"])
+
+    def test_force_spawn_bypasses_guard(self) -> None:
+        proc = mock.Mock(pid=4321, returncode=None)
+        proc.poll.return_value = None
+        with (
+            mock.patch("sw_core.cli.should_auto_spawn", return_value=True),
+            mock.patch("sw_core.cli._probe_healthy_daemon", return_value=False),
+            mock.patch("sw_core.cli._find_conflicting_daemon") as finder,
+            mock.patch("sw_core.cli._resolve_daemon_start_env_files", return_value=[]),
+            mock.patch("sw_core.cli._load_daemon_start_env_files", return_value=({}, [])),
+            mock.patch("sw_core.cli.subprocess.Popen", return_value=proc) as popen,
+            mock.patch("sw_core.cli.rpc_call", side_effect=[{"ok": True}, {"ok": True}]),
+            mock.patch("sw_core.cli.time.sleep"),
+            mock.patch("sw_core.cli._print") as printer,
+        ):
+            rc = cli._run_daemon_start(self._args(force_spawn=True))
+
+        self.assertEqual(rc, 0)
+        finder.assert_not_called()
+        popen.assert_called_once()
+        self.assertTrue(printer.call_args.args[0]["ok"])
+
+    def test_no_conflict_spawns_normally(self) -> None:
+        """同 socket（或無其他 daemon）：既有冪等/spawn 路徑不變。"""
+        proc = mock.Mock(pid=4321, returncode=None)
+        proc.poll.return_value = None
+        with (
+            mock.patch("sw_core.cli.should_auto_spawn", return_value=True),
+            mock.patch("sw_core.cli._probe_healthy_daemon", return_value=False),
+            mock.patch("sw_core.cli._find_conflicting_daemon", return_value=None) as finder,
+            mock.patch("sw_core.cli._resolve_daemon_start_env_files", return_value=[]),
+            mock.patch("sw_core.cli._load_daemon_start_env_files", return_value=({}, [])),
+            mock.patch("sw_core.cli.subprocess.Popen", return_value=proc) as popen,
+            mock.patch("sw_core.cli.rpc_call", side_effect=[{"ok": True}, {"ok": True}]),
+            mock.patch("sw_core.cli.time.sleep"),
+            mock.patch("sw_core.cli._print") as printer,
+        ):
+            rc = cli._run_daemon_start(self._args())
+
+        self.assertEqual(rc, 0)
+        finder.assert_called_once_with("/tmp/target.sock")
+        popen.assert_called_once()
+        self.assertTrue(printer.call_args.args[0]["ok"])
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_daemon_start.py
+++ b/tests/test_cli_daemon_start.py
@@ -359,6 +359,29 @@ class TestDaemonStartSpawnGuard(unittest.TestCase):
         self.assertIn("/run/serialwrap/serialwrapd.sock", payload["message"])
         self.assertIn("--force-spawn", payload["hint"])
 
+    def test_reject_hint_without_socket_does_not_suggest_placeholder(self) -> None:
+        """review：/proc 讀不出既有 daemon 的 --socket 時，hint 不得建議
+        `--socket <佔位字串>`（不可用且誤導）；改建議 daemon status 確認 + --force-spawn。"""
+        conflict = {"pid": 2114, "socket": None}
+        with (
+            mock.patch("sw_core.cli.should_auto_spawn", return_value=True),
+            mock.patch("sw_core.cli._probe_healthy_daemon", return_value=False),
+            mock.patch("sw_core.cli._find_conflicting_daemon", return_value=conflict),
+            mock.patch("sw_core.cli.subprocess.Popen") as popen,
+            mock.patch("sw_core.cli._print") as printer,
+        ):
+            rc = cli._run_daemon_start(self._args())
+
+        self.assertEqual(rc, 2)
+        popen.assert_not_called()
+        payload = printer.call_args.args[0]
+        self.assertEqual(payload["error_code"], "DAEMON_ALREADY_RUNNING_ELSEWHERE")
+        self.assertIsNone(payload["existing_socket"])
+        self.assertNotIn("--socket 未知", payload["hint"])
+        self.assertNotIn("--socket 未知", payload["message"])
+        self.assertIn("daemon status", payload["hint"])
+        self.assertIn("--force-spawn", payload["hint"])
+
     def test_force_spawn_bypasses_guard(self) -> None:
         proc = mock.Mock(pid=4321, returncode=None)
         proc.poll.return_value = None

--- a/tests/test_daemon_service_selector.py
+++ b/tests/test_daemon_service_selector.py
@@ -132,6 +132,45 @@ def test_write_config_endpoint_writes_socket_path(tmp_path, monkeypatch):
     assert rc.mode() == "on-demand"  # supervision_mode 不應被覆蓋
 
 
+# ──────────────────────── _write_effective_endpoint ────────────────────────
+# #173：POSIX 也要無條件寫入 config.yaml socket_path（先前只有 win backend 會寫）。
+
+
+def test_write_effective_endpoint_called_unconditionally_on_posix(monkeypatch, tmp_path):
+    """posix 後端：_write_effective_endpoint 仍須呼叫 _write_config_endpoint（#173 回歸 pin）。
+
+    先前 _run_async 內用 ``if select_rpc_backend() == "win":`` gate 住這個呼叫，POSIX
+    永遠不寫 config.yaml——本測試把 gate 拿掉後的行為釘住：即使後端明確是 posix，
+    _write_effective_endpoint 仍要以 ``args.socket`` 呼叫一次 _write_config_endpoint。
+    """
+    import sw_core.platform_backends as pb
+    monkeypatch.setattr(pb, "select_rpc_backend", lambda backend=None: "posix")
+
+    import sw_core.daemon as daemon_mod
+    calls: list[str] = []
+    monkeypatch.setattr(daemon_mod, "_write_config_endpoint", lambda ep: calls.append(ep))
+
+    args = daemon_mod.build_parser().parse_args(["--socket", str(tmp_path / "custom.sock")])
+    daemon_mod._write_effective_endpoint(args)
+
+    assert calls == [str(tmp_path / "custom.sock")]
+
+
+def test_write_effective_endpoint_called_unconditionally_on_win(monkeypatch, tmp_path):
+    """win 後端：既有行為（#84 PORT-4）不應被本次重構破壞，仍要呼叫一次。"""
+    import sw_core.platform_backends as pb
+    monkeypatch.setattr(pb, "select_rpc_backend", lambda backend=None: "win")
+
+    import sw_core.daemon as daemon_mod
+    calls: list[str] = []
+    monkeypatch.setattr(daemon_mod, "_write_config_endpoint", lambda ep: calls.append(ep))
+
+    args = daemon_mod.build_parser().parse_args(["--socket", "tcp://127.0.0.1:48700"])
+    daemon_mod._write_effective_endpoint(args)
+
+    assert calls == ["tcp://127.0.0.1:48700"]
+
+
 # ─────────────────────── RuntimeConfig.set_socket ──────────────────────────
 
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -38,6 +38,8 @@ LINUX_CHECKS = [
     "systemd",
     "supervision_mode",
     "single_daemon",
+    # #173：本 client 解析到的 endpoint 是否與實際執行中 daemon 一致且可連。
+    "endpoint_reachable",
     "wal_dir",
     "profile_bootloader_prompts",
     "devices",
@@ -161,7 +163,7 @@ class TestWindowsDoctor:
 
     def test_windows_has_no_linux_only_checks(self):
         names = {i["check"] for i in self._win_report()}
-        assert names.isdisjoint({"dialout", "systemd", "wsl_systemd", "single_daemon"})
+        assert names.isdisjoint({"dialout", "systemd", "wsl_systemd", "single_daemon", "endpoint_reachable"})
 
     def test_pyserial_ok_when_importable(self):
         item = next(i for i in self._win_report() if i["check"] == "pyserial")

--- a/tests/test_doctor_endpoint_reachable.py
+++ b/tests/test_doctor_endpoint_reachable.py
@@ -108,5 +108,42 @@ class TestCheckEndpointReachable(unittest.TestCase):
         self.assertIn("未知", result["detail"])
 
 
+class TestResolveDefaultEndpointSourceLabel(unittest.TestCase):
+    """review：#108 dangling fallback 使 _resolve_endpoint 回傳值 ≠ config.yaml 記錄時，
+    來源標籤必須如實標示 fallback，不得仍寫「config.yaml」誤導 doctor 判讀。"""
+
+    def test_source_label_marks_dangling_fallback(self) -> None:
+        from sw_core.cli import _resolve_default_endpoint_with_source
+
+        rc = mock.MagicMock()
+        rc.socket_path.return_value = "/tmp/wrapper/serialwrapd.sock"  # config 記錄（已 dangling）
+        with (
+            mock.patch("sw_core.cli._safe_runtime_config", return_value=rc),
+            mock.patch(
+                "sw_core.cli._resolve_endpoint",
+                return_value="/run/user/1000/serialwrap/serialwrapd.sock",  # fallback 後的 canonical
+            ),
+        ):
+            endpoint, source = _resolve_default_endpoint_with_source()
+        self.assertEqual(endpoint, "/run/user/1000/serialwrap/serialwrapd.sock")
+        self.assertIn("fallback", source)
+        self.assertIn("/tmp/wrapper/serialwrapd.sock", source)
+
+    def test_source_label_plain_config_when_resolved_matches(self) -> None:
+        from sw_core.cli import _resolve_default_endpoint_with_source
+
+        rc = mock.MagicMock()
+        rc.socket_path.return_value = "/tmp/wrapper/serialwrapd.sock"
+        with (
+            mock.patch("sw_core.cli._safe_runtime_config", return_value=rc),
+            mock.patch(
+                "sw_core.cli._resolve_endpoint",
+                return_value="/tmp/wrapper/serialwrapd.sock",
+            ),
+        ):
+            endpoint, source = _resolve_default_endpoint_with_source()
+        self.assertEqual(source, "config.yaml")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_doctor_endpoint_reachable.py
+++ b/tests/test_doctor_endpoint_reachable.py
@@ -1,0 +1,112 @@
+"""tests/test_doctor_endpoint_reachable.py — doctor `endpoint_reachable` 檢查（#173）。
+
+涵蓋三態：
+- 無 serialwrapd 行程在跑 → advisory ok（on-demand 模式正常）。
+- 有行程在跑，本 client 解析到的 endpoint 可連 → ok。
+- 有行程在跑，本 client 解析到的 endpoint 連不上（daemon 綁在別的 socket）→ not ok，
+  detail 同時點出本 client 解析到的路徑（含來源）與實際 daemon 綁定的路徑。
+
+/proc 掃描沿用 `multi_open.detect_multi_open` 既有的可注入 fake `/proc` 慣例
+（`_make_fake_proc`，鏡射 tests/test_multi_open_detect.py）。endpoint 解析與可連性探測
+透過 monkeypatch `sw_core.cli._resolve_default_endpoint_with_source` /
+`sw_core.cli._endpoint_alive` 直接控制，不依賴真實 socket 檔案存在與否。
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+import unittest.mock as mock
+from pathlib import Path
+
+from sw_core.doctor_cmd import _check_endpoint_reachable
+
+
+def _make_fake_proc(proc_root: Path, spec: dict) -> None:
+    """依 spec 佈置 fake /proc：{pid: {"cmdline": str, "fd": {}}}（鏡射 test_multi_open_detect）。"""
+    proc_root.mkdir(parents=True, exist_ok=True)
+    for pid, info in spec.items():
+        pdir = proc_root / str(pid)
+        pdir.mkdir()
+        (pdir / "cmdline").write_bytes(info.get("cmdline", "").encode())
+        fd_dir = pdir / "fd"
+        fd_dir.mkdir()
+
+
+class TestCheckEndpointReachable(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.proc = Path(self._tmp.name) / "proc"
+
+    def test_no_daemon_process_is_advisory_ok(self) -> None:
+        """無 serialwrapd 行程 → ok=True（on-demand 模式尚未啟動不是異常）。"""
+        _make_fake_proc(self.proc, {"3000": {"cmdline": "bash\0"}})
+        with mock.patch(
+            "sw_core.cli._resolve_default_endpoint_with_source",
+            return_value=("/run/user/1000/serialwrap/serialwrapd.sock", "預設"),
+        ):
+            result = _check_endpoint_reachable(proc_root=str(self.proc))
+        self.assertEqual(result["check"], "endpoint_reachable")
+        self.assertTrue(result["ok"])
+        self.assertIn("未偵測到執行中的 serialwrapd", result["detail"])
+
+    def test_daemon_running_and_endpoint_reachable_is_ok(self) -> None:
+        """有行程在跑，本 client 解析到的 endpoint 可連 → ok=True。"""
+        _make_fake_proc(
+            self.proc,
+            {"2114": {"cmdline": "python\0serialwrapd.py\0--socket\0/tmp/serialwrap/serialwrapd.sock\0"}},
+        )
+        with (
+            mock.patch(
+                "sw_core.cli._resolve_default_endpoint_with_source",
+                return_value=("/tmp/serialwrap/serialwrapd.sock", "config.yaml"),
+            ),
+            mock.patch("sw_core.cli._endpoint_alive", return_value=True) as m_alive,
+        ):
+            result = _check_endpoint_reachable(proc_root=str(self.proc))
+        m_alive.assert_called_once_with("/tmp/serialwrap/serialwrapd.sock")
+        self.assertTrue(result["ok"])
+        self.assertIn("/tmp/serialwrap/serialwrapd.sock", result["detail"])
+        self.assertIn("config.yaml", result["detail"])
+
+    def test_daemon_running_but_endpoint_unreachable_is_not_ok(self) -> None:
+        """有行程在跑，但本 client 解析到的 endpoint 連不上（daemon 實際綁在別處）→ not ok。
+
+        detail 必須同時點出本 client 解析到的路徑（含來源）與實際 daemon 綁定的路徑——
+        這是 #173 的核心驗收：把事故從「一個下午」縮短到「一分鐘」。
+        """
+        _make_fake_proc(
+            self.proc,
+            {"2114": {"cmdline": "python\0serialwrapd.py\0--socket\0/tmp/serialwrap/serialwrapd.sock\0"}},
+        )
+        with (
+            mock.patch(
+                "sw_core.cli._resolve_default_endpoint_with_source",
+                return_value=("/run/user/1000/serialwrap/serialwrapd.sock", "預設（SOCKET_PATH，受 SERIALWRAP_STATE_DIR/XDG 環境變數影響）"),
+            ),
+            mock.patch("sw_core.cli._endpoint_alive", return_value=False),
+        ):
+            result = _check_endpoint_reachable(proc_root=str(self.proc))
+        self.assertFalse(result["ok"])
+        self.assertIn("/run/user/1000/serialwrap/serialwrapd.sock", result["detail"])
+        self.assertIn("預設", result["detail"])
+        self.assertIn("/tmp/serialwrap/serialwrapd.sock", result["detail"])
+        self.assertTrue(result["fix"])
+
+    def test_daemon_socket_unknown_still_shown_in_detail(self) -> None:
+        """行程 --socket 擷取不到（舊版 daemon／非典型 argv）時，detail 仍需標示『未知』而非空白。"""
+        _make_fake_proc(self.proc, {"2114": {"cmdline": "python\0serialwrapd.py\0"}})
+        with (
+            mock.patch(
+                "sw_core.cli._resolve_default_endpoint_with_source",
+                return_value=("/run/user/1000/serialwrap/serialwrapd.sock", "預設"),
+            ),
+            mock.patch("sw_core.cli._endpoint_alive", return_value=False),
+        ):
+            result = _check_endpoint_reachable(proc_root=str(self.proc))
+        self.assertFalse(result["ok"])
+        self.assertIn("未知", result["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_win_daemon_start.py
+++ b/tests/test_win_daemon_start.py
@@ -46,6 +46,10 @@ def _run_with_mocks(args, monkeypatch, backend: str, rpc_side_effect=None):
     with (
         mock.patch("sw_core.cli._safe_runtime_config", return_value=None),
         mock.patch("sw_core.cli._probe_healthy_daemon", return_value=False),
+        # #173：spawn 防線會掃真實 /proc；測試固定回報「無衝突」，避免測到本機真的在跑的
+        # daemon 而使這批既有 spawn 路徑測試變成環境相依（見 TestConflictingDaemonGuard
+        # 另外對此防線本身做隔離的 fake /proc 驗證）。
+        mock.patch("sw_core.cli._find_conflicting_daemon", return_value=None),
         mock.patch("sw_core.cli._resolve_daemon_start_env_files", return_value=[]),
         mock.patch("sw_core.cli._load_daemon_start_env_files", return_value=({}, [])),
         mock.patch("sw_core.cli.subprocess.Popen", return_value=proc) as popen,


### PR DESCRIPTION
## Summary

修正 #173：POSIX 上 `serialwrapd` 過去只有 Windows 後端會把有效 bind endpoint 寫回
`config.yaml::socket_path`，理由是「POSIX on-demand 模式下 CLI 一定算得出同一個
`SOCKET_PATH` 預設值」。但部署 wrapper 若以 `SERIALWRAP_STATE_DIR` 把 socket 搬離
XDG 預設路徑，這個假設不成立：任何不經過該 wrapper 的 client（其他工具內嵌的
venv、CI runner…）永遠連不到健康運作中的 daemon，只會拿到 `SOCKET_ERROR`，且沒有
任何診斷指出真正原因；更危險的是，這類「探測失敗」的 client 若接著自己觸發
on-demand `daemon start`，會在 XDG 預設路徑另外 spawn 出第二個 daemon，兩個 daemon
同時開同一批裝置（two-reader）。

Closes #173

## 變更點

1. **`sw_core/daemon.py`**：拿掉 `_write_config_endpoint()` 呼叫外層「僅 Windows」
   的 `if select_rpc_backend() == "win":` gate，改為 server 啟動成功後全平台無條件
   寫入 `config.yaml` 的 `socket_path`（抽出 `_write_effective_endpoint()` 供單測，
   `_write_config_endpoint` 本身不變，仍是 best-effort、失敗只記 stderr）。
2. **`sw_core/doctor_cmd.py`**：新增 `endpoint_reachable` 檢查（**非** advisory，會
   拉低整體 `ok`——這是刻意設計，見下方「偏差」）。以與 CLI 相同的解析 seam
   （新增的 `cli._resolve_default_endpoint_with_source`）得出本 client 會連上的
   endpoint 與其來源（`config.yaml` 或平台預設），並掃 `/proc` 找出實際執行中的
   `serialwrapd` 行程：
   - 無 daemon 行程 → advisory ok（on-demand 模式尚未啟動不是異常）。
   - 有行程且本 client 解析到的 endpoint 可連 → ok。
   - 有行程但連不上 → not ok，`detail` 同時列出本 client 解析到的路徑（含來源）與
     實際執行中 daemon 綁定的路徑。
3. **`sw_core/cli.py`（`_run_daemon_start` on-demand spawn 分支）**：既有的「探測
   `_resolve_endpoint(args)` 是否已有健康 daemon」冪等路徑之後、實際 spawn 之前，
   新增 `_find_conflicting_daemon(sock)`——ground-truth 直接掃 `/proc`（不依賴
   `config.yaml`，因為後者正是本 issue 想修的東西，暫時失準時不能拿來當唯一防線）：
   若找到「行程存在且其 `--socket` 與本次 spawn 目標不同」的 `serialwrapd`，回傳
   `error_code=DAEMON_ALREADY_RUNNING_ELSEWHERE`（訊息帶出兩個路徑與修復提示）、
   `rc=2`、不 spawn。新增 `--force-spawn` flag 可跳過此防線；同一個 socket 的既有
   冪等探測不受影響。
4. **`sw_core/multi_open.py`**：`detect_multi_open()` 的每個 `daemons` 項目新增
   `socket` 欄位（從 cmdline 擷取 `--socket` 引數值，擷取不到時為 `None`），供上述
   兩處防線與 `daemon status` 的 `multi_open_detail` 共用。
5. **文件**：`README.md`（同機多開／two-reader 段落新增「自訂安裝路徑與
   config.yaml 同步」小節）與 `docs/serialwrap-spec.md`（新增 §8.5a）說明本次修法，
   並更新 `multi_open_detail.daemons[].socket` 欄位格式。

## Validation

```bash
python3 -m pytest -q tests/
# 1590 passed, 16 skipped, 44 subtests passed
```

- Targeted：`tests/test_daemon_service_selector.py`（`_write_effective_endpoint`
  POSIX/win 兩態）、`tests/test_doctor_endpoint_reachable.py`（`endpoint_reachable`
  三態，fake `/proc`）、`tests/test_cli_daemon_start.py`
  （`_find_conflicting_daemon` 純函式 + spawn 防線 reject/`--force-spawn`/無衝突
  三態）、`tests/test_multi_open_detect.py`（既有 13 案不受 `socket` 欄位擴充影響）、
  `tests/test_doctor.py`（Linux 檢查清單 pin 加入 `endpoint_reachable`）、
  `tests/test_win_daemon_start.py`（既有 spawn 路徑測試補 `_find_conflicting_daemon`
  mock，避免測到本機真實 daemon 造成環境相依）全數綠燈。
- conftest #120 三層 live guard：全數 PASS（無 state/wal/config/daemon 維度被
  touch 到），本 PR 未執行 serialwrap 二進位、未動 `/run/serialwrap` 等即時目錄。
- `python3 -m policy_check --repo .`：本機無 PR context（無法判定 diff 內
  code_paths），R-09/R-10/R-12/R-17/R-18 因此顯示「no code path files changed」／
  「non-PR context」而非真的檢查本次變更；其餘規則（R-03～R-08、R-13～R-16、
  R-19～R-21、R-23～R-26）皆 pass。R-22 顯示 113 筆既有 dangling reference（advisory，
  pre-existing，非本次引入）。CI 帶 PR context 會補上完整的 R-09/R-18 判定。

## Regression-case 評估

- **本 PR 新增行為已由 pytest/mock 完整覆蓋**：
  - `_write_effective_endpoint` 在 posix/win 兩種 `select_rpc_backend()` 下皆呼叫
    `_write_config_endpoint(args.socket)`（mock 驗證呼叫發生與參數）。
  - `endpoint_reachable` 三態（無行程 / 行程在+可連 / 行程在+不可連）皆用 fake
    `/proc`（`_make_fake_proc`）+ mock `_resolve_default_endpoint_with_source` /
    `_endpoint_alive` 隔離驗證，含「`--socket` 擷取不到仍標示未知」邊界案例。
  - spawn 防線：`_find_conflicting_daemon` 純函式對 fake `/proc` 驗證「無 daemon」
    「同 socket」「不同 socket」「socket 擷取不到」四種輸入；`_run_daemon_start`
    端對端測試涵蓋「偵測到衝突即拒絕並帶正確 payload 欄位」「`--force-spawn`
    完全跳過（`finder.assert_not_called()`）」「無衝突時走既有 spawn 路徑不變」。
- **只有實機才驗得到的行為**（建議 follow-up，本 PR 不實作）：
  - **真實 wrapper 分歧場景**：一支經 `SERIALWRAP_STATE_DIR` wrapper 啟動的
    daemon + 一支不經 wrapper 的裸 client，在同一台實機上驗證 (a) daemon 重啟後
    `config.yaml::socket_path` 確實落到 wrapper 指定的路徑、(b) 裸 client 執行
    `serialwrap session list` 不再回報 `SOCKET_ERROR`、(c) `serialwrap doctor` 的
    `endpoint_reachable` 在人為製造分歧時（例如手動改 `SERIALWRAP_STATE_DIR` 後
    不重啟 daemon）確實抓到並印出兩個路徑。這類「跨 process 環境變數分歧」目前
    只能在 mock 層面模擬，PR 描述中事故現場的完整重現需要兩支獨立行程 + 真實
    XDG 目錄。
  - 建議新增 realhw family case（例如併入既有 `serialwrap_regression` 的 F8
    daemon 單一性家族，或新開 F13）：「wrapper 啟動 daemon → 裸 client 用
    `serialwrap doctor` 偵測 endpoint 分歧 → `daemon start`（裸 client 視角）
    因 spawn 防線被拒絕 → 加 `--force-spawn` 後才 spawn 出第二個 daemon
    （驗證 flag 確實是唯一逃生門）」。此為只有實機才能端到端驗證 daemon 重啟
    時序與跨行程 env 分歧的場景，pytest mock 無法替代。

## 已知邊界（非本 PR 範圍）

- `_find_conflicting_daemon` 找到第一個 socket 不同的行程即回傳；多個既有 daemon
  並存時只回報其中一個，完整列舉留給既有 `serialwrap daemon status` 的
  `multi_open_detail`。
- issue #173 期望 2（「安裝流程重新檢討」）以文件方式處理（README/spec 補充說明
  wrapper 不再需要手動同步 config.yaml），未變更 `install.sh` 或 wrapper 產生邏輯
  本身。
