### PR TITLE
fix(session_manager): explicit target 的 device_by_id 恢復排他，不受 profile 載入順序影響

### DIFF
--- a/README.md
+++ b/README.md
@@ -1288,6 +1288,50 @@ serialwrap service restart
 
 `others-template` 使用 `platform=passthrough`。attach 時不做 prompt/login/ready 限制，只建立 broker bridge，讓 `ttyUSB` 與 broker 建出的 `ttyPTS` 直接透傳；這類 session 會停在 `ATTACHED`，適合不認識的設備先用 minicom/human console 觀察。
 
+### 範例：debug probe（如 TI XDS110）passthrough explicit target（#186）
+
+TI XDS110 這類 debug probe 是 composite USB 裝置，會列舉出兩個 CDC-ACM 介面（application
+console + auxiliary data port），兩者都沒有 Linux shell prompt，動態偵測只會不斷收到
+`PROMPT_UNAVAILABLE`。以下是一份可直接放進 `profiles/*.yaml` 的 explicit target 範例
+（`<FW_VERSION>` / `<PROBE_SERIAL>` 為佔位符，換成實際探棒的值）：
+
+```yaml
+profiles:
+  xds110-passthrough:
+    platform: passthrough
+    prompt_regex: ".*"
+    login_regex: "$^"
+    password_regex: "$^"
+    ready_probe: ""
+    uart:
+      baud: 921600        # 實測值：許多 debug probe 的 application console 不是 115200，
+                           # 套用前務必先用 human console 量測，不要照抄模板預設值
+      data_bits: 8
+      parity: N
+      stop_bits: 1
+      flow_control: none
+      xonxoff: false
+targets:
+  - act_no: 1
+    com: COM0
+    alias: probe-console
+    profile: xds110-passthrough
+    device_by_id: /dev/serial/by-id/usb-Texas_Instruments_XDS110__<FW_VERSION>__Embed_with_CMSIS-DAP_<PROBE_SERIAL>-if00
+```
+
+兩個容易踩到的坑：
+
+1. **探棒韌體版本內嵌在 by-id 字串裡**：`XDS110__<FW_VERSION>__...` 這段版本號是 by-id
+   路徑的一部分，探棒韌體升級後整串 by-id 會變，`targets` 的綁定會安靜地永久失效——
+   session 停在 `DETACHED`，症狀跟「裝置沒插」完全一樣、沒有任何診斷指出原因。升級探棒
+   韌體後務必回來同步更新這裡的 `device_by_id`（相關硬化建議見 issue #186）。
+2. **UART baud 不是模板預設的 115200**：debug probe 的 application console 實際 baud
+   常常更高（本例實測 921600）。套用 `prpl-template` 之類假設 115200 的模板會導致完全
+   收不到可辨識的 prompt，`session list` 的 WAL rx 計數會停在 0；`prpl-template` 也會
+   對這種非 Linux shell 的 console（如 OpenThread 的 `>` prompt）持續 `PROMPT_UNAVAILABLE`
+   reprobe。應改用像上面這種 `platform: passthrough` 的專用 profile，並先用 minicom
+   手動量測正確 baud 再套用。
+
 ### Auto-detect 流程
 
 當 DeviceWatcher 偵測到新 UART 裝置且沒有任何 explicit binding 匹配時，daemon 會自動執行 template 偵測：

