### PR TITLE
chore(policy): 同步 project policy 1.0.15 → 1.0.17

### DIFF
--- a/.github/workflows/policy-check.yml
+++ b/.github/workflows/policy-check.yml
@@ -6,8 +6,8 @@ permissions:
 
 jobs:
   policy:
-    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@a764806046c410eb4f254ac0b6a8aec8b7559dab # v1.0.15
+    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@9e7fabbf0b5eea9ad933fa6798764b723934a0b7 # v1.0.17
     with:
       policy_profile: flat
-      policy_version: "1.0.15"
-      policy_engine_ref: a764806046c410eb4f254ac0b6a8aec8b7559dab
+      policy_version: "1.0.17"
+      policy_engine_ref: 9e7fabbf0b5eea9ad933fa6798764b723934a0b7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,11 @@ permissions:
 
 jobs:
   project-policy:
-    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@a764806046c410eb4f254ac0b6a8aec8b7559dab # v1.0.15
+    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@9e7fabbf0b5eea9ad933fa6798764b723934a0b7 # v1.0.17
     with:
       policy_profile: flat
-      policy_version: "1.0.15"
-      policy_engine_ref: a764806046c410eb4f254ac0b6a8aec8b7559dab
+      policy_version: "1.0.17"
+      policy_engine_ref: 9e7fabbf0b5eea9ad933fa6798764b723934a0b7
 
   publish:
     runs-on: ubuntu-latest

--- a/.project-policy.yml
+++ b/.project-policy.yml
@@ -1,5 +1,5 @@
 policy_profile: flat
-policy_version: "1.0.15"
+policy_version: "1.0.17"
 # 內容分類（R-21）：serialwrap 為通用序列工具、無雇主機密 → 維持 public
 tier: shareable
 secret_scan:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.15 -->
+<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.17 -->
 <!-- CLAUDE.md 為單一事實來源；AGENTS.md / GEMINI.md / .github/copilot-instructions.md 為指向本檔的 symlink，只需維護本檔 -->
-policy_version: 1.0.15
+policy_version: 1.0.17
 <!-- policy_version 為 policy_check R-14 machine-readable marker；需保持裸行格式，請勿移入 frontmatter 或 code block。 -->
 
 # serialwrap — AI Agent Policy Checklist
@@ -49,11 +49,11 @@ policy_version: 1.0.15
   ```bash
   python3 -m policy_check --repo .
   ```
-- policy engine pinned SHA：`a764806046c410eb4f254ac0b6a8aec8b7559dab`（v1.0.15）。
+- policy engine pinned SHA：`9e7fabbf0b5eea9ad933fa6798764b723934a0b7`（v1.0.17）。
 - 安裝命令：
   ```bash
   python3 -m pip install --user --disable-pip-version-check \
-    "git+https://github.com/hamanpaul/paulsha-conventions.git@a764806046c410eb4f254ac0b6a8aec8b7559dab"
+    "git+https://github.com/hamanpaul/paulsha-conventions.git@9e7fabbf0b5eea9ad933fa6798764b723934a0b7"
   ```
 
 ## Agent 檔案同步政策
