### PR TITLE
fix(login_fsm): login FSM 硬化——錯誤分流、raw 上下文、regex 錨定、login recovery lease（#174）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1221,8 +1221,10 @@ profiles:
       xonxoff: false
   brcm-template:
     platform: bcm
-    prompt_regex: "(?m)[>#]\\s*$"
-    login_regex: "(?mi)login:\\s*$"
+    # #174：錨定行首＋排除連續 '#'/'>' 裝飾線（BDK login banner 的 "#####" 分隔行
+    # 與 CEVENT 洪流都不會誤配成 prompt）。可用 `serialwrap profile test` 離線驗證。
+    prompt_regex: "(?m)^(?:.*[^>#\\s])?[>#][ \\t]*$"
+    login_regex: "(?mi)login:\\s*$"  # 勿錨定行首：getty 是 "<hostname> login: "（#174）
     password_regex: "(?mi)password:\\s*$"
     post_login_cmd: "sh"         # 登入後自動執行，從 BCM shell (>) 切到 Linux shell (#)
     user_env: "BRCM_USER"
@@ -2211,6 +2213,7 @@ command groups:
     service            透過 systemctl 管理 serialwrap systemd service（systemd 監管模式適用）
     setup              安裝資產並設定監管模式（systemd-user／systemd-system／on-demand）
     doctor             診斷安裝與執行環境（平台感知：Linux 檢 dialout／systemd／by-id 裝置／human console 就緒（serialwrap-minicom／jq／minicom），Windows 檢 pyserial／daemon endpoint／COM 列舉）
+    profile            離線 profile regex 診斷（免連 daemon／免碰 UART）
     skill              輸出操作指南（skill）原文到 stdout（--platform windows 為 Windows 操作指南）
 
 examples:

--- a/changelog.d/174-login-fsm-hardening.md
+++ b/changelog.d/174-login-fsm-hardening.md
@@ -1,0 +1,17 @@
+---
+type: fix
+issue: 174
+scope: login-fsm
+---
+login FSM 硬化：`POST_LOGIN_CMD_TIMEOUT` 混淆三種原因且 `last_error_detail` 恆為 `null`、`brcm-template` 的 `prompt_regex` 未錨定行首在洪流／banner 板上可誤配登入成功。
+
+- **送 `post_login_cmd` 前的 login guard**：`login_fsm._finalize_ready()` 送出前先查 rx tail 是否命中 `login_regex`／`password_regex`（`login_fsm.matches_login_or_password()`）——命中就代表 `prompt_regex` 誤配（如 BDK login banner 的 `#####` 裝飾線／CEVENT 洪流被誤配成 prompt）、`_maybe_login` 整段被跳過，此時**絕不**把 `post_login_cmd` 當帳密送進 login prompt，直接回可行動的 `LOGIN_REQUIRED`。
+- **失敗分流**：`POST_LOGIN_CMD_TIMEOUT`／`READY_NONCE_TIMEOUT` 逾時後，若 rx tail 已回到 login/password prompt（憑證錯導致板子重印 `login:`，或 guard 仍漏接的邊界情況），改分流為 `LOGIN_REQUIRED`，不再與「登入成功但指令無回應」擠同一個 timeout 碼。`LOGIN_REQUIRED` 依既有 RX_FLOOD 反分類原則永不被遮蔽。
+- **`last_error_detail` 帶 rx tail**：`session_manager._refine_probe_failure()`（attach/recover/reprobe/自動登入五處呼叫共用的單一 choke point）在 login FSM 失敗碼（`login_fsm.LOGIN_FSM_DETAIL_ERRORS`）未被翻轉為 `TRANSPORT_STALL` 時，附上失敗當下的 rx tail（`clean_text()` 去控制碼／ANSI 後截尾 300 字元），取代舊行為恆為 `null`。
+- **出貨 `brcm-template` 的 `prompt_regex` 錨定行首**：`(?m)[>#]\s*$` → `(?m)^(?:.*[^>#\s])?[>#][ \t]*$`，並排除連續 `#`/`>` 裝飾線；`login_regex` 維持不錨定行首（getty 是 `<hostname> login: `，錨定會打壞這個最常見格式）。
+- **login recovery lease**：`session_manager.interactive_open(..., allow_attached=True)` 的 `ATTACHED` 分支，bootloader prompt／boot banner 皆未命中時再檢查 rx tail 是否命中 `login_regex`／`password_regex`——命中則同樣授予 recovery lease，回應標 `login_required: true`（比照既有 `boot_interrupt` 欄位模式），讓 agent／人可用 `interactive-send` 打帳密把 session 救回 `READY`，不必整個 `device release`。三者皆未命中才維持既有 `NOT_BOOTLOADER`。
+- **`serialwrap profile test --profile <name> --sample <file> [--profile-dir DIR]`**：離線診斷子命令，不連 daemon、不碰任何 UART，對樣本文字跑 prompt/login/password/bootloader regex，stdout 印 JSON 回報命中結果，供 operator 收緊 regex 前先驗證，不必上板試錯。
+
+canonical 規格見 `openspec/specs/session-interactive/spec.md`（interactive_open 的 login recovery lease 分支）；`README.md` / `docs/serialwrap-spec.md` 同步。
+
+**regression-case 評估**：mock/unit 已覆蓋 guard／分流／last_error_detail／regex 四類樣本／login recovery lease／`profile test` CLI，共 5 個新測試檔＋既有 login FSM／RX_FLOOD／bootloader-recovery 回歸線全綠。「真板 login banner 誤配」（S2'／S4）屬只有實機才驗得到的行為，建議新增 F10（登入帳密 family）realhw case 作 follow-up，不在本 PR 實作。

--- a/docs/serialwrap-spec.md
+++ b/docs/serialwrap-spec.md
@@ -282,6 +282,8 @@ Agent 收到 sentinel 後應短暫 sleep 後重試，而非視為錯誤。
 
 > **#114 續補（autoboot 倒數窗）**：`allow_attached=True` 的授予條件除既有 bootloader prompt 命中（`ATTACHED` 且 RX tail 末行匹配 `bootloader_prompts`）外，擴充至 RX tail 命中 boot banner（`detect_boot_banner`，比對 `BOOT_BANNER_PATTERNS`＝autoboot 倒數行／`U-Boot` 版本行，複用 #130 單一事實來源）——即 autoboot 倒數當下。此情境同樣授予 recovery lease（`recovery_mode=True`），並於回應標 `boot_interrupt: true`（bootloader prompt 命中則省略此欄位，additive、向後相容），供呼叫端於倒數窗連打按鍵中斷 autoboot 進 `=>`。此 lease 的 TX 不受 #130 boot quiet window gate。詳見 canonical 規格 [`openspec/specs/session-interactive/spec.md`](../openspec/specs/session-interactive/spec.md)。
 
+> **#174 續補（login recovery lease）**：bootloader prompt 與 boot banner 皆未命中時，`allow_attached=True` 再檢查 RX tail 是否命中該 session 的 `login_regex` 或 `password_regex`（`login_fsm.matches_login_or_password`）——board 完全健康、只差有人打帳密，語意上比 bootloader recovery 更安全（不必整個 `device release` 出去）。命中則同樣授予 recovery lease（`recovery_mode=True`），回應標 `login_required: true`（比照 `boot_interrupt` 欄位模式，additive），供呼叫端用 `interactive-send` 打帳密把 session 救回 `READY`。三者（bootloader prompt／boot banner／login-password）皆未命中才回 `SESSION_NOT_READY` + `NOT_BOOTLOADER`。詳見 canonical 規格 [`openspec/specs/session-interactive/spec.md`](../openspec/specs/session-interactive/spec.md)。
+
 ### 6.4 recover
 
 適用：
@@ -608,6 +610,7 @@ background mode 的 `command.result_tail` 在 capture 尚未建立時，會回�
 - `serialwrap stream tail` (legacy alias，對應 `result.tail`)
 - `serialwrap wal export`
 - `serialwrap session pin|unpin`
+- `serialwrap profile test --profile <name> --sample <file> [--profile-dir DIR]`（#174，純離線診斷）
 
 #### session pin / unpin（動態裝置 profile 持久化，#95）
 
@@ -618,6 +621,10 @@ background mode 的 `command.result_tail` 在 capture 尚未建立時，會回�
 - `session list` 的 `profile_source` 欄位顯示來源：`pin` / `sticky` / `detected` / `fallback` / `yaml-target`。
 - 錯誤碼：`UNKNOWN_PROFILE`（profile 名不存在）、`PROFILE_IS_EXPLICIT`（對 YAML explicit-target 裝置 pin/unpin）、`DEVICE_NOT_FOUND`（selector 解析不到裝置）、`INVALID_ARGS`（缺 selector/profile）。
 - **生效時機**：pin/unpin 寫入後不主動重新 attach；對已存在的 session，**下次 daemon 重啟生效**（重啟時 session 重建走動態偵測路徑才重讀 pin/sticky）。執行期 `clear`/`attach` 沿用既有 session 的 profile、不重選。
+
+#### profile test（離線 regex 診斷，#174）
+
+`serialwrap profile test --profile <name> --sample <file> [--profile-dir DIR]` 不連 daemon、不碰任何 UART：從 `--profile-dir`（預設 `PROFILE_DIR`）載入 profile YAML，找出名為 `<name>` 的 template，對 `--sample` 檔案的文字內容跑 `prompt_regex` / `login_regex` / `password_regex`（整段文字 `re.search`，比對基準同 `wait_for_regex`）與 `bootloader_prompts`（清單逐條，僅比對樣本**最後一個非空白行**，比對基準同 `_matches_any_bootloader_prompt` 的 recovery gate 語意），stdout 印 JSON 回報各 regex 是否命中與命中的行，exit code 恆為 0（純診斷、不因未命中而失敗）。用途：operator 自訂／收緊 regex 前，先拿一段真實 console 文字（例如外部 minicom capture log 的片段）離線驗證，不必上板試錯導致 session 卡死。
 
 ### 11.2 RPC
 