--- a/changelog.d/186-explicit-target-device-ownership.md
+++ b/changelog.d/186-explicit-target-device-ownership.md
@@ -1,0 +1,35 @@
+---
+type: fix
+issue: 186
+scope: session-manager
+---
+explicit `targets` binding 的 `device_by_id` 現在對其他 target 排他：restart 後不再受
+profile 檔案載入順序（`self._sessions` insertion order）擺佈而把裝置指派給錯的
+session。
+
+- **根因**：`SessionManager.__init__` 套用持久化 `_binding_overrides`（`session.bind`
+  或 `_attach_by_id` 的 DETACHED-rebind fallback 留下的紀錄）時，未檢查該值是否與
+  「另一個 explicit target 自己在 YAML 宣告」的 `device_by_id` 衝突。實測（TI XDS110
+  探棒兩個 CDC-ACM port）：`00-com2-prpl.yaml` 綁 `COM2` 到一顆未插著的 CH340；另一份
+  profile 檔把 `COM3`/`COM4` explicit 綁到 XDS110 的 `-if00`/`-if03`（皆在線）。
+  `systemctl restart serialwrap` 後 `COM2` 佔用了 `-if00`、`COM3` 反而 `DETACHED`；
+  把 XDS110 的 profile 檔改名成排序上先載入即可讓結果反過來——即裝置指派實際上是
+  first-come-by-load-order。
+- **修法**：`__init__` 建 session 前先收集本次載入的所有 explicit target `device_by_id`
+  宣告集合；套用某 session 的持久化 override 時，若該值與**另一個** target 自己宣告
+  的值衝突，視為過期殘留紀錄，改用該 target 自己的 YAML 宣告值，並清掉這筆過期
+  override，避免下次載入再誤用。修復後「哪個 target 拿到哪顆裝置」不再依賴 profile
+  檔案載入順序。
+- 刻意不動 `_attach_by_id` 的 DETACHED-rebind fallback 本體：那條路徑同時也是
+  `test_session_bind.py::test_auto_bind_on_device_attach` 涵蓋的既有功能（`targets`
+  用佔位符 `device_by_id`、讓任意上線裝置依 `act_no` 自動填入指定 COM slot），與本次
+  要修的「明確裝置被搶走」不是同一件事，收窄修復範圍避免波及該功能。
+- **文件**：`README.md` 新增「範例：debug probe（如 TI XDS110）passthrough explicit
+  target」小節，附可直接套用的 profile 範例，並記錄兩個 bench 排查坑：探棒韌體版本
+  內嵌在 by-id 字串裡（升級韌體後綁定會安靜失效）、UART baud 常非模板預設的
+  115200（本例實測 921600）。
+
+**regression-case 評估**：`tests/test_explicit_target_device_ownership.py` 新增兩個
+pytest（重建 restart 情境本身、驗證結果與 profile 傳入順序無關），修復前皆可重現地
+FAIL、修復後 PASS；純 in-process session-state 邏輯，unit/mock 已完整覆蓋，不需另加
+`regression/`（TestPilot real-hw）case。

--- a/sw_core/session_manager.py
+++ b/sw_core/session_manager.py
@@ -680,9 +680,22 @@ class SessionManager:
         self._last_console_reap_at: float = 0.0
 
         self._load_state()
+        # #186：一個 explicit YAML target 自己宣告的 device_by_id 對其他 target 而言必須排他。
+        # 若某 session 的持久化 binding override 剛好等於「另一個 target 自己在 YAML 宣告」的
+        # device_by_id（多半是舊版 _attach_by_id DETACHED-rebind fallback 在該 target 尚未配置
+        # 前，把這顆當時無人認領的裝置誤借給別的 DETACHED target、又持久化下來的殘留紀錄——見
+        # issue #186），這筆 override 已不具權威性：這顆裝置現在有明確主人，不能再讓別的 target
+        # 頂著這筆 override 繼續佔用它。改用該 target 自己的 YAML 宣告值，並清掉這筆過期 override，
+        # 避免下次載入再誤用；同時讓「哪個 target 真正拿到這顆裝置」不再取決於 profile 檔案的
+        # 載入順序（self._sessions insertion order 只在後面 exact-match 時當 tiebreak）。
+        declared_by_ids = {p.device_by_id for p in profiles if p.device_by_id}
         for p in profiles:
             sid = f"{p.profile_name}:{p.com}"
-            device_by_id = self._binding_overrides.get(sid, p.device_by_id)
+            override = self._binding_overrides.get(sid)
+            if override and override != p.device_by_id and override in declared_by_ids:
+                del self._binding_overrides[sid]
+                override = None
+            device_by_id = override if override else p.device_by_id
             if not device_by_id:
                 continue
             profile = dataclasses.replace(p, device_by_id=device_by_id)