@@ -67,7 +67,7 @@ policy_version: 1.0.15
     ln -sf CLAUDE.md GEMINI.md
     ln -sf ../CLAUDE.md .github/copilot-instructions.md
     ```
-- 本檔首行保留 `<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.15 -->`，第 3 行保留裸行 `policy_version: 1.0.15`（R-14 machine-readable marker，勿移入 frontmatter 或 code block）。
+- 本檔首行保留 `<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.17 -->`，第 3 行保留裸行 `policy_version: 1.0.17`（R-14 machine-readable marker，勿移入 frontmatter 或 code block）。
 
 ## PR 政策
 

--- a/changelog.d/policy-1.0.17-sync.md
+++ b/changelog.d/policy-1.0.17-sync.md
@@ -1,0 +1,5 @@
+---
+type: change
+scope: policy
+---
+同步 hamanpaul project policy 1.0.15 → 1.0.17：`.project-policy.yml`、`Policy Check` workflow **與** `Publish Release` workflow（`uses:` 與 `policy_engine_ref` 雙重釘選至 `9e7fabbf0b5eea9ad933fa6798764b723934a0b7`）、canonical `CLAUDE.md`（symlink `AGENTS.md` / `GEMINI.md` / `.github/copilot-instructions.md` 自動跟隨，含內文兩處內嵌 pinned SHA 安裝指令引用）全數同步至 v1.0.17。1.0.16／1.0.17 對下游 repo 未新增或變更任何規則，僅上游引擎自身的 distribution identity、runtime bundle 與 release workflow 修正，故本次為純版本同步；其中 1.0.16 引入的引擎版本 gate（執行中引擎版本與 repo 宣告的 `policy_version` 不符即 fail-loud）是本次同步的實益。


### PR DESCRIPTION
## Summary

同步 hamanpaul project policy 1.0.15 → 1.0.17。上游 hamanpaul/paulsha-conventions 已發布 v1.0.17（tag SHA `9e7fabbf0b5eea9ad933fa6798764b723934a0b7`）。1.0.16 引入引擎版本 gate：執行中引擎版本與 repo 宣告的 `policy_version` 不符即 fail-loud，因此 pin SHA 與 `policy_version` 必須**同 PR 原子更新**。1.0.16／1.0.17 對下游 repo 未新增或變更任何規則，本次為純版本同步：

- `.project-policy.yml` `policy_version` 1.0.15 → 1.0.17
- `Policy Check` workflow **與** `Publish Release` workflow：`uses:` 與 `policy_engine_ref` 雙重釘選至 `9e7fabbf0b5eea9ad933fa6798764b723934a0b7`（本 repo 兩支 workflow 都帶 policy 引用，`release.yml` 亦同步）
- canonical `CLAUDE.md`（`AGENTS.md`／`GEMINI.md`／`.github/copilot-instructions.md` symlink 自動跟隨，含內文兩處內嵌 pinned SHA 安裝指令引用）版本引用同步
- changelog fragment：`changelog.d/policy-1.0.17-sync.md`

## Test Plan

- [x] 執行 `python3 -m pytest -q tests/` — 無新增失敗（見下方「驗證」）
- [x] 執行 `python3 -m policy_check --repo .` — 通過（見下方「驗證」）

## 驗證

- 本機以 v1.0.17 引擎 `python3 -m policy_check --repo .`：**EXIT=0**（0 fail）。R-19 對 `tests.yml`／`release.yml` 的安裝行殘留 advisory warn——本 repo `pytest` 並非既有 runtime/test 依賴、該行是唯一安裝點，移除會破壞實際測試執行，故不比照其他 repo「移除多餘 pytest」的工法，維持現狀（pre-existing 樣式，非本次引入）；僅餘 R-22 114 個 pre-existing dangling doc reference（advisory）。
- 本機 `/tmp/venv-sw/bin/python -m pytest -q tests/`（pytest + pyyaml + pyserial）：**1636 passed, 16 skipped, 44 subtests passed**（88.9s）。首輪執行曾有 2 個 timing 型測試（`test_doctor.py::test_pyserial_ok_when_importable`、`test_resilience_timeout.py::TestCommandCancel::test_canceled_command_skipped_by_worker`）失敗，前者為缺少 `pyserial` 依賴（已補裝修正），後者單獨 rerun 即過，屬本 repo 已知 timing flaky（CLAUDE.md 測試政策章節記載），非本次變更引入的回歸。

## Policy Checklist (R-11)

- [x] 分支不是 `main`（不可直接 commit 到 main）—— `feature/policy-1-0-17`
- [x] 變更已記錄：新增 `changelog.d/policy-1.0.17-sync.md` fragment
- [x] `VERSION` 已更新（若有版本號變動）—— 不適用：本次為 policy 版本同步，不涉及 `serialwrap` 自身 semver
- [x] `python3 -m pytest -q tests/` 通過（無新失敗）
- [x] `python3 -m policy_check --repo .` 通過
- [x] 四份 agent 檔案已同步（`CLAUDE.md` 為 canonical，`AGENTS.md` / `GEMINI.md` / `.github/copilot-instructions.md` 為 symlink，自動跟隨）
- [x] 已標記適用 label —— 不適用：本 PR 非 release PR，亦無需豁免任何 policy 規則
- [x] 回歸 case 評估已記錄 —— 不適用：本 PR 為純 policy 版本同步，非 bug 修復，無對應 issue 需評估回歸 case

## Issue Reference

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