@@ -736,6 +743,8 @@ targets:
 **帳密解析狀態與 `CREDENTIALS_UNRESOLVED` 終態（#140）**：`resolve_session_auth()` 除回傳 `SessionAuth` 外，另回一個 `AuthResolution`，其 `reason` 為 `ok` / `env_file_missing` / `env_file_unreadable` / `key_absent` / `not_configured` 之一，並帶「實際解析到的 env_file 絕對路徑」。只要 `username`／`password` 皆非空即為 `ok`（即使 env_file 缺失、只要 `os.environ` 補齊亦然，避免誤擋可用帳密）。當 profile **宣告了帳密來源**（`user_env`／`pass_env`／`env_file` 任一）但 `reason` 非 `ok`（帳密為空）時，login 流程 **不對** `Login:`／`Password:` 送空字串，session 標 `last_error=CREDENTIALS_UNRESOLVED`（與「板子尚未到 login prompt」的 `LOGIN_REQUIRED` 區分），且此為明確終態——自動 reprobe 不再反覆送空帳密，需操作者補帳密後手動 `session attach`／`recover`（或重啟 daemon 重讀 env_file）才重試。進入此態時 daemon 輸出一次 log + WAL 警告（去重），內含 env_file 實際解析絕對路徑與 `reason`，**絕不含帳密值**。profile **未宣告**帳密來源（`not_configured`）者行為完全不變（既有 passwordless/auto-login 路徑不受影響）。
 
 **`platform=bcm`**：Broadcom 原生平台（如 BCM968575）。登入後 target 進入 BCM CLI shell（`>`），需再執行 `post_login_cmd`（通常是 `sh`）才進到 Linux shell（`#`）。`timeout_s` 建議加大（15s+），因 Broadcom 登入流程較慢。
+
+**login FSM 硬化（#174）**：`login_fsm._finalize_ready()` 送出 `post_login_cmd` 前，先以 `login_fsm.matches_login_or_password()` 檢查 rx tail 是否命中該 session 的 `login_regex` / `password_regex`——命中就代表 `prompt_regex` 誤配（例如 BDK login banner 的 `#####` 裝飾線、CEVENT 洪流誤配成 prompt）、`_probe_prompt` 假成功、整段 `_maybe_login` 被跳過，此時**絕不**把 `post_login_cmd` 當帳密送進 login prompt，直接回可行動的 `LOGIN_REQUIRED`。同一檢查也用於**失敗分流**：`POST_LOGIN_CMD_TIMEOUT`／`READY_NONCE_TIMEOUT` 逾時後，若 rx tail 已回到 login/password prompt（憑證錯導致板子重印 `login:`，或前述 guard 仍漏接），改回 `LOGIN_REQUIRED`，不再與「登入成功但指令無回應」擠同一個 timeout 碼；`LOGIN_REQUIRED` 依既有原則永不被 RX_FLOOD 反分類遮蔽（login prompt 可見＝可行動）。所有 login FSM 失敗碼（`login_fsm.LOGIN_FSM_DETAIL_ERRORS`：`LOGIN_REQUIRED`／`LOGIN_PROMPT_TIMEOUT`／`*_PROMPT_TIMEOUT`／`POST_LOGIN_CMD_TIMEOUT`／`READY_NONCE_TIMEOUT`／`USER_ENV_MISSING`／`PASS_ENV_*` 等）在 `session_manager._refine_probe_failure()`（attach/recover/reprobe/自動登入共用的單一 choke point）未被翻轉為 `TRANSPORT_STALL` 時，`last_error_detail` 會帶上失敗當下的 rx tail（`clean_text()` 去控制碼／ANSI 後取最後 300 字元），取代舊行為恆為 `null`。出貨 `brcm-template` 的 `prompt_regex` 亦已錨定行首並排除連續 `#`/`>` 裝飾線（見 §13.2 範例），可用 `serialwrap profile test --profile <name> --sample <file>` 離線驗證 prompt/login/password/bootloader regex 對一段真實 console 文字的匹配結果，不必上板試錯。
 
 **`platform=prpl`**：prplOS 平台。`prompt_regex` 應匹配 prompt prefix，例如 `(?m)^root@prplOS:.*# `。不依賴行尾錨點，以適應 prompt 後接 driver / kernel log 的情境。`ready_probe` 保持最小 `echo __READY__${nonce}`。
 

--- a/openspec/specs/session-interactive/spec.md
+++ b/openspec/specs/session-interactive/spec.md
@@ -15,10 +15,11 @@
 3. `session.state == "ATTACHED"` 且 `bridge.snapshot()["running"]` 與 `["serial_alive"]` 與 `["vtty_alive"]` 皆 True → 對 `bridge.rx_tail(BOOTLOADER_RX_TAIL_BYTES)` 依序判定：
    - 末行匹配 `profile.bootloader_prompts` 任一條（bootloader prompt，如 `=>`）→ 開 lease（`recovery_mode=True`），回應 `boot_interrupt` 省略或為 `False`。
    - 否則，RX tail 命中 boot banner（`detect_boot_banner`，比對 `BOOT_BANNER_PATTERNS`＝`U-Boot` 版本行／`Hit any key to stop autoboot` autoboot 倒數行；#130 既有單一事實來源）→ 開 lease（`recovery_mode=True`），回應標 `boot_interrupt: True`（表「autoboot 倒數窗中斷模式」，供呼叫端連打按鍵中斷 autoboot）。
-   - 兩者皆未命中 → 回 `SESSION_NOT_READY`、`error_detail: "NOT_BOOTLOADER"`。
+   - 否則，RX tail 命中該 session 的 `login_regex` 或 `password_regex`（`login_fsm.matches_login_or_password`；#174）→ 開 lease（`recovery_mode=True`），回應標 `login_required: True`（表「板子健康、只差登入」，供呼叫端用 `interactive-send` 打帳密把 session 救回 `READY`，不必整個 `device release`）。
+   - 三者皆未命中 → 回 `SESSION_NOT_READY`、`error_detail: "NOT_BOOTLOADER"`。
 4. 其他 state（`ATTACHING` / `RECOVERING` / `PASSTHROUGH` 等）→ 回 `SESSION_NOT_READY`。
 
-banner 命中所授予的 lease 與 prompt 命中者相同（`recovery_mode=True`、`owner` 沿用 `--owner`，預設 `agent`、human lease stash/restore 行為一致）；差異僅在回應的 `boot_interrupt` 欄位。此 lease 的 TX 不受 #130 boot quiet window gate（human/lease TX 永不 gate），故 agent 可於倒數窗連打按鍵中斷 autoboot。
+banner／login 命中所授予的 lease 與 prompt 命中者相同（`recovery_mode=True`、`owner` 沿用 `--owner`，預設 `agent`、human lease stash/restore 行為一致）；差異僅在回應的 `boot_interrupt` / `login_required` 欄位（兩者互斥、additive，向後相容）。此 lease 的 TX 不受 #130 boot quiet window gate（human/lease TX 永不 gate），故 agent 可於倒數窗連打按鍵中斷 autoboot，或於 login lease 下用 `interactive-send` 打帳密。
 
 #### Scenario: allow_attached=False rejects ATTACHED state
 