--- a/tests/test_explicit_target_device_ownership.py
+++ b/tests/test_explicit_target_device_ownership.py
@@ -1,0 +1,167 @@
+"""explicit `targets` device_by_id 排他性回歸測試（#186）。
+
+Bench 實測（TI XDS110 探棒，兩個 CDC-ACM port）：`00-com2-prpl.yaml` 把 COM2 綁到一顆
+**未插著**的 CH340 by-id；另一份 profile 檔把 COM3/COM4 explicit 綁到 XDS110 的
+`-if00`/`-if03` by-id，兩者都確實在線。`systemctl restart serialwrap` 後：
+
+    COM2 com2-prpl        prpl-template        ATTACHED  /dev/ttyACM0   <- 佔用了沒綁給它的裝置
+    COM3 cc2745-console   xds110-passthrough   DETACHED  None           <- 自己的裝置被搶走
+    COM4 cc2745-aux       xds110-passthrough   DETACHED  None
+
+把 XDS110 的 profile 檔改名成排序上先於 `00-com2-prpl.yaml` 載入後，結果整個反過來
+（COM2 DETACHED、COM3/COM4 正確 ATTACHED）——即目前的裝置指派是
+**first-come-by-load-order**：`self._sessions` 的 insertion order（由 profile 檔案
+載入順序決定）在裝置 by-id 出現「一個以上 session 同時宣稱擁有」時，替 `next()` 的
+exact-match 做了不該存在的 tiebreak。
+
+根因在 `SessionManager.__init__`：`_binding_overrides`（`session.bind` 或舊版
+`_attach_by_id` DETACHED-rebind fallback 留下的持久化紀錄，存在 `state.json`）套用
+時完全沒檢查是否與「另一個 explicit target 自己在 YAML 宣告」的 device_by_id 衝突。
+在這支探棒的真實時間線上：COM3/COM4 的 explicit target 檔案是**後來才加進來**的；
+在那之前，`_attach_by_id` 的 DETACHED-rebind fallback（#100，這條路徑本身是刻意
+設計給「placeholder 裝置自動綁定」用的，見 `test_session_bind.py::
+test_auto_bind_on_device_attach`，非本次修復對象）已經把當時「還沒有任何 target
+認領」的 XDS110 -if00 借給了 COM2、寫進 `state.json` 的 `bindings`。等 COM3 的
+explicit target 加入、daemon 重啟後，COM2 的持久化 override 與 COM3 自己宣告的
+device_by_id 撞成同一個值，`__init__` 沒有偵測這個衝突，兩個 session 都以
+`device_by_id == if00` 存在於 `self._sessions`，`_attach_by_id` 的 exact-match
+`next()` 就只能靠 insertion order 亂猜贏家——這正是「改檔名讀取順序」會翻轉結果的
+原因。
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import tempfile
+import unittest
+import unittest.mock as mock
+from pathlib import Path
+
+from sw_core.config import SessionProfile, UartProfile
+from sw_core.device_watcher import DeviceInfo
+from sw_core.session_manager import SessionManager
+import sw_core.session_manager as sm_mod
+from sw_core.wal import WalWriter
+
+# 對應 bench 實測的兩個 by-id（CH340 未插 / XDS110 -if00 已插）。
+ABSENT_BY_ID = "/dev/serial/by-id/usb-1a86_USB_Serial-if00-port0"
+PRESENT_BY_ID = (
+    "/dev/serial/by-id/usb-Texas_Instruments_XDS110__03.00.00.43__"
+    "Embed_with_CMSIS-DAP_LT4704QJ-if00"
+)
+
+
+class TestExplicitTargetDeviceOwnership(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._state_path = str(Path(self._tmp.name) / "state.json")
+        self._old_state_path = sm_mod.STATE_PATH
+        sm_mod.STATE_PATH = self._state_path
+        self.addCleanup(lambda: setattr(sm_mod, "STATE_PATH", self._old_state_path))
+
+    def _make_profile(self, name: str, com: str, alias: str, by_id: str, act_no: int) -> SessionProfile:
+        return SessionProfile(
+            profile_name=name,
+            com=com,
+            act_no=act_no,
+            alias=alias,
+            device_by_id=by_id,
+            platform="passthrough",
+            login_regex="",
+            ready_probe="",
+            uart=UartProfile(),
+        )
+
+    def _mgr(self, profiles: list[SessionProfile]) -> SessionManager:
+        return SessionManager(
+            profiles,
+            WalWriter(wal_dir=self._tmp.name),
+            on_ready=lambda _sid: None,
+            on_detached=lambda _sid: None,
+            state_path=self._state_path,
+        )
+
+    def test_restart_does_not_let_stale_override_steal_another_targets_device(self) -> None:
+        """重現 bench 上「改檔名載入順序」才會翻轉結果的那個 restart 情境，並驗證
+        修復後結果與 profile 檔案（`self._sessions` insertion order）順序無關：
+        COM3（真正宣告 XDS110 -if00 的 target）必須拿到它，COM2 必須退回自己
+        設定的（缺席的）CH340、維持 DETACHED。
+        """
+        target_absent = self._make_profile("com2-prpl", "COM2", "com2-prpl+3", ABSENT_BY_ID, act_no=3)
+        target_present = self._make_profile(
+            "cc2745-console", "COM3", "cc2745-console+4", PRESENT_BY_ID, act_no=4
+        )
+
+        # Step 1：只有 COM2 存在時，XDS110 -if00 上線但尚無任何 target 宣告它——
+        # `_attach_by_id` 的 DETACHED-rebind fallback（#100，非本次修復對象）把它
+        # 借給 COM2 並持久化。直接重建這個持久化結果（等價於該 fallback 真的跑過
+        # 一次），聚焦驗證下面 Step 2 的 restart 行為。
+        mgr1 = self._mgr([target_absent])
+        with mgr1._lock:
+            com2_v1 = mgr1.get_session("COM2")
+            assert com2_v1 is not None
+            com2_v1.profile = dataclasses.replace(com2_v1.profile, device_by_id=PRESENT_BY_ID)
+            mgr1._binding_overrides[com2_v1.session_id] = PRESENT_BY_ID
+            mgr1._save_state()
+
+        # Step 2：加入 COM3 的 explicit target（對應「第二份 profile 檔案後來才
+        # 加進來」），以同一份 state.json 模擬 `systemctl restart serialwrap`。
+        mgr2 = self._mgr([target_absent, target_present])
+        with mgr2._lock:
+            mgr2._devices = {PRESENT_BY_ID: DeviceInfo(by_id=PRESENT_BY_ID, real_path="/dev/ttyACM0")}
+        with mock.patch("sw_core.session_manager.UARTBridge") as MockBridge:
+            MockBridge.return_value.start.return_value = None
+            mgr2._attach_by_id(PRESENT_BY_ID)
+
+        com2 = mgr2.get_session("COM2")
+        com3 = mgr2.get_session("COM3")
+        assert com2 is not None and com3 is not None
+        self.assertEqual(
+            com3.profile.device_by_id, PRESENT_BY_ID,
+            "COM3 自己宣告的裝置必須歸自己",
+        )
+        self.assertEqual(com3.state, "ATTACHED")
+        self.assertEqual(
+            com2.profile.device_by_id, ABSENT_BY_ID,
+            "COM2 必須退回自己設定的裝置，不得繼續頂著過期 override 佔用 COM3 的裝置",
+        )
+        self.assertEqual(com2.state, "DETACHED")
+
+    def test_restart_outcome_is_independent_of_profile_file_load_order(self) -> None:
+        """同一組 target，profiles 傳入順序（對應 profile 檔案載入順序）互換後，
+        結果必須一致——修復前這正是 bench 上「改檔名」才能繞過問題的根因
+        （`self._sessions` insertion order 決定 exact-match 的 tiebreak）。
+        """
+        target_absent = self._make_profile("com2-prpl", "COM2", "com2-prpl+3", ABSENT_BY_ID, act_no=3)
+        target_present = self._make_profile(
+            "cc2745-console", "COM3", "cc2745-console+4", PRESENT_BY_ID, act_no=4
+        )
+
+        mgr1 = self._mgr([target_absent])
+        with mgr1._lock:
+            com2_v1 = mgr1.get_session("COM2")
+            assert com2_v1 is not None
+            com2_v1.profile = dataclasses.replace(com2_v1.profile, device_by_id=PRESENT_BY_ID)
+            mgr1._binding_overrides[com2_v1.session_id] = PRESENT_BY_ID
+            mgr1._save_state()
+
+        # 順序反過來：COM3（present target）先於 COM2 出現在 profiles 列表。
+        mgr2 = self._mgr([target_present, target_absent])
+        with mgr2._lock:
+            mgr2._devices = {PRESENT_BY_ID: DeviceInfo(by_id=PRESENT_BY_ID, real_path="/dev/ttyACM0")}
+        with mock.patch("sw_core.session_manager.UARTBridge") as MockBridge:
+            MockBridge.return_value.start.return_value = None
+            mgr2._attach_by_id(PRESENT_BY_ID)
+
+        com2 = mgr2.get_session("COM2")
+        com3 = mgr2.get_session("COM3")
+        assert com2 is not None and com3 is not None
+        self.assertEqual(com3.profile.device_by_id, PRESENT_BY_ID)
+        self.assertEqual(com3.state, "ATTACHED")
+        self.assertEqual(com2.profile.device_by_id, ABSENT_BY_ID)
+        self.assertEqual(com2.state, "DETACHED")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

修復 explicit `targets` binding 的 `device_by_id` 不排他問題（#186）：`SessionManager.__init__`
套用持久化 `_binding_overrides` 時沒檢查是否與「另一個 explicit target 自己在 YAML 宣告」的
`device_by_id` 衝突，導致實測（TI XDS110 探棒兩個 CDC-ACM port）中，一個裝置缺席的
explicit target（`COM2`→未插著的 CH340）在 restart 後把另一個裝置在線的 explicit target
（`COM3`→XDS110 `-if00`）的裝置搶走，且結果依 profile 檔案載入順序（`self._sessions`
insertion order）而定（改檔名排序即可讓結果反過來）。

修法：`__init__` 建 session 前先收集本次載入的所有 explicit target `device_by_id` 宣告
集合；套用某 session 的持久化 override 時，若該值與**另一個** target 自己宣告的值衝突，
視為過期殘留紀錄，改用該 target 自己的 YAML 宣告值，並清掉這筆過期 override。修復後
「哪個 target 拿到哪顆裝置」不再依賴 profile 檔案載入順序。

刻意**沒有**動 `_attach_by_id` 的 DETACHED-rebind fallback 本體——那條路徑同時也是
`test_session_bind.py::test_auto_bind_on_device_attach` / `test_multi_device_auto_bind_order`
涵蓋的既有功能（`targets` 用佔位符 `device_by_id`、讓任意上線裝置依 `act_no` 自動填入
指定 COM slot），與本次要修的「明確裝置被搶走」語意不同，收窄修復範圍避免波及該功能
（也因此本 PR 未處理 issue #186 提到的「探棒韌體升級 by-id 失配」硬化建議——那是獨立
的診斷缺口，留在 issue 上）。

文件：`README.md` 新增「範例：debug probe（如 TI XDS110）passthrough explicit target」
小節，附可直接套用的 profile 範例，並記錄兩個 bench 排查坑（探棒韌體版本內嵌在 by-id
字串裡、UART baud 常非模板預設的 115200）。

## Test Plan

新增 `tests/test_explicit_target_device_ownership.py`（2 個 pytest）：

- `test_restart_does_not_let_stale_override_steal_another_targets_device`：重建 bench
  上的 restart 情境（先只有 COM2 存在時，XDS110 裝置上線但無人認領，`_attach_by_id`
  的既有 fallback 把它借給 COM2 並持久化——這一步本身非本次修復對象；再加入 COM3
  explicit target 模擬 daemon 重啟），驗證 COM3 拿到自己的裝置、COM2 退回自己的
  （缺席）裝置並維持 `DETACHED`。
- `test_restart_outcome_is_independent_of_profile_file_load_order`：同一組 target，
  profiles 傳入順序互換（對應 profile 檔案改檔名排序），結果必須一致。

修復前兩者皆可重現地 **FAIL**（分別為 `COM2` device_by_id 錯誤停在 present-device、
`COM2` 未退回 absent-device），修復後皆 **PASS**。

- [x] 執行 `python3 -m pytest -q tests/` — 無新增失敗（`1638 passed, 16 skipped, 44 subtests passed`；較 main 的 `1636 passed` 多 2 個新增測試，0 failed）
- [x] 執行 `python3 -m policy_check --repo .` — 通過（fail: 0；R-22 為既有 pre-existing warn，非本 PR 引入）

## Policy Checklist (R-11)

- [x] 分支不是 `main`（`feature/186-explicit-target-device-ownership`）
- [x] 變更已記錄：新增 `changelog.d/186-explicit-target-device-ownership.md` fragment
- [x] `VERSION` 已更新（若有版本號變動）：本 PR 無版本變動
- [x] `python3 -m pytest -q tests/` 通過（無新失敗）
- [x] `python3 -m policy_check --repo .` 通過
- [x] 四份 agent 檔案已同步：本 PR 未修改 `CLAUDE.md`，不適用
- [x] 已標記適用 label（若適用）：無需豁免 label
- [x] 回歸 case 評估已記錄：純 in-process session-state 邏輯缺陷，pytest/mock 已完整
      覆蓋（見上方 Test Plan），不需另加 `regression/`（TestPilot real-hw）case

## Issue Reference

Closes #186