@@ -38,9 +39,15 @@ banner 命中所授予的 lease 與 prompt 命中者相同（`recovery_mode=True
 - **AND** caller 呼叫 `interactive_open(selector, allow_attached=True)`
 - **THEN** result `ok` 為 `True`、回傳 `interactive_id`、該 lease `recovery_mode == True`，且回應 `boot_interrupt == True`
 
-#### Scenario: allow_attached=True rejects ATTACHED without bootloader nor banner match
+#### Scenario: allow_attached=True opens lease when RX tail is at a login/password prompt
 
-- **WHEN** `session.state == "ATTACHED"`、bridge healthy、`bridge.rx_tail(512)` 既不匹配任何 `bootloader_prompts` 也不命中 `detect_boot_banner`
+- **WHEN** `session.state == "ATTACHED"`、bridge healthy、`bridge.rx_tail(512)` 未匹配 `bootloader_prompts` 也未命中 `detect_boot_banner`，但命中該 session 的 `login_regex` 或 `password_regex`
+- **AND** caller 呼叫 `interactive_open(selector, allow_attached=True)`
+- **THEN** result `ok` 為 `True`、回傳 `interactive_id`、該 lease `recovery_mode == True`，且回應 `login_required == True`（`boot_interrupt` 省略或非 `True`）
+
+#### Scenario: allow_attached=True rejects ATTACHED without bootloader, banner, nor login/password match
+
+- **WHEN** `session.state == "ATTACHED"`、bridge healthy、`bridge.rx_tail(512)` 既不匹配任何 `bootloader_prompts`、不命中 `detect_boot_banner`，也不匹配 `login_regex` / `password_regex`
 - **AND** caller 呼叫 `interactive_open(selector, allow_attached=True)`
 - **THEN** result `ok` 為 `False`、`error_code` 為 `"SESSION_NOT_READY"`、`error_detail` 為 `"NOT_BOOTLOADER"`
 

--- a/sw_core/assets/profiles/default.yaml
+++ b/sw_core/assets/profiles/default.yaml
@@ -39,7 +39,14 @@ profiles:
       xonxoff: false
   brcm-template:
     platform: bcm
-    prompt_regex: "(?m)[>#]\\s*$"
+    # #174：錨定行首＋排除連續 '#'/'>' 裝飾線（如 BDK login banner 的 "#####" 分隔
+    # 行）。舊版 "(?m)[>#]\\s*$" 會匹配 buffer 任意位置以 '>'/'#' 結尾的行，在洪流
+    # 板（CEVENT ... DRIVER -- E_RADIO/40 這類持續輸出）與 banner 裝飾線下皆會誤配
+    # 成 prompt，讓 login FSM 整段跳過、把 post_login_cmd 當帳密送進 login prompt。
+    # serialwrap profile test 可離線用樣本驗證本 regex。
+    prompt_regex: "(?m)^(?:.*[^>#\\s])?[>#][ \\t]*$"
+    # 勿錨定行首：getty 標準格式是 "<hostname> login: "（如 "(none) login: "），
+    # 行首前面帶 hostname，錨定 ^login: 會打壞這個最常見的格式（#174 S4）。
     login_regex: "(?mi)login:\\s*$"
     password_regex: "(?mi)password:\\s*$"
     post_login_cmd: "sh"

--- a/sw_core/cli.py
+++ b/sw_core/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -931,6 +932,105 @@ def _run_setup(args: argparse.Namespace) -> int:
     return 0
 
 
+def _profile_test_check(pattern: str, sample_text: str) -> dict[str, Any]:
+    """單一 regex 對樣本文字的命中檢查（#174 profile test 共用）。
+
+    invalid regex 不拋例外，回報於 ``error`` 欄位；命中時 ``matched_line`` 帶
+    命中處所在的完整行（供 operator 目視核對，而非只給 match span）。
+    """
+    if not pattern:
+        return {"pattern": pattern, "matched": False, "matched_line": None, "error": None}
+    try:
+        regex = re.compile(pattern)
+    except re.error as exc:
+        return {"pattern": pattern, "matched": False, "matched_line": None, "error": str(exc)}
+    m = regex.search(sample_text)
+    if not m:
+        return {"pattern": pattern, "matched": False, "matched_line": None, "error": None}
+    prefix_lines = sample_text[: m.end()].splitlines()
+    matched_line = prefix_lines[-1] if prefix_lines else m.group()
+    return {"pattern": pattern, "matched": True, "matched_line": matched_line, "error": None}
+
+
+def _profile_test_last_nonblank_line(text: str) -> str | None:
+    """取樣本文字最後一個非空白行（供 bootloader_prompts 檢查用）。
+
+    與 ``session_manager._matches_any_bootloader_prompt`` 的比對基準一致
+    （bootloader recovery gate 只看 rx tail 的最後一個非空行，非整段 buffer）。
+    """
+    for line in reversed(text.splitlines()):
+        if line.strip():
+            return line
+    return None
+
+
+def _profile_test_bootloader_check(pattern: str, last_line: str | None) -> dict[str, Any]:
+    """單一 bootloader_prompts pattern 對「最後一個非空白行」的命中檢查。
+
+    刻意與 ``_profile_test_check``（整段文字 ``re.search``）分開：bootloader
+    prompt 的實際 gate 邏輯只看 rx tail 最後一行，混用整段比對會誤導 operator
+    （見 ``session_manager._matches_any_bootloader_prompt``）。
+    """
+    if not pattern:
+        return {"pattern": pattern, "matched": False, "matched_line": None, "error": None}
+    try:
+        regex = re.compile(pattern)
+    except re.error as exc:
+        return {"pattern": pattern, "matched": False, "matched_line": None, "error": str(exc)}
+    if last_line is not None and regex.search(last_line):
+        return {"pattern": pattern, "matched": True, "matched_line": last_line, "error": None}
+    return {"pattern": pattern, "matched": False, "matched_line": None, "error": None}
+
+
+def _run_profile_test(args: argparse.Namespace) -> int:
+    """離線驗證 profile 的 prompt/login/password/bootloader regex 是否命中樣本文字（#174）。
+
+    純讀檔＋``re.search``：不連 daemon、不碰任何 UART。exit code 恆為 0（純診斷，
+    命中與否皆非錯誤——讓 operator 在改 regex 前先離線驗證，不必上板試錯導致
+    session 卡死）。
+    """
+    from .config import load_profiles
+
+    profile_dir = getattr(args, "profile_dir", None) or PROFILE_DIR
+    result = load_profiles(profile_dir)
+    tpl = next((t for t in result.templates if t.profile_name == args.profile), None)
+    if tpl is None:
+        _print({
+            "ok": False,
+            "error_code": "UNKNOWN_PROFILE",
+            "profile": args.profile,
+            "profile_dir": profile_dir,
+            "available": sorted({t.profile_name for t in result.templates}),
+        })
+        return 0
+
+    try:
+        with open(args.sample, "r", encoding="utf-8", errors="replace") as fp:
+            sample_text = fp.read()
+    except OSError as exc:
+        _print({"ok": False, "error_code": "SAMPLE_READ_FAILED", "message": str(exc)})
+        return 0
+
+    last_line = _profile_test_last_nonblank_line(sample_text)
+    checks: dict[str, Any] = {
+        "prompt_regex": _profile_test_check(tpl.prompt_regex, sample_text),
+        "login_regex": _profile_test_check(tpl.login_regex, sample_text),
+        "password_regex": _profile_test_check(tpl.password_regex, sample_text),
+        "bootloader_prompts": [
+            _profile_test_bootloader_check(pattern, last_line) for pattern in tpl.bootloader_prompts
+        ],
+    }
+    _print({
+        "ok": True,
+        "profile": tpl.profile_name,
+        "platform": tpl.platform,
+        "profile_dir": profile_dir,
+        "sample": args.sample,
+        "checks": checks,
+    })
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="serialwrap",
@@ -1399,6 +1499,32 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawTextHelpFormatter,
     )
 
+    p_profile = sub.add_parser(
+        "profile",
+        help="離線 profile regex 診斷（免連 daemon／免碰 UART）",
+        description="離線驗證 profile 的 prompt/login/password/bootloader regex 是否命中一段樣本文字（#174）。",
+    )
+    profile_sub = p_profile.add_subparsers(dest="profile_cmd", required=True, metavar="<command>")
+    p_ptest = profile_sub.add_parser(
+        "test",
+        help="對樣本文字逐一跑 prompt/login/password/bootloader regex，回報是否命中",
+        description=(
+            "從 --profile-dir 載入 profile YAML，找出 --profile 指定的 template，\n"
+            "對 --sample 檔案內容依序跑 prompt_regex／login_regex／password_regex／\n"
+            "bootloader_prompts（逐條），stdout 印 JSON 回報各 regex 是否命中與命中的行。\n"
+            "純離線診斷：不連 daemon、不碰任何 UART，exit code 恆為 0。"
+        ),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    p_ptest.add_argument("--profile", required=True, help="要測試的 template 名稱（如 brcm-template）")
+    p_ptest.add_argument("--sample", required=True, help="樣本文字檔路徑（如一段真實 console capture log）")
+    p_ptest.add_argument(
+        "--profile-dir",
+        dest="profile_dir",
+        default=PROFILE_DIR,
+        help="profile YAML 目錄（預設: %(default)s）",
+    )
+
     p_skill = sub.add_parser(
         "skill",
         help="輸出操作指南（skill）原文到 stdout（--platform windows 為 Windows 操作指南）",
@@ -1619,6 +1745,10 @@ def main(argv: list[str] | None = None) -> int:
         result = service_action(args.action, mode=mode, with_sudo=args.with_sudo)
         _print(result)
         return 0 if result.get("ok") else 2
+
+    if args.cmd == "profile":
+        if args.profile_cmd == "test":
+            return _run_profile_test(args)
 
     if args.cmd == "setup":
         return _run_setup(args)

--- a/sw_core/cli.py
+++ b/sw_core/cli.py
@@ -947,8 +947,13 @@ def _profile_test_check(pattern: str, sample_text: str) -> dict[str, Any]:
     m = regex.search(sample_text)
     if not m:
         return {"pattern": pattern, "matched": False, "matched_line": None, "error": None}
-    prefix_lines = sample_text[: m.end()].splitlines()
-    matched_line = prefix_lines[-1] if prefix_lines else m.group()
+    # review：matched_line 必須是命中處所在的**完整原始行**（供 operator 目視核對），
+    # 舊寫法 sample_text[:m.end()] 取尾行，regex 只命中行內片段時會回截斷片段。
+    line_start = sample_text.rfind("\n", 0, m.start()) + 1
+    line_end = sample_text.find("\n", m.start())
+    if line_end == -1:
+        line_end = len(sample_text)
+    matched_line = sample_text[line_start:line_end]
     return {"pattern": pattern, "matched": True, "matched_line": matched_line, "error": None}
 
 

--- a/sw_core/login_fsm.py
+++ b/sw_core/login_fsm.py
@@ -9,6 +9,7 @@ from .auth import SessionAuth
 from .config import ProfileTemplate, SessionProfile
 from .constants import BOOT_BANNER_PATTERNS, ERROR_RX_FLOOD, RX_FLOOD_BYTES_PER_10S
 from .uart_io import UARTBridge
+from .util import clean_text
 
 # RX 洪水可遮蔽的失敗碼集合（#153）：這些碼在「console 被灌爆」時全是同一個病灶
 # （probe/等待被洪水淹沒），反分類為 RX_FLOOD 讓上層知道該等排空而非重建 session。
@@ -130,7 +131,7 @@ def _probe_prompt(bridge: UARTBridge, sp: SessionProfile) -> bool:
 
 def _classify_non_ready_state(bridge: UARTBridge, sp: SessionProfile) -> str:
     snapshot = bridge.rx_tail()
-    if re.search(sp.login_regex, snapshot):
+    if matches_login_or_password(snapshot, sp):
         return "LOGIN_REQUIRED"
     return "PROMPT_UNAVAILABLE"
 
@@ -138,17 +139,22 @@ def _classify_non_ready_state(bridge: UARTBridge, sp: SessionProfile) -> str:
 def matches_login_or_password(text: str, sp: SessionProfile) -> bool:
     """``text`` 是否命中 ``sp`` 的 ``login_regex`` 或 ``password_regex``（#174）。
 
-    invalid regex 容錯（略過該 pattern，不拋例外）。跨 login FSM 內部 guard／分流
-    與 ``session_manager.interactive_open`` 的 login recovery lease 共用同一判準，
-    避免兩處各自維護一份、語意漂移。
+    比對前先 ``clean_text()`` 去除 ANSI/控制碼（review）：``rx_tail()`` 回原始
+    buffer，帶色彩輸出的 login prompt（如 ``\\x1b[1m(none) login:\\x1b[0m``）
+    在 raw 比對下會漏判，login guard 就會把 ``post_login_cmd`` 送進 login
+    prompt——正是本 guard 要防的事故。invalid regex 容錯（略過該 pattern，
+    不拋例外）。跨 login FSM 內部 guard／分流與
+    ``session_manager.interactive_open`` 的 login recovery lease 共用同一判準
+    （``_classify_non_ready_state`` 亦收斂到本函式），避免多處各自維護、語意漂移。
     """
     if not text:
         return False
+    cleaned = clean_text(text)
     for pattern in (sp.login_regex, sp.password_regex):
         if not pattern:
             continue
         try:
-            if re.search(pattern, text):
+            if re.search(pattern, cleaned) or re.search(pattern, text):
                 return True
         except re.error:
             continue

--- a/sw_core/login_fsm.py
+++ b/sw_core/login_fsm.py
@@ -22,6 +22,25 @@ _FLOOD_MASKABLE_ERRORS = frozenset({
     "LOGIN_PROMPT_TIMEOUT",
 })
 
+# login FSM 會產生的失敗碼集合（#174）：session_manager 的 _refine_probe_failure
+# 據此把 last_error_detail 補上失敗當下的 rx tail（截尾去控制碼），取代恆為 null
+# 的現況。與 _FLOOD_MASKABLE_ERRORS 刻意分離——後者管「能否被 RX_FLOOD 遮蔽」，
+# 本集合管「是否附 rx tail 佐證」，兩者交集但不相同（如 LOGIN_REQUIRED 只在本集合）。
+LOGIN_FSM_DETAIL_ERRORS: frozenset[str] = frozenset({
+    "USER_ENV_MISSING",
+    "PASS_ENV_REQUIRED",
+    "PASS_ENV_MISSING",
+    "LOGIN_USER_REQUIRED",
+    "LOGIN_PROMPT_TIMEOUT",
+    "BCM_PROMPT_TIMEOUT",
+    "SHELL_PROMPT_TIMEOUT",
+    "PRPL_PROMPT_TIMEOUT",
+    "POST_LOGIN_CMD_TIMEOUT",
+    "READY_NONCE_TIMEOUT",
+    "READY_PROMPT_TIMEOUT",
+    "LOGIN_REQUIRED",
+})
+
 
 def _maybe_reclassify_flood(bridge: UARTBridge, err: str | None) -> str | None:
     """probe 失敗碼的 RX 洪水反分類（#153，單一 choke point）。
@@ -116,11 +135,43 @@ def _classify_non_ready_state(bridge: UARTBridge, sp: SessionProfile) -> str:
     return "PROMPT_UNAVAILABLE"
 
 
+def matches_login_or_password(text: str, sp: SessionProfile) -> bool:
+    """``text`` 是否命中 ``sp`` 的 ``login_regex`` 或 ``password_regex``（#174）。
+
+    invalid regex 容錯（略過該 pattern，不拋例外）。跨 login FSM 內部 guard／分流
+    與 ``session_manager.interactive_open`` 的 login recovery lease 共用同一判準，
+    避免兩處各自維護一份、語意漂移。
+    """
+    if not text:
+        return False
+    for pattern in (sp.login_regex, sp.password_regex):
+        if not pattern:
+            continue
+        try:
+            if re.search(pattern, text):
+                return True
+        except re.error:
+            continue
+    return False
+
+
 def _finalize_ready(bridge: UARTBridge, sp: SessionProfile) -> tuple[bool, str | None]:
     if sp.post_login_cmd:
+        # #174 login guard：prompt_regex 誤配（如 BDK login banner 的 "###" 裝飾線／
+        # CEVENT 洪流誤配成 prompt）會讓 _probe_prompt 假成功、整段 _maybe_login 被
+        # 跳過。送 post_login_cmd 前先查 rx tail 是否其實仍在 login/password prompt——
+        # 命中就絕不把它當帳密送出去，直接回可行動的 LOGIN_REQUIRED。
+        if matches_login_or_password(bridge.rx_tail(), sp):
+            return False, "LOGIN_REQUIRED"
         bridge.send_command(sp.post_login_cmd, source="system")
         ok, err = _wait_or_fail(bridge, sp.prompt_regex, sp.timeout_s, "POST_LOGIN_CMD_TIMEOUT")
         if not ok:
+            # #174 分流：POST_LOGIN_CMD_TIMEOUT 逾時後 rx tail 若已在 login/password
+            # prompt（憑證錯導致板子重印 login:，或上面的 guard 仍漏接的邊界情況），
+            # 改回可行動的 LOGIN_REQUIRED，不再與「登入成功但 post_login_cmd 無回應」
+            # 擠同一個 timeout 碼。
+            if matches_login_or_password(bridge.rx_tail(), sp):
+                return False, "LOGIN_REQUIRED"
             return ok, err
 
     nonce = uuid.uuid4().hex[:8]
@@ -128,6 +179,10 @@ def _finalize_ready(bridge: UARTBridge, sp: SessionProfile) -> tuple[bool, str |
     bridge.send_command(probe, source="system")
     ok, err = _wait_or_fail(bridge, nonce, sp.timeout_s, "READY_NONCE_TIMEOUT")
     if not ok:
+        # #174 分流：同上，nonce 等不到時 rx tail 若已回到 login/password prompt，
+        # 同樣改回 LOGIN_REQUIRED。
+        if matches_login_or_password(bridge.rx_tail(), sp):
+            return False, "LOGIN_REQUIRED"
         return ok, err
     ok, err = _wait_or_fail(bridge, sp.prompt_regex, sp.timeout_s, "READY_PROMPT_TIMEOUT")
     if not ok:

--- a/sw_core/session_manager.py
+++ b/sw_core/session_manager.py
@@ -47,7 +47,14 @@ from .constants import (
 )
 from .device_watcher import DeviceInfo
 from .file_transfer import DEFAULT_CHUNK_SIZE, DEFAULT_ECHO_TIMEOUT_S
-from .login_fsm import detect_boot_banner, detect_template, ensure_ready, probe_ready
+from .login_fsm import (
+    LOGIN_FSM_DETAIL_ERRORS,
+    detect_boot_banner,
+    detect_template,
+    ensure_ready,
+    matches_login_or_password,
+    probe_ready,
+)
 from .transport_stall import classify_probe_failure, transport_stall_hint
 from .uart_io import PreservedConsoles, UARTBridge, _pty_available
 from .util import clean_text, now_iso
@@ -142,6 +149,25 @@ def _matches_any_bootloader_prompt(
             # invalid regex → 略過
             continue
     return None
+
+
+def _login_fsm_rx_tail_detail(bridge: Any) -> str | None:
+    """login FSM 失敗碼的 rx tail 摘要（#174）：清除控制碼／ANSI 後截尾 300 字元。
+
+    找不到 ``rx_tail`` 或讀取例外一律回 None（getattr 防禦，對不支援 rx_tail 的
+    fake bridge 行為零變更）；rx tail 為空亦回 None，不寫入空字串 detail。
+    """
+    tail_fn = getattr(bridge, "rx_tail", None)
+    if not callable(tail_fn):
+        return None
+    try:
+        raw = tail_fn()
+    except Exception:
+        return None
+    if not raw:
+        return None
+    cleaned = clean_text(raw)[-300:]
+    return cleaned or None
 
 
 def _is_reboot_command(command: str) -> bool:
@@ -1121,7 +1147,9 @@ class SessionManager:
 
         回傳 ``(err, detail)``：翻轉為 TRANSPORT_STALL 時 detail 帶 host 層復原提示，
         並做一次性 log + WAL META 告警（``transport_stall_warned`` 去重、RX 恢復重臂）；
-        其餘原樣直通、detail=None。**只在真的送過 probe 後呼叫**——boot-quiet 合成的
+        未翻轉但 ``err`` 屬 login FSM 失敗碼（``LOGIN_FSM_DETAIL_ERRORS``，#174）時，
+        detail 帶失敗當下的 rx tail（截尾去控制碼），取代恆為 null 的現況；其餘原樣
+        直通、detail=None。**只在真的送過 probe 後呼叫**——boot-quiet 合成的
         PROMPT_UNAVAILABLE（沒送 probe、且 quiet 代表剛有 RX）不得經此。不得在持有
         self._lock 時呼叫（內部會取鎖做去重）。
         """
@@ -1138,6 +1166,8 @@ class SessionManager:
             now=now,
         )
         if not flipped:
+            if err in LOGIN_FSM_DETAIL_ERRORS:
+                return err, _login_fsm_rx_tail_detail(bridge)
             return err, None
         rx_age_s = now - session.last_rx_mono
         real_path = getattr(bridge, "device_path", None)
@@ -3704,11 +3734,20 @@ class SessionManager:
                     # 但 RX tail 命中 boot banner（U-Boot 版本行／autoboot 倒數行，複用
                     # #130 detect_boot_banner 單一事實來源），視為 autoboot 倒數窗，同樣
                     # 授予 recovery lease，並在回應標 boot_interrupt=True 供呼叫端連打按鍵
-                    # 中斷 autoboot。兩者皆未命中才維持 NOT_BOOTLOADER。
+                    # 中斷 autoboot。
+                    # #174：兩者皆未命中時，再檢查 rx tail 是否命中 login_regex／
+                    # password_regex——board 完全健康、只差有人打帳密是「session 卡住但
+                    # 板子正常」最常見的情境，語意上比 bootloader recovery 更安全（不必
+                    # 整個 device release 出去）。命中則同樣授予 lease，回應標
+                    # login_required=True，讓呼叫端用 interactive-send 打帳密救回 READY。
+                    # 三者皆未命中才維持 NOT_BOOTLOADER。
                     boot_interrupt = False
+                    login_required = False
                     if matched is None:
                         if detect_boot_banner(rx_tail_clean):
                             boot_interrupt = True
+                        elif matches_login_or_password(rx_tail_clean, session.profile):
+                            login_required = True
                         else:
                             return {
                                 "ok": False,
@@ -3771,6 +3810,10 @@ class SessionManager:
                         # （additive，與既有回應相容）。BUSY 路徑已提前 return，不會到此。
                         if boot_interrupt:
                             result["boot_interrupt"] = True
+                        # #174：login/password prompt 命中授予的 recovery lease，於回應
+                        # 標 login_required=True（比照 boot_interrupt 欄位模式，additive）。
+                        if login_required:
+                            result["login_required"] = True
 
                 else:
                     return {"ok": False, "error_code": "SESSION_NOT_READY", "selector": selector}

--- a/tests/test_brcm_prompt_regex.py
+++ b/tests/test_brcm_prompt_regex.py
@@ -1,0 +1,82 @@
+"""#174 — 出貨 brcm-template prompt_regex／login_regex 回歸測試。
+
+舊版 ``prompt_regex: "(?m)[>#]\\s*$"`` 未錨定行首，會被 BDK login banner 的
+``#####`` 裝飾線與 CEVENT 洪流行誤配成 prompt，讓 login FSM 整段跳過、把
+``post_login_cmd`` 當帳密送進 login prompt。本檔直接載入出貨
+``sw_core/assets/profiles/default.yaml``，對四類真實樣本釘死行為，
+防止未來又漂移回寬鬆版本。
+"""
+from __future__ import annotations
+
+import os
+import unittest
+
+from sw_core.config import load_profiles
+
+_ASSETS_PROFILE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "sw_core", "assets", "profiles",
+)
+
+
+def _load_brcm_template():
+    result = load_profiles(_ASSETS_PROFILE_DIR)
+    tpl = next((t for t in result.templates if t.profile_name == "brcm-template"), None)
+    assert tpl is not None, "出貨 profile 缺少 brcm-template"
+    return tpl
+
+
+class TestShippedBrcmPromptRegex(unittest.TestCase):
+    """prompt_regex 四類樣本（#174 issue 原文釘死清單）。"""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tpl = _load_brcm_template()
+
+    def test_bdk_bare_hash_prompt_matches(self) -> None:
+        import re
+        self.assertIsNotNone(re.search(self.tpl.prompt_regex, "# "))
+
+    def test_root_shell_prompt_matches(self) -> None:
+        import re
+        self.assertIsNotNone(re.search(self.tpl.prompt_regex, "root@host:~# "))
+
+    def test_banner_decoration_line_no_match(self) -> None:
+        import re
+        self.assertIsNone(re.search(self.tpl.prompt_regex, "#########################################"))
+
+    def test_cevent_flood_line_no_match(self) -> None:
+        import re
+        cevent_line = "... wl1 00:00:00:00:00:00 24 0000 0000 0000 DRIVER -- E_RADIO/40"
+        self.assertIsNone(re.search(self.tpl.prompt_regex, cevent_line))
+
+    def test_full_login_banner_block_no_match(self) -> None:
+        """完整 banner 區塊（裝飾線＋標題＋login prompt）也不得誤配（防線 D）。"""
+        import re
+        banner = (
+            "#########################################\n"
+            "#   ... Broadband Router ...            #\n"
+            "#########################################\n"
+            "(none) login: "
+        )
+        self.assertIsNone(re.search(self.tpl.prompt_regex, banner))
+
+
+class TestShippedBrcmLoginRegex(unittest.TestCase):
+    """login_regex 不得錨定行首，須容忍 getty 的 "<hostname> login: " 格式（#174 S4）。"""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tpl = _load_brcm_template()
+
+    def test_matches_getty_hostname_login(self) -> None:
+        import re
+        self.assertIsNotNone(re.search(self.tpl.login_regex, "(none) login: "))
+
+    def test_matches_bare_login(self) -> None:
+        import re
+        self.assertIsNotNone(re.search(self.tpl.login_regex, "login: "))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_profile_test.py
+++ b/tests/test_cli_profile_test.py
@@ -51,6 +51,27 @@ def test_profile_test_reports_prompt_match(tmp_path, capsys):
     assert payload["checks"]["prompt_regex"]["matched_line"] == "root@host:~# "
 
 
+def test_profile_test_matched_line_is_full_line_on_midline_match(tmp_path, capsys):
+    """review：regex 命中行內片段時，matched_line 仍須回完整原始行（供目視核對），
+    不得回 sample_text[:m.end()] 的截斷片段。"""
+    profile_dir = _write_profile_dir(tmp_path)
+    sample = tmp_path / "sample.txt"
+    # login_regex "(?mi)login:\s*$" 的命中點在行中段（"login:" 之後的 \s*$ 不含
+    # 行首前綴）——matched_line 必須回含前綴的完整原始行，而非 m.end() 截到的片段
+    sample.write_text("noise before\nsome-hostname login: \nnoise after\n", encoding="utf-8")
+
+    rc = cli.main([
+        "profile", "test",
+        "--profile", "brcm-template",
+        "--sample", str(sample),
+        "--profile-dir", str(profile_dir),
+    ])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["checks"]["login_regex"]["matched"] is True
+    assert payload["checks"]["login_regex"]["matched_line"] == "some-hostname login: "
+
+
 def test_profile_test_reports_prompt_no_match_on_banner(tmp_path, capsys):
     profile_dir = _write_profile_dir(tmp_path)
     sample = tmp_path / "sample.txt"

--- a/tests/test_cli_profile_test.py
+++ b/tests/test_cli_profile_test.py
@@ -1,0 +1,121 @@
+"""#174 — `serialwrap profile test` CLI 子命令：離線 regex 診斷。
+
+不連 daemon、不碰任何 UART：從 --profile-dir 載入 profile YAML，對 --sample
+檔案文字跑 prompt/login/password/bootloader regex，輸出 JSON 回報命中結果，
+exit code 恆為 0（純診斷）。
+"""
+from __future__ import annotations
+
+import json
+
+import sw_core.cli as cli
+
+
+_PROFILE_YAML = """
+profiles:
+  brcm-template:
+    platform: bcm
+    prompt_regex: "(?m)^(?:.*[^>#\\\\s])?[>#][ \\\\t]*$"
+    login_regex: "(?mi)login:\\\\s*$"
+    password_regex: "(?mi)password:\\\\s*$"
+    post_login_cmd: "sh"
+    bootloader_prompts:
+      - "^CFE> $"
+      - "^=> $"
+"""
+
+
+def _write_profile_dir(tmp_path):
+    profile_dir = tmp_path / "profiles"
+    profile_dir.mkdir()
+    (profile_dir / "default.yaml").write_text(_PROFILE_YAML, encoding="utf-8")
+    return profile_dir
+
+
+def test_profile_test_reports_prompt_match(tmp_path, capsys):
+    profile_dir = _write_profile_dir(tmp_path)
+    sample = tmp_path / "sample.txt"
+    sample.write_text("root@host:~# ", encoding="utf-8")
+
+    rc = cli.main([
+        "profile", "test",
+        "--profile", "brcm-template",
+        "--sample", str(sample),
+        "--profile-dir", str(profile_dir),
+    ])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["profile"] == "brcm-template"
+    assert payload["checks"]["prompt_regex"]["matched"] is True
+    assert payload["checks"]["prompt_regex"]["matched_line"] == "root@host:~# "
+
+
+def test_profile_test_reports_prompt_no_match_on_banner(tmp_path, capsys):
+    profile_dir = _write_profile_dir(tmp_path)
+    sample = tmp_path / "sample.txt"
+    sample.write_text("#########################################\n(none) login: ", encoding="utf-8")
+
+    rc = cli.main([
+        "profile", "test",
+        "--profile", "brcm-template",
+        "--sample", str(sample),
+        "--profile-dir", str(profile_dir),
+    ])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["checks"]["prompt_regex"]["matched"] is False
+    assert payload["checks"]["login_regex"]["matched"] is True
+    assert payload["checks"]["login_regex"]["matched_line"] == "(none) login: "
+
+
+def test_profile_test_reports_bootloader_prompts_list(tmp_path, capsys):
+    profile_dir = _write_profile_dir(tmp_path)
+    sample = tmp_path / "sample.txt"
+    sample.write_text("U-Boot 2021.01\n=> ", encoding="utf-8")
+
+    rc = cli.main([
+        "profile", "test",
+        "--profile", "brcm-template",
+        "--sample", str(sample),
+        "--profile-dir", str(profile_dir),
+    ])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    bl = payload["checks"]["bootloader_prompts"]
+    assert len(bl) == 2
+    matched_patterns = {c["pattern"] for c in bl if c["matched"]}
+    assert matched_patterns == {"^=> $"}
+
+
+def test_profile_test_unknown_profile_returns_ok_false(tmp_path, capsys):
+    profile_dir = _write_profile_dir(tmp_path)
+    sample = tmp_path / "sample.txt"
+    sample.write_text("whatever", encoding="utf-8")
+
+    rc = cli.main([
+        "profile", "test",
+        "--profile", "does-not-exist",
+        "--sample", str(sample),
+        "--profile-dir", str(profile_dir),
+    ])
+    assert rc == 0  # 純診斷，不因命中失敗而非零 exit
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["error_code"] == "UNKNOWN_PROFILE"
+    assert "brcm-template" in payload["available"]
+
+
+def test_profile_test_missing_sample_file_returns_ok_false(tmp_path, capsys):
+    profile_dir = _write_profile_dir(tmp_path)
+
+    rc = cli.main([
+        "profile", "test",
+        "--profile", "brcm-template",
+        "--sample", str(tmp_path / "does-not-exist.txt"),
+        "--profile-dir", str(profile_dir),
+    ])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["error_code"] == "SAMPLE_READ_FAILED"

--- a/tests/test_login_error_detail.py
+++ b/tests/test_login_error_detail.py
@@ -1,0 +1,158 @@
+"""#174 — last_error_detail 帶 rx tail 回歸測試。
+
+login FSM 失敗碼（``login_fsm.LOGIN_FSM_DETAIL_ERRORS``）過去 ``last_error_detail``
+恆為 ``null``，等於把唯一能定案的證據丟掉。本檔驗證
+``SessionManager._refine_probe_failure``（attach/recover/reprobe/自動登入五處呼叫
+共用的單一 choke point）在未翻轉為 ``TRANSPORT_STALL`` 時，把失敗當下的 rx tail
+（清除控制碼／ANSI 後截尾 300 字元）附到 detail；非 login FSM 錯誤碼與既有
+TRANSPORT_STALL 精煉行為維持不變（回歸線）。
+"""
+from __future__ import annotations
+
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from typing import Any
+
+from sw_core.config import SessionProfile, UartProfile
+from sw_core.device_watcher import DeviceInfo
+from sw_core.session_manager import SessionManager, SessionRuntime
+import sw_core.session_manager as sm_mod
+from sw_core.wal import WalWriter
+
+
+class _DetailBridge:
+    """``_refine_probe_failure`` 用 fake bridge：可控 rx_total_bytes／rx_tail。"""
+
+    def __init__(self, *, rx_total: int = 0, tail: str = "") -> None:
+        self._rx_total = rx_total
+        self.tail = tail
+        self.device_path = "/dev/ttyFAKE0"
+
+    def rx_total_bytes(self) -> int:
+        return self._rx_total
+
+    def rx_tail(self, max_chars: int = 4096) -> str:
+        return self.tail
+
+
+class _NoRxTailBridge:
+    """不支援 rx_tail 的舊 fake bridge（getattr 防禦回歸線）。"""
+
+    def __init__(self, *, rx_total: int = 0) -> None:
+        self._rx_total = rx_total
+        self.device_path = "/dev/ttyFAKE0"
+
+    def rx_total_bytes(self) -> int:
+        return self._rx_total
+
+
+def _make_profile(**overrides: Any) -> SessionProfile:
+    defaults: dict[str, Any] = {
+        "profile_name": "p",
+        "com": "COM0",
+        "act_no": 1,
+        "alias": "lab+1",
+        "device_by_id": "/dev/serial/by-id/fake",
+        "platform": "bcm",
+        "uart": UartProfile(),
+    }
+    defaults.update(overrides)
+    return SessionProfile(**defaults)
+
+
+class _ManagerTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._old_state_path = sm_mod.STATE_PATH
+        sm_mod.STATE_PATH = str(Path(self._tmp.name) / "state.json")
+        self.addCleanup(self._restore_state_path)
+
+    def _restore_state_path(self) -> None:
+        sm_mod.STATE_PATH = self._old_state_path
+
+    def _make_manager(self, **profile_overrides: Any) -> tuple[SessionManager, SessionRuntime]:
+        profile = _make_profile(**profile_overrides)
+        mgr = SessionManager(
+            [profile],
+            WalWriter(wal_dir=self._tmp.name),
+            on_ready=lambda _sid: None,
+            on_detached=lambda _sid: None,
+        )
+        session = mgr.get_session("COM0")
+        assert session is not None
+        with mgr._lock:
+            mgr._devices = {
+                profile.device_by_id: DeviceInfo(
+                    by_id=profile.device_by_id,
+                    real_path="/dev/ttyFAKE0",
+                )
+            }
+        return mgr, session
+
+
+class TestLoginFsmErrorDetail(_ManagerTestBase):
+    def test_login_required_gets_rx_tail_detail(self) -> None:
+        mgr, session = self._make_manager()
+        bridge = _DetailBridge(rx_total=100, tail="\x1b[31m(none) login: \x1b[0m")
+        err, detail = mgr._refine_probe_failure(session, bridge, "LOGIN_REQUIRED", rx_before=0)
+        self.assertEqual(err, "LOGIN_REQUIRED")
+        self.assertEqual(detail, "(none) login: ")
+
+    def test_post_login_cmd_timeout_gets_rx_tail_detail_when_not_stalled(self) -> None:
+        """有 RX 流量（rx_delta != 0）→ 不翻轉 TRANSPORT_STALL，改附 rx tail。"""
+        mgr, session = self._make_manager()
+        bridge = _DetailBridge(rx_total=200, tail="login: ")
+        err, detail = mgr._refine_probe_failure(session, bridge, "POST_LOGIN_CMD_TIMEOUT", rx_before=50)
+        self.assertEqual(err, "POST_LOGIN_CMD_TIMEOUT")
+        self.assertEqual(detail, "login: ")
+
+    def test_detail_truncated_to_last_300_chars(self) -> None:
+        mgr, session = self._make_manager()
+        long_tail = "x" * 500 + "TAIL_MARKER"
+        bridge = _DetailBridge(rx_total=1, tail=long_tail)
+        err, detail = mgr._refine_probe_failure(session, bridge, "LOGIN_REQUIRED", rx_before=0)
+        self.assertEqual(err, "LOGIN_REQUIRED")
+        assert detail is not None
+        self.assertLessEqual(len(detail), 300)
+        self.assertTrue(detail.endswith("TAIL_MARKER"))
+
+    def test_empty_rx_tail_yields_none_detail(self) -> None:
+        mgr, session = self._make_manager()
+        bridge = _DetailBridge(rx_total=1, tail="")
+        err, detail = mgr._refine_probe_failure(session, bridge, "LOGIN_REQUIRED", rx_before=0)
+        self.assertEqual(err, "LOGIN_REQUIRED")
+        self.assertIsNone(detail)
+
+    def test_bridge_without_rx_tail_does_not_crash(self) -> None:
+        """舊 fake bridge（無 rx_tail）→ detail None、不拋例外（getattr 防禦）。"""
+        mgr, session = self._make_manager()
+        bridge = _NoRxTailBridge(rx_total=1)
+        err, detail = mgr._refine_probe_failure(session, bridge, "LOGIN_REQUIRED", rx_before=0)
+        self.assertEqual(err, "LOGIN_REQUIRED")
+        self.assertIsNone(detail)
+
+    def test_non_login_fsm_error_keeps_none_detail(self) -> None:
+        """非 login FSM 錯誤碼（不在 LOGIN_FSM_DETAIL_ERRORS）→ detail 仍為 None（回歸線）。"""
+        mgr, session = self._make_manager()
+        bridge = _DetailBridge(rx_total=1, tail="some tail text")
+        err, detail = mgr._refine_probe_failure(session, bridge, "DEVICE_NOT_FOUND", rx_before=0)
+        self.assertEqual(err, "DEVICE_NOT_FOUND")
+        self.assertIsNone(detail)
+
+    def test_transport_stall_flip_keeps_its_own_hint_not_rx_tail(self) -> None:
+        """真正翻轉為 TRANSPORT_STALL 時，detail 仍是既有 host 復原提示，不被 rx tail 蓋掉。"""
+        mgr, session = self._make_manager()
+        session.last_rx_mono = time.monotonic() - 60.0  # 已凍結超過 30s 門檻
+        bridge = _DetailBridge(rx_total=0, tail="login: ")  # rx_delta == 0（全程零 echo）
+        err, detail = mgr._refine_probe_failure(session, bridge, "BCM_PROMPT_TIMEOUT", rx_before=0)
+        self.assertEqual(err, "TRANSPORT_STALL")
+        assert detail is not None
+        self.assertNotEqual(detail, "login: ")
+        self.assertIn("USB", detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_login_fsm.py
+++ b/tests/test_login_fsm.py
@@ -4,7 +4,12 @@ from unittest import mock
 
 from sw_core.auth import SessionAuth
 from sw_core.config import SessionProfile, UartProfile
-from sw_core.login_fsm import ensure_ready, probe_ready
+from sw_core.login_fsm import (
+    LOGIN_FSM_DETAIL_ERRORS,
+    ensure_ready,
+    matches_login_or_password,
+    probe_ready,
+)
 
 
 class TestLoginFsm(unittest.TestCase):
@@ -72,6 +77,189 @@ class TestLoginFsm(unittest.TestCase):
         bridge.send_command.assert_called_once_with("", source="system")
         bridge.send_secret.assert_not_called()
         bridge.clear_rx_buffer.assert_called_once_with()
+
+
+class _FakeBcmBridge:
+    """login guard／分流測試用 fake bridge：wait_for_regex 與 rx_tail 皆走預排序列。"""
+
+    def __init__(self, *, wait_results: list, rx_tail_sequence: list[str]) -> None:
+        self._wait_results = list(wait_results)
+        self._rx_tail_sequence = list(rx_tail_sequence)
+        self.sent: list[str] = []
+
+    def clear_rx_buffer(self) -> None:
+        pass
+
+    def send_command(self, cmd: str, *, source: str, cmd_id: str | None = None) -> None:
+        self.sent.append(cmd)
+
+    def send_secret(self, secret: str) -> None:
+        self.sent.append("<secret>")
+
+    def wait_for_regex(self, pattern: str, timeout_s: float) -> bool:
+        return self._wait_results.pop(0)
+
+    def rx_tail(self, max_chars: int = 4096) -> str:
+        if self._rx_tail_sequence:
+            return self._rx_tail_sequence.pop(0)
+        return ""
+
+
+class TestLoginFsmHardening(unittest.TestCase):
+    """#174：post_login_cmd 送出前的 login guard、失敗分流、regex 四類樣本。"""
+
+    def _make_bcm_profile(self, **overrides) -> SessionProfile:
+        defaults: dict = dict(
+            profile_name="brcm-template",
+            com="COM1",
+            act_no=1,
+            alias="brcm+1",
+            device_by_id="/dev/serial/by-id/bcm",
+            platform="bcm",
+            prompt_regex=r"(?m)^(?:.*[^>#\s])?[>#][ \t]*$",
+            login_regex=r"(?mi)login:\s*$",
+            password_regex=r"(?mi)password:\s*$",
+            post_login_cmd="sh",
+            ready_probe="echo __READY__${nonce}",
+            timeout_s=0.01,
+            uart=UartProfile(),
+        )
+        defaults.update(overrides)
+        return SessionProfile(**defaults)
+
+    def test_guard_never_sends_post_login_cmd_into_login_prompt(self) -> None:
+        """S2'：prompt_regex 誤配成功，但 rx tail 其實仍在 login prompt——
+        絕不能把 post_login_cmd 當帳密送出去，直接回可行動的 LOGIN_REQUIRED。"""
+        bridge = _FakeBcmBridge(
+            wait_results=[True],  # _probe_prompt 誤配成功
+            rx_tail_sequence=["(none) login: "],  # guard 讀到的 rx tail
+        )
+        profile = self._make_bcm_profile()
+
+        ok, err = probe_ready(bridge, profile)
+
+        self.assertFalse(ok)
+        self.assertEqual(err, "LOGIN_REQUIRED")
+        self.assertNotIn("sh", bridge.sent)
+
+    def test_post_login_cmd_timeout_reclassified_to_login_required(self) -> None:
+        """POST_LOGIN_CMD_TIMEOUT 逾時後 rx tail 已回到 login prompt → 改分流為 LOGIN_REQUIRED。"""
+        bridge = _FakeBcmBridge(
+            wait_results=[True, False],  # probe 成功、post_login_cmd 逾時
+            rx_tail_sequence=["", "login: "],  # guard 通過、逾時後讀到 login prompt
+        )
+        profile = self._make_bcm_profile()
+
+        ok, err = probe_ready(bridge, profile)
+
+        self.assertFalse(ok)
+        self.assertEqual(err, "LOGIN_REQUIRED")
+        self.assertIn("sh", bridge.sent)
+
+    def test_post_login_cmd_timeout_stays_when_not_at_login_prompt(self) -> None:
+        """POST_LOGIN_CMD_TIMEOUT 逾時但 rx tail 非 login/password prompt → 原碼不變（回歸線）。"""
+        bridge = _FakeBcmBridge(
+            wait_results=[True, False],
+            rx_tail_sequence=["", "some garbage output\n"],
+        )
+        profile = self._make_bcm_profile()
+
+        ok, err = probe_ready(bridge, profile)
+
+        self.assertFalse(ok)
+        self.assertEqual(err, "POST_LOGIN_CMD_TIMEOUT")
+
+    def test_ready_nonce_timeout_reclassified_to_login_required(self) -> None:
+        """READY_NONCE_TIMEOUT 逾時後 rx tail 已回到 password prompt → 改分流為 LOGIN_REQUIRED。"""
+        bridge = _FakeBcmBridge(
+            wait_results=[True, True, False],  # probe 成功、post_login_cmd 成功、nonce 逾時
+            rx_tail_sequence=["", "Password: "],
+        )
+        profile = self._make_bcm_profile()
+
+        ok, err = probe_ready(bridge, profile)
+
+        self.assertFalse(ok)
+        self.assertEqual(err, "LOGIN_REQUIRED")
+
+    def test_ready_nonce_timeout_stays_when_not_at_login_prompt(self) -> None:
+        """READY_NONCE_TIMEOUT 逾時但 rx tail 非 login/password prompt → 原碼不變（回歸線）。"""
+        bridge = _FakeBcmBridge(
+            wait_results=[True, True, False],
+            rx_tail_sequence=["", "garbage\n"],
+        )
+        profile = self._make_bcm_profile()
+
+        ok, err = probe_ready(bridge, profile)
+
+        self.assertFalse(ok)
+        self.assertEqual(err, "READY_NONCE_TIMEOUT")
+
+    def test_guard_skipped_when_no_post_login_cmd(self) -> None:
+        """post_login_cmd 為空的 platform（如 shell）不受 guard 影響（回歸線）。"""
+        bridge = mock.MagicMock()
+        bridge.wait_for_regex.side_effect = [False, True, True, True, True, True]
+        profile = SessionProfile(
+            profile_name="opi-shell",
+            com="COM2",
+            act_no=3,
+            alias="default+3",
+            device_by_id="/dev/serial/by-id/tty2",
+            platform="shell",
+            prompt_regex=r".*[$#] $",
+            login_regex=r"(?mi)^.*login:\s*$",
+            password_regex=r"(?mi)^password:\s*$",
+            ready_probe="echo __READY__${nonce}",
+            user_env="SW_OPI_U",
+            pass_env="SW_OPI_P",
+            uart=UartProfile(),
+        )
+        with mock.patch.dict(os.environ, {"SW_OPI_U": "haman", "SW_OPI_P": "secret"}, clear=False):
+            ok, err = ensure_ready(bridge, profile)
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+
+
+class TestMatchesLoginOrPassword(unittest.TestCase):
+    """matches_login_or_password() 純函式：login guard 與 interactive_open 共用判準。"""
+
+    def _profile(self, **overrides) -> SessionProfile:
+        defaults: dict = dict(
+            profile_name="p",
+            com="COM0",
+            act_no=1,
+            alias="p+1",
+            device_by_id="/dev/serial/by-id/p",
+            platform="bcm",
+            login_regex=r"(?mi)login:\s*$",
+            password_regex=r"(?mi)password:\s*$",
+            uart=UartProfile(),
+        )
+        defaults.update(overrides)
+        return SessionProfile(**defaults)
+
+    def test_matches_getty_hostname_login(self) -> None:
+        self.assertTrue(matches_login_or_password("(none) login: ", self._profile()))
+
+    def test_matches_password_prompt(self) -> None:
+        self.assertTrue(matches_login_or_password("Password: ", self._profile()))
+
+    def test_no_match_on_unrelated_text(self) -> None:
+        self.assertFalse(matches_login_or_password("root@dut:~# ls\n", self._profile()))
+
+    def test_empty_text_no_match(self) -> None:
+        self.assertFalse(matches_login_or_password("", self._profile()))
+
+    def test_invalid_regex_tolerated(self) -> None:
+        """login_regex 為 invalid regex 時不拋例外，續檢查 password_regex。"""
+        profile = self._profile(login_regex="(unterminated", password_regex=r"(?mi)password:\s*$")
+        self.assertTrue(matches_login_or_password("Password: ", profile))
+
+    def test_login_fsm_detail_errors_contains_login_required(self) -> None:
+        """LOGIN_FSM_DETAIL_ERRORS 涵蓋 LOGIN_REQUIRED 與 POST_LOGIN_CMD_TIMEOUT（回歸線）。"""
+        self.assertIn("LOGIN_REQUIRED", LOGIN_FSM_DETAIL_ERRORS)
+        self.assertIn("POST_LOGIN_CMD_TIMEOUT", LOGIN_FSM_DETAIL_ERRORS)
+        self.assertIn("READY_NONCE_TIMEOUT", LOGIN_FSM_DETAIL_ERRORS)
 
 
 class TestDetectTemplate(unittest.TestCase):

--- a/tests/test_login_fsm.py
+++ b/tests/test_login_fsm.py
@@ -241,6 +241,23 @@ class TestMatchesLoginOrPassword(unittest.TestCase):
     def test_matches_getty_hostname_login(self) -> None:
         self.assertTrue(matches_login_or_password("(none) login: ", self._profile()))
 
+    def test_matches_ansi_colored_login_prompt(self) -> None:
+        """review：rx_tail 是原始 buffer，帶 ANSI 色彩的 login prompt 不得漏判——
+        漏判會讓 login guard 失效、post_login_cmd 被送進 login prompt。"""
+        self.assertTrue(
+            matches_login_or_password("\x1b[1m(none) login: \x1b[0m", self._profile())
+        )
+
+    def test_classify_non_ready_state_sees_ansi_login(self) -> None:
+        """_classify_non_ready_state 收斂到同一判準：ANSI login prompt → LOGIN_REQUIRED。"""
+        from unittest import mock
+
+        from sw_core.login_fsm import _classify_non_ready_state
+
+        bridge = mock.MagicMock()
+        bridge.rx_tail.return_value = "\x1b[1m(none) login: \x1b[0m"
+        self.assertEqual(_classify_non_ready_state(bridge, self._profile()), "LOGIN_REQUIRED")
+
     def test_matches_password_prompt(self) -> None:
         self.assertTrue(matches_login_or_password("Password: ", self._profile()))
 

--- a/tests/test_login_recovery_lease.py
+++ b/tests/test_login_recovery_lease.py
@@ -1,0 +1,142 @@
+"""#174 — interactive_open(allow_attached=True) 的 login recovery lease。
+
+停在 login prompt 時，`--allow-attached` 過去只認 bootloader prompt／boot banner，
+一律回 SESSION_NOT_READY + NOT_BOOTLOADER——即使板子完全健康、只差有人打帳密。
+本檔驗證 rx tail 命中 login_regex／password_regex 時同樣授予 recovery lease，
+回應標 login_required=True；仍非 login prompt 時維持既有 NOT_BOOTLOADER 行為
+（回歸線）。
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+import unittest.mock as mock
+from pathlib import Path
+
+from sw_core.config import SessionProfile, UartProfile
+from sw_core.device_watcher import DeviceInfo
+from sw_core.session_manager import SessionManager, SessionRuntime
+import sw_core.session_manager as sm_mod
+from sw_core.wal import WalWriter
+
+
+def _make_profile(
+    bootloader_prompts: tuple[str, ...] = (r"^=> ",),
+    login_regex: str = r"(?mi)login:\s*$",
+    password_regex: str = r"(?mi)password:\s*$",
+) -> SessionProfile:
+    return SessionProfile(
+        profile_name="p",
+        com="COM0",
+        act_no=1,
+        alias="lab+1",
+        device_by_id="/dev/serial/by-id/orig",
+        platform="bcm",
+        login_regex=login_regex,
+        password_regex=password_regex,
+        uart=UartProfile(),
+        bootloader_prompts=bootloader_prompts,
+    )
+
+
+class TestLoginRecoveryLease(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._old_state_path = sm_mod.STATE_PATH
+        sm_mod.STATE_PATH = str(Path(self._tmp.name) / "state.json")
+        self.addCleanup(self._restore_state_path)
+
+    def _restore_state_path(self) -> None:
+        sm_mod.STATE_PATH = self._old_state_path
+
+    def _make_mgr_attached(
+        self,
+        *,
+        rx_tail_str: str,
+        bootloader_prompts: tuple[str, ...] = (r"^=> ",),
+    ) -> tuple[SessionManager, SessionRuntime, mock.MagicMock]:
+        profile = _make_profile(bootloader_prompts=bootloader_prompts)
+        mgr = SessionManager(
+            [profile],
+            WalWriter(wal_dir=self._tmp.name),
+            on_ready=lambda _sid: None,
+            on_detached=lambda _sid: None,
+        )
+        session = mgr.get_session("COM0")
+        assert session is not None
+
+        bridge = mock.MagicMock()
+        bridge.snapshot.return_value = {
+            "running": True,
+            "serial_alive": True,
+            "vtty_alive": True,
+            "vtty": "/dev/pts/9",
+        }
+        bridge.rx_tail.return_value = rx_tail_str
+        bridge.console_has_external_peer.return_value = True
+
+        session.bridge = bridge
+        session.state = "ATTACHED"
+        session.attached_real_path = "/dev/ttyUSB0"
+
+        with mgr._lock:
+            mgr._devices = {
+                "/dev/serial/by-id/orig": DeviceInfo(
+                    by_id="/dev/serial/by-id/orig", real_path="/dev/ttyUSB0"
+                )
+            }
+        return mgr, session, bridge
+
+    def test_login_prompt_grants_lease_with_login_required_flag(self) -> None:
+        """rx tail 命中 login_regex（如 "(none) login: "）→ 授予 recovery lease，login_required=True。"""
+        mgr, session, bridge = self._make_mgr_attached(rx_tail_str="(none) login: ")
+        resp = mgr.interactive_open("COM0", owner="agent:test", allow_attached=True)
+
+        self.assertTrue(resp["ok"])
+        self.assertTrue(resp["recovery_mode"])
+        self.assertIs(resp.get("login_required"), True)
+        self.assertIsNot(resp.get("boot_interrupt"), True)
+        lease = mgr._interactive[resp["interactive_id"]]
+        self.assertTrue(lease.recovery_mode)
+
+    def test_password_prompt_grants_lease_with_login_required_flag(self) -> None:
+        """rx tail 命中 password_regex → 同樣授予 lease，login_required=True。"""
+        mgr, session, bridge = self._make_mgr_attached(rx_tail_str="Password: ")
+        resp = mgr.interactive_open("COM0", owner="agent:test", allow_attached=True)
+
+        self.assertTrue(resp["ok"])
+        self.assertIs(resp.get("login_required"), True)
+
+    def test_non_login_non_bootloader_still_not_bootloader(self) -> None:
+        """rx tail 既非 bootloader／banner 也非 login/password prompt → 維持既有 NOT_BOOTLOADER（回歸線）。"""
+        mgr, session, bridge = self._make_mgr_attached(rx_tail_str="root@dut:~# ls\nbin  etc  usr")
+        resp = mgr.interactive_open("COM0", owner="agent:test", allow_attached=True)
+
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error_code"], "SESSION_NOT_READY")
+        self.assertEqual(resp.get("error_detail"), "NOT_BOOTLOADER")
+
+    def test_bootloader_prompt_still_takes_priority_over_login(self) -> None:
+        """bootloader prompt 命中優先於 login 檢查（既有行為不變，回歸線）。"""
+        mgr, session, bridge = self._make_mgr_attached(rx_tail_str="boot output\n=> ")
+        resp = mgr.interactive_open("COM0", owner="agent:test", allow_attached=True)
+
+        self.assertTrue(resp["ok"])
+        self.assertIsNot(resp.get("login_required"), True)
+        self.assertIsNot(resp.get("boot_interrupt"), True)
+
+    def test_boot_banner_still_takes_priority_over_login(self) -> None:
+        """autoboot 倒數 banner 命中優先於 login 檢查（既有行為不變，回歸線）。"""
+        mgr, session, bridge = self._make_mgr_attached(
+            rx_tail_str="Hit any key to stop autoboot:  2 "
+        )
+        resp = mgr.interactive_open("COM0", owner="agent:test", allow_attached=True)
+
+        self.assertTrue(resp["ok"])
+        self.assertIs(resp.get("boot_interrupt"), True)
+        self.assertIsNot(resp.get("login_required"), True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

現場事故（見 #174 issue 與兩則 comment 的完整證據鏈）：一塊 BRCM BDK 板重開機後停在 login prompt，session 卡在 `state=ATTACHED` / `last_error=POST_LOGIN_CMD_TIMEOUT`、`last_error_detail=null`，之後全部 `command.submit` 一律 `SESSION_NOT_READY`；且停在 login prompt 時 `interactive-open --allow-attached` 無正規恢復路徑（只認 bootloader，不認 login prompt）。

本 PR 針對 issue 列出的五項期望逐一硬化 login FSM，範圍嚴格限於 `sw_core/login_fsm.py` / `sw_core/session_manager.py` / `sw_core/assets/profiles/default.yaml` / `sw_core/cli.py`。

## 變更點

1. **送 `post_login_cmd` 前的 login guard**：`login_fsm._finalize_ready()` 送出前先用 `matches_login_or_password()` 查 rx tail 是否仍在 login/password prompt（S2' 場景：`prompt_regex` 誤配、`_probe_prompt` 假成功、`_maybe_login` 整段被跳過）——命中就絕不把 `post_login_cmd` 當帳密送出去，直接回可行動的 `LOGIN_REQUIRED`。
2. **失敗後分流**：`POST_LOGIN_CMD_TIMEOUT` / `READY_NONCE_TIMEOUT` 逾時後再檢查 rx tail，命中 login/password prompt 就改回 `LOGIN_REQUIRED`（可行動）而非 timeout 碼。`LOGIN_REQUIRED` 依既有 `_maybe_reclassify_flood` 註解原則，永不被 RX_FLOOD 遮蔽（既有集合 `_FLOOD_MASKABLE_ERRORS` 本就不含 `LOGIN_REQUIRED`，未變更）。
3. **`last_error_detail` 帶 rx tail**：五處呼叫 `_refine_probe_failure` 的 sink（attach/recover/reprobe/自動登入）是單一 choke point，login FSM 失敗碼（`login_fsm.LOGIN_FSM_DETAIL_ERRORS`）未被翻轉為 `TRANSPORT_STALL` 時，附上 `clean_text(rx_tail)[-300:]`，取代恆為 `null` 的現況。既有 `TRANSPORT_STALL` 精煉路徑的 host 復原提示不受影響（優先序：先判 stall，未 stall 才補 rx tail）。
4. **出貨 `brcm-template.prompt_regex` 錨定行首**：`(?m)[>#]\s*$` → `(?m)^(?:.*[^>#\s])?[>#][ \t]*$`，用四類樣本釘死（BDK 裸 `# ` match；`root@host:~# ` match；`#####` 裝飾線 no match；CEVENT 洪流行 no match）。`login_regex` 維持不錨定行首（getty 是 `<hostname> login: `，錨定會打壞這個最常見格式，加了註解警告）。
5. **login recovery lease**：`interactive_open(allow_attached=True)` 的 `ATTACHED` 分支，bootloader prompt／boot banner 皆未命中時，再檢查 rx tail 是否命中 `login_regex`／`password_regex`——命中則同樣授予 recovery lease，回應標 `login_required=True`（比照既有 `boot_interrupt` 欄位模式，additive、向後相容）；未命中維持既有 `NOT_BOOTLOADER`。
6. **`serialwrap profile test --profile <name> --sample <file> [--profile-dir DIR]`**：純離線診斷子命令，不連 daemon、不碰 UART，對樣本文字跑 prompt/login/password/bootloader regex，stdout JSON 回報命中結果，exit 0。
7. **錯誤碼**：沿用既有 `LOGIN_REQUIRED`，未新增新錯誤碼。

docs 同步：`README.md`（brcm-template 範例＋CLI help marker `serialwrap-help`）、`docs/serialwrap-spec.md`（§6.3 login recovery lease、§13.3 login FSM 硬化段、§11.1 CLI 清單、profile test 子小節）、canonical `openspec/specs/session-interactive/spec.md`（interactive_open 新增 login_required 分支的 Requirement/Scenario）。

## Validation

- `python3 -m pytest -q tests/` 全綠：**1613 passed, 16 skipped**（含 5 個新測試檔：`test_login_fsm.py` 新增 guard/分流測試、`test_brcm_prompt_regex.py`、`test_login_error_detail.py`、`test_login_recovery_lease.py`、`test_cli_profile_test.py`）。conftest #120 三層 liveguard 全程未觸發（純 mock/fake bridge，未碰任何 daemon/UART）。
- `python3 -m policy_check --repo .`：**pass 25 / fail 0 / warn 1**（R-22 為 108 筆既有陳年 dangling reference，advisory、非本次新破壞）。

## regression-case 評估

本 PR 的行為改動（guard／分流／`last_error_detail`／regex 錨定／login recovery lease／`profile test` CLI）皆已用 mock/fake bridge 的 unit test 覆蓋，且刻意逐一保留「非 login prompt 時原碼不變」的回歸線（如 `test_post_login_cmd_timeout_stays_when_not_at_login_prompt`、`test_non_login_non_bootloader_still_not_bootloader`）。

**只有實機才驗得到的行為**：issue 描述的 S2'（BDK login banner 的 `#####` 裝飾線在真實 CEVENT 洪流板上誤配 prompt）與 S4（getty `(none) login:` 格式）雖已用真實樣本字串釘死 regex 行為，但「真板持續輸出洪流時 login FSM 端到端走一次完整流程」仍需上板驗證。建議在 F10（登入帳密 family）新增一個 realhw case，涵蓋：開機到 login banner → 驗證 `prompt_regex` 不誤配 → 完整登入 → `post_login_cmd` → `READY`；以及一個「刻意留在 login prompt」的 case 驗證 `interactive-open --allow-attached` 的 `login_required=True` 恢復路徑。此 follow-up 不在本 PR 實作。

Closes #174