### PR TITLE
docs: 界定 file push 的檔案大小與通道邊界，並把 remote 拓樸重整為 reachability provider 模型 (#188 #185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,11 +257,20 @@ serialwrap session console-detach --selector COM0 --client-id <client_id>
 checksum verification:
 
 ```bash
-serialwrap file push --selector COM0 --local ./firmware.bin --remote /tmp/firmware.bin
+serialwrap file push --selector COM0 --local ./probe.sh --remote /tmp/probe.sh
 serialwrap file pull --selector COM0 --remote /etc/config/wireless --local ./wireless.bak
 ```
 
 The session must be `READY`, and the target must provide `base64` and `md5sum`.
+
+**Scope — small files only.** `file push` is meant for config files, scripts and
+probes (tens of KB). A UART at 115200 baud tops out around 11 KB/s raw, and the
+echo-ACK pacing below lowers that further, so an 81 MB firmware image would take
+hours even on a perfectly stable link. Whenever the DUT is reachable over
+SSH/TFTP/HTTP, move large files with SCP/TFTP and let serialwrap drive only the
+control plane — `cmd submit` to trigger the board-side `scp`/`tftp`/`wget` and
+watch the result. Reach for `file push` on a large file only as an explicit
+fallback, after confirming the DUT has no network path at all, and record why.
 
 On consoles without flow control (`flow_control: none`), long chunk command
 lines get throttled and characters are silently dropped. `file push` therefore
@@ -592,7 +601,33 @@ background. **The daemon itself is unchanged**, and no separate `socat` is
 needed — `ssh -R` can forward a remote TCP port directly to a local AF_UNIX
 socket (OpenSSH >= 6.7).
 
-#### Architecture overview (direct)
+#### Responsibility boundary: reachability is not serialwrap's job
+
+`serialwrap remote` does **not** implement NAT traversal. It creates, verifies
+and manages the lifecycle of an SSH forward on a target that is *already*
+reachable. Where that reachability comes from — a routable address, a corporate
+LAN, an ssh jump host, or an overlay/private network (Cloudflare Zero Trust
+private network, Tailscale, WireGuard, ZeroTier, a site-to-site VPN) — is
+outside serialwrap's concern. All it needs is an `ssh_target` the system `ssh`
+can connect to.
+
+```
+serialwrap RPC          session / command / file / log
+      |
+serialwrap remote       -R / -L / lifecycle / readiness / registry
+      |
+reachability provider   LAN / Cloudflare / Tailscale / WireGuard / VPN / jump host
+      |
+physical network        NAT / CGNAT / corporate LAN / firewall
+```
+
+Provider-specific detail belongs in `ssh_config` (a host alias, `ProxyJump`) or
+in `--ssh-opt`, never in serialwrap's own CLI. There is deliberately no
+`--cloudflare` / `--tailscale` flag and no provider SDK or runtime dependency:
+auth, routing, DNS and device policy already live with the provider, and
+swapping providers must not require a serialwrap code change.
+
+#### Topology 1 (preferred): the agent host is reachable — `-R` lands on it directly
 
 ```
 [FAE site, running serialwrapd]                       [Taiwan RD / agent host]
@@ -600,8 +635,33 @@ serialwrap remote tester@AGENT_HOST:7777  --ssh -R-->  tcp://127.0.0.1:7777
 (-R: reverse-push the local daemon socket to the peer)  serialwrap --endpoint tcp://127.0.0.1:7777
 ```
 
-When the agent and the UART host can't reach each other directly (double NAT
-/ relay), the agent side instead runs `serialwrap remote -L` (below).
+An overlay/private network is a perfectly good source of that reachability, and
+with one in place this stays the normal topology **even across a double NAT** —
+no relay and no paired `-L`:
+
+```bash
+# UART host
+serialwrap remote --autossh agent:7777
+
+# agent
+serialwrap --endpoint tcp://127.0.0.1:7777 session list
+```
+
+`--autossh` keeps the ssh transport alive across drops; the overlay's own
+reconnect is the provider's business, not serialwrap's.
+
+#### Topology 2 (fallback): double NAT with no reachability provider — public relay
+
+When neither side can reach the other at all, both dial out to a relay both can
+reach: the UART host pushes with `-R`, the agent pulls with `-L` (below).
+
+```
+UART host  -- ssh -R -->  public relay  <-- ssh -L --  agent
+```
+
+This is the fallback for "no overlay, no route" — not the only way to cross a
+double NAT. The `-R` listener keeps the same trust boundary in both topologies
+(loopback bind, or a remote unix socket with `--remote-socket`).
 
 #### UART host side: open the tunnel (one line)
 
@@ -1442,13 +1502,15 @@ serialwrap session interactive-close --interactive-id <iid>
 
 ```bash
 # 推送本地檔案到 target
-serialwrap file push --selector COM0 --local ./firmware.bin --remote /tmp/firmware.bin
+serialwrap file push --selector COM0 --local ./probe.sh --remote /tmp/probe.sh
 
 # 從 target 拉取檔案到本地
 serialwrap file pull --selector COM0 --remote /etc/config/wireless --local ./wireless.bak
 ```
 
 傳輸完成後自動進行 md5 校驗。Session 必須處於 `READY` 狀態，target 需有 `base64` 與 `md5sum`。
+
+**適用範圍＝小檔**。`file push` 針對設定檔、腳本、探針這類數十 KB 內的檔案。UART 115200 baud 的原始上限約 11 KB/s，再加上下述 echo-ACK 節流會更低——一顆 81 MB 的 firmware image 即使通道完全穩定也要數小時。只要 DUT 有 SSH／TFTP／HTTP 可達，大檔一律走 SCP／TFTP，serialwrap 只負責控制面（以 `cmd submit` 觸發板端的 `scp`／`tftp`／`wget` 並觀察結果）。大檔用 `file push` 只能是**確認 DUT 無任何網路通道後**的明確 fallback，並在紀錄裡說明原因。
 
 無流控 console（`flow_control: none`）上，長 chunk 命令行會被節流靜默掉字。故 `file push` 預設走 **echo-ACK 節流**（#161）：chunk 命令行拆成短 slice 逐段送出，每段等板端 echo 回讀確認才續送——換行在**全行確認後**才送出，因此 echo 停滯（`TRANSFER_ECHO_STALL`）時命令必未執行、可安全重試。`--ack-mode {auto,echo,none}` 控制此行為：`auto`（預設）＝bridge 支援即節流；`echo`＝強制節流；`none`＝維持 legacy 整行送出；其餘值一律 `INVALID_ARGS`（RPC 層**與** `push_file()` 模組入口各一道，避免未知模式靜默降級成無保護的整行送出）。取捨：節流犧牲吞吐——1MB push 約 10–17 分鐘；急件且鏈路確認有流控時可用 `--ack-mode none` 走快路徑。單一 slice 的 echo 等待逾時**下限 5s**，實際值依 profile `timeout_s` 推導（`max(profile.timeout_s, 5.0)`，比照 #157 `chunk_timeout_s` 的推導精神）——實機兩案都在第 8 個 slice（448/512 字元）確定性卡住，原本的 2.0s 對慢板偏緊、把「還在追」誤判成「停滯」。此值只約束**失敗路徑**的等待上限，echo 正常到達時立即返回、成功路徑吞吐不變。
 
@@ -2043,7 +2105,23 @@ CLI（`bind` 只改 device、`recover`/`clear` 沿用舊 profile）。在 produc
 
 當 FAE 在海外（美國／歐洲電信客戶端）用 serialwrap 連接 DUT，台灣 RD 可用 `serialwrap remote` 讓 agent 對遠端 daemon 下命令：純 CLI 便利層，外包系統 `ssh` 建立 `-R`（reverse／expose，預設）或 `-L`（forward／connect，relay／雙 NAT 情境）隧道，background 常駐；**daemon 端零改動**，也不需要另跑 `socat`——`ssh -R` 可直接把遠端 TCP port 轉發到本機的 AF_UNIX socket（OpenSSH ≥ 6.7）。
 
-### 架構概覽（direct）
+### 責任邊界：可達性不是 serialwrap 的職責
+
+`serialwrap remote` **不實作 NAT traversal**，它只在一個**本來就可達**的 SSH target 上建立、驗證與管理 forward 的 lifecycle。可達性從哪來——公網位址、公司 LAN、ssh jump host，或既有的 overlay／private network（Cloudflare Zero Trust private network、Tailscale、WireGuard、ZeroTier、site-to-site VPN）——都在 serialwrap 的關注範圍之外；它只需要一個系統 `ssh` 連得到的 `ssh_target`。
+
+```
+serialwrap RPC          session / command / file / log
+      │
+serialwrap remote       -R / -L / lifecycle / readiness / registry
+      │
+reachability provider   LAN / Cloudflare / Tailscale / WireGuard / VPN / jump host
+      │
+physical network        NAT / CGNAT / 公司 LAN / firewall
+```
+
+provider 專屬的細節屬於 `ssh_config`（host alias、`ProxyJump`）或 `--ssh-opt`，**不進 serialwrap 的 CLI**。刻意不提供 `--cloudflare`／`--tailscale` 之類的旗標，也不引入任何 provider SDK 或執行期依賴：auth、routing、DNS、device policy 本來就該由 provider 負責，而更換 connectivity provider 時 serialwrap 不應需要改 code。
+
+### 拓樸一（preferred）：agent host 可達——`-R` 直接落在它身上
 
 ```
 [FAE 現場，跑 serialwrapd]                          [台灣 RD / agent host]
@@ -2051,7 +2129,27 @@ serialwrap remote tester@AGENT_HOST:7777  --ssh -R-->  tcp://127.0.0.1:7777
 （-R：本機 daemon socket 反向推到對端）                serialwrap --endpoint tcp://127.0.0.1:7777
 ```
 
-agent 與 UART host 互不可達（雙 NAT／relay）時，改由 agent 端另跑 `serialwrap remote -L`（見下）。
+overlay／private network 是合法的可達性來源；只要有 overlay，**即使兩端都在 NAT 後**這仍是常態拓樸——不需要 relay，也不需要成對的 `-L`：
+
+```bash
+# UART host
+serialwrap remote --autossh agent:7777
+
+# agent
+serialwrap --endpoint tcp://127.0.0.1:7777 session list
+```
+
+`--autossh` 負責 ssh transport 的連線續命；overlay 自身的 reconnect 由 provider 處理，不是 serialwrap 的事。
+
+### 拓樸二（fallback）：無可達性 provider 的雙 NAT——public relay
+
+兩端完全互不可達時，才各自對一台雙方都連得到的 relay 撥出：UART host 用 `-R` 推上去，agent 用 `-L` 拉回來（見下）。
+
+```
+UART host  -- ssh -R -->  public relay  <-- ssh -L --  agent
+```
+
+這是「無 overlay、無路由」情境的 fallback，**不是**跨雙 NAT 的唯一解法。兩種拓樸下 `-R` listener 的信任邊界一致（loopback bind，或以 `--remote-socket` 改用遠端 unix socket）。
 
 ### UART host 端：起隧道（一行）
 

--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ socket (OpenSSH >= 6.7).
 `serialwrap remote` does **not** implement NAT traversal. It creates, verifies
 and manages the lifecycle of an SSH forward on a target that is *already*
 reachable. Where that reachability comes from — a routable address, a corporate
-LAN, an ssh jump host, or an overlay/private network (Cloudflare Zero Trust
+LAN, an SSH jump host, or an overlay/private network (Cloudflare Zero Trust
 private network, Tailscale, WireGuard, ZeroTier, a site-to-site VPN) — is
 outside serialwrap's concern. All it needs is an `ssh_target` the system `ssh`
 can connect to.
@@ -2107,7 +2107,7 @@ CLI（`bind` 只改 device、`recover`/`clear` 沿用舊 profile）。在 produc
 
 ### 責任邊界：可達性不是 serialwrap 的職責
 
-`serialwrap remote` **不實作 NAT traversal**，它只在一個**本來就可達**的 SSH target 上建立、驗證與管理 forward 的 lifecycle。可達性從哪來——公網位址、公司 LAN、ssh jump host，或既有的 overlay／private network（Cloudflare Zero Trust private network、Tailscale、WireGuard、ZeroTier、site-to-site VPN）——都在 serialwrap 的關注範圍之外；它只需要一個系統 `ssh` 連得到的 `ssh_target`。
+`serialwrap remote` **不實作 NAT traversal**，它只在一個**本來就可達**的 SSH target 上建立、驗證與管理 forward 的 lifecycle。可達性從哪來——公網位址、公司 LAN、SSH jump host，或既有的 overlay／private network（Cloudflare Zero Trust private network、Tailscale、WireGuard、ZeroTier、site-to-site VPN）——都在 serialwrap 的關注範圍之外；它只需要一個系統 `ssh` 連得到的 `ssh_target`。
 
 ```
 serialwrap RPC          session / command / file / log

--- a/changelog.d/188-185-docs-file-push-boundary-and-remote-topology.md
+++ b/changelog.d/188-185-docs-file-push-boundary-and-remote-topology.md
@@ -1,0 +1,28 @@
+---
+type: docs
+issue: 188
+scope: docs
+---
+釐清兩條對外契約的邊界，皆為純文件變更、不動實作。
+
+- **`file push` 的檔案大小與通道界線（#188）**：`SKILL.md` 的「避免 base64 inline」原本只寫
+  「改用 `serialwrap file push`」，照這條規則走 agent 會把整包 firmware image 也交給
+  `file push`。實測一顆 81 MB image 走 SCP 經 LAN 數秒完成；同一顆走 UART 115200
+  （原始上限約 11 KB/s，echo-ACK 節流後更低）即使通道穩定也需數小時。現在明訂
+  `file push` 適用**數十 KB 內的小檔**（設定檔／腳本／探針），DUT 有 SSH／TFTP／HTTP
+  通道時大檔一律走 SCP／TFTP、serialwrap 只負責控制面，`file push` 用於大檔僅能是
+  「確認無網路通道後」的明確 fallback。`README.md`（中英雙語）與 `SKILL.md` 的範例
+  一併從 `./firmware.bin` 改為 `./probe.sh`——原範例本身正是要避免的反面示範。
+- **`serialwrap remote` 的責任邊界與拓樸模型（#185）**：明訂 `serialwrap remote`
+  **不實作 NAT traversal**，只在一個本來就可達的 SSH target 上管理 forward lifecycle；
+  可達性由外部 reachability provider 提供（LAN／Cloudflare Zero Trust／Tailscale／
+  WireGuard／ZeroTier／VPN／jump host），新增責任分層圖。拓樸重新分級：overlay 已提供
+  互相可達性時，`UART host -R→ agent` 為 **preferred**（即使兩端皆在 NAT 後也不需要
+  relay 或成對的 `-L`）；public relay 的 `-R/-L` 鏈降為兩端完全互不可達時的
+  **fallback**，不再是雙 NAT 的唯一描述。明文記錄刻意**不提供** `--cloudflare`／
+  `--tailscale` 之類 provider-specific 旗標、不引入 provider SDK 或執行期依賴——
+  provider 細節屬於 `ssh_config` alias／`ProxyJump`／`--ssh-opt`。既有 loopback bind
+  不變量、`--remote-socket` 硬化與單租戶 relay 要求在所有拓樸下維持不變。
+
+同時涵蓋 #185。`code_paths`（`**/*.py`／`**/*.sh`／`scripts/**`）未變動，本 fragment
+為自願記錄以利 release 收斂。

--- a/docs/superpowers/specs/2026-07-19-remote-tunnel-cli-design.md
+++ b/docs/superpowers/specs/2026-07-19-remote-tunnel-cli-design.md
@@ -57,6 +57,19 @@ agent/RD 端  ── ssh -L 7777:127.0.0.1:7777 ──►  UART host（FAE）─
 - 不做 relay 伺服器、不做隧道健康自動修復以外的 orchestration。
 - 不改變既有 `--endpoint` 語意；agent 端 direct 情境仍用既有 `--endpoint tcp://…`。
 - **native Windows UART host 本期不支援**（R2 finding 4）：lifecycle 全用 POSIX primitive，Windows 無等價；native Windows 執行 `remote` 回 `REMOTE_NOT_SUPPORTED`，defer 至 §13（Windows 現行仍可手動 `ssh -R`）。
+- **不實作 NAT traversal、不綁 connectivity provider**（2026-09-05 補充，#185）：`serialwrap remote` 只在一個**本來就可達**的 SSH target 上管理 forward lifecycle；可達性由外部的 reachability provider 提供（LAN／Cloudflare Zero Trust／Tailscale／WireGuard／ZeroTier／VPN／jump host）。**不新增 `--cloudflare`／`--tailscale` 之類的 provider-specific 旗標，不引入任何 provider SDK 或執行期依賴**——provider 的 auth／routing／DNS／device policy 本就在 serialwrap 之外，且既有 `ssh_config` alias／`ProxyJump`／`--ssh-opt` 已足以承載這些細節；更換 provider 時 serialwrap 不應需要改 code。
+
+### 拓樸模型（2026-09-05 補充，#185）
+
+本設計原文把雙 NAT 唯一地描述為 `UART host -R→ relay ←-L- agent`。實務上該 relay 鏈是**兩端完全互不可達時的 fallback**，不是雙 NAT 的唯一解法：
+
+| 拓樸 | 條件 | 形式 |
+|---|---|---|
+| preferred | overlay／private network 已提供互相可達性 | `UART host --(overlay)--> agent:sshd`，`-R` 直接落在 agent loopback；**不需要成對的 `-L`** |
+| fallback | 無 overlay、無路由，兩端皆不可達 | `UART host -R→ public relay ←-L- agent`（本設計原文的鏈路） |
+| legacy/direct | agent host 本來就可被撥入 | 同 §3 的 direct |
+
+三者共用同一套指令與同一組信任邊界規則（loopback bind 不變量、`--remote-socket` 硬化、單租戶 relay 要求），實作不需改動——因此 #185 為純文件變更。`--autossh` 負責 ssh transport 續命；overlay 自身的 reconnect 由 provider 處理。
 
 ## 3. 使用者介面（CLI surface）
 

--- a/sw_core/assets/skill/SKILL.md
+++ b/sw_core/assets/skill/SKILL.md
@@ -96,7 +96,7 @@ serialwrap 另提供原生 MCU flash 端點（與上面 device handoff 互補）
 
 Agent 要從遠端操作本機 UART 時：**在 UART host（daemon 所在機）** 跑一行反向隧道，agent 端照舊用 `--endpoint`。daemon 不重啟、不做預設。
 
-**責任邊界**：`serialwrap remote` 不做 NAT traversal，只在一個**本來就可達**的 SSH target 上管理 forward 的 lifecycle。可達性由外部提供——公網位址、公司 LAN、ssh jump host，或 overlay／private network（Cloudflare Zero Trust、Tailscale、WireGuard、ZeroTier、VPN）皆可。provider 專屬細節寫在 `ssh_config`（host alias、`ProxyJump`）或 `--ssh-opt`，**不要**去找 `--cloudflare`／`--tailscale` 這類旗標，serialwrap 刻意不提供。
+**責任邊界**：`serialwrap remote` 不做 NAT traversal，只在一個**本來就可達**的 SSH target 上管理 forward 的 lifecycle。可達性由外部提供——公網位址、公司 LAN、SSH jump host，或 overlay／private network（Cloudflare Zero Trust、Tailscale、WireGuard、ZeroTier、VPN）皆可。provider 專屬細節寫在 `ssh_config`（host alias、`ProxyJump`）或 `--ssh-opt`，**不要**去找 `--cloudflare`／`--tailscale` 這類旗標，serialwrap 刻意不提供。
 
 ```bash
 # UART host（有 serialwrapd）：把本機 daemon 反向推到對端（-R 為預設）

--- a/sw_core/assets/skill/SKILL.md
+++ b/sw_core/assets/skill/SKILL.md
@@ -96,6 +96,8 @@ serialwrap 另提供原生 MCU flash 端點（與上面 device handoff 互補）
 
 Agent 要從遠端操作本機 UART 時：**在 UART host（daemon 所在機）** 跑一行反向隧道，agent 端照舊用 `--endpoint`。daemon 不重啟、不做預設。
 
+**責任邊界**：`serialwrap remote` 不做 NAT traversal，只在一個**本來就可達**的 SSH target 上管理 forward 的 lifecycle。可達性由外部提供——公網位址、公司 LAN、ssh jump host，或 overlay／private network（Cloudflare Zero Trust、Tailscale、WireGuard、ZeroTier、VPN）皆可。provider 專屬細節寫在 `ssh_config`（host alias、`ProxyJump`）或 `--ssh-opt`，**不要**去找 `--cloudflare`／`--tailscale` 這類旗標，serialwrap 刻意不提供。
+
 ```bash
 # UART host（有 serialwrapd）：把本機 daemon 反向推到對端（-R 為預設）
 serialwrap remote tester@AGENT_OR_RELAY:7777
@@ -103,10 +105,12 @@ serialwrap remote tester@AGENT_OR_RELAY:7777
 
 Agent 端連線（依拓樸擇一）：
 
-- **direct**（agent host 就是上面 ssh 的對端）：直接
-  `serialwrap --endpoint tcp://127.0.0.1:7777 session list`
-- **relay / 雙 NAT**（agent 與 UART host 互不可達，各自對 relay 撥出）：agent 端先
+- **direct（preferred）**（agent host 就是上面 ssh 的對端）：直接
+  `serialwrap --endpoint tcp://127.0.0.1:7777 session list`。
+  兩端已有 overlay／private network 互相可達時，**即使都在 NAT 後也走這條**——`-R` 直接落在 agent 的 loopback，不需要 relay、不需要成對的 `-L`。
+- **relay / 雙 NAT（fallback）**（兩端**完全**互不可達，各自對 relay 撥出）：agent 端先
   `serialwrap remote -L tester@RELAY:7777`（回傳 `endpoint`），再用該 endpoint。
+  這是「無 overlay、無路由」時的退路，不是跨雙 NAT 的唯一解法。
 
 管理：`serialwrap remote`（列隧道）、`serialwrap remote close 7777|all`（拆除）。
 回傳 `status`：`active`＝就緒可用；`starting`＝尚未確認（慢速認證／上游未就緒），需再 `remote status` 或重試。
@@ -150,12 +154,15 @@ serialwrap event tail --rule-id owner.name -n 20
 
 ## 透過 UART 推送／拉取檔案
 ```bash
-serialwrap file push --selector COM0 --local ./fw.bin --remote /tmp/fw.bin --source agent:diag
+serialwrap file push --selector COM0 --local ./probe.sh --remote /tmp/probe.sh --source agent:diag
 serialwrap file pull --selector COM0 --remote /etc/config/wireless --local ./wireless.bak --source agent:diag
 ```
 - `--remote`／`--local` 必填於 push；pull 省略 `--local` 時回傳檔案內容。
 - `--chunk-size` 預設 2048（push）。
 - remote 模式下 `--local` 指 daemon 所在 host 的路徑。
+- **適用範圍＝小檔（設定檔、腳本、探針等，數十 KB 內）**。UART 115200 baud 的原始上限約 11 KB/s，echo-ACK 節流後更低（1 MB 約 10–17 分鐘）——`file push` 的設計目標本來就不是大檔。
+- **大檔走網路通道，不走 UART**：firmware image 這類檔案，只要 DUT 有 SSH／TFTP／HTTP 可達，一律用 SCP／TFTP 傳輸，serialwrap 只負責控制面（以 `cmd submit` 觸發板端的 `scp`／`tftp`／`wget` 並觀察結果）。實測一顆 81 MB image 走 SCP 經 LAN 數秒完成；同一顆走 UART 即使通道完全穩定也需兩小時以上。
+- `file push` 用在大檔只能是**確認 DUT 無任何網路通道後**的明確 fallback，並在紀錄裡說明原因。
 
 ## 安全規則
 - 禁止 Agent 直接寫 `/dev/ttyUSB*` 或 `/dev/ttyACM*`。
@@ -169,7 +176,7 @@ serialwrap file pull --selector COM0 --remote /etc/config/wireless --local ./wir
 ## 短命令原則（Best Practice）
 - **避免 heredoc**：heredoc 經 UART 傳輸時容易遺失字元或打亂 prompt，改用 `echo ... > file` 分步寫入。
 - **單行盡量短**：每條命令控制在 2 KB 以內；UTF-8 位元組 > 4 KB 會 warning、> 16 KB 會被 reject（`CMD_TOO_LONG`）。命令不得含 `\n` 換行字元，否則回 `CMD_CONTAINS_NEWLINE`。broker 不截斷；但 broker 上限與 target 端 tty line buffer（常見 4096 bytes）的物理單行限制是兩回事，過長單行仍可能在 target 端被截斷。上限可由 `serialwrap daemon status` 的 `limits` 欄位執行期查詢，不需硬編碼。
-- **避免 base64 inline**：不要將整個檔案 base64 編碼塞進 `cmd submit`，改用 `serialwrap file push`。
+- **避免 base64 inline**：不要將整個檔案 base64 編碼塞進 `cmd submit`。小檔（數十 KB 內）改用 `serialwrap file push`；firmware image 這類大檔在 DUT 有網路通道時一律走 SCP／TFTP，不要交給 `file push`（界線見「透過 UART 推送／拉取檔案」）。
 - **長命令拆分**：管線命令過長時，先寫成 script 檔再 `source` 或 `sh /tmp/script.sh`。
 - **長命令 keepalive**：長時間命令加 `--expected-duration <秒>`，broker 在此期間暫停 prompt timeout 並監控 RX 活動延長等待，避免誤判 PROMPT_TIMEOUT。
 - **line vs background**：`line` 命令直接看 `cmd status`，不要用 `cmd result-tail`（那是給 `background` capture 用的）。


### PR DESCRIPTION
## Summary

兩條**對外契約邊界**的文件釐清，純文件變更、不動任何實作。

### `file push` 的檔案大小與通道界線（#188）

`SKILL.md` 的「避免 base64 inline」原本只寫「改用 `serialwrap file push`」，沒有界定適用的檔案大小，也沒說「DUT 有網路通道時該怎麼選」——照這條規則走，agent 會把整包 firmware image 也交給 `file push`。

- 明訂 `file push` 適用**數十 KB 內的小檔**（設定檔、腳本、探針）。UART 115200 baud 原始上限約 11 KB/s，echo-ACK 節流後更低（1 MB 約 10–17 分鐘）。
- 大檔在 DUT 有 SSH／TFTP／HTTP 通道時一律走 SCP／TFTP，serialwrap 只負責控制面（`cmd submit` 觸發板端的 `scp`／`tftp`／`wget` 並觀察結果）；`file push` 用於大檔僅能是「確認無網路通道後」的明確 fallback，並須記錄原因。
- **範例一併修正**：`README.md`（中英雙語）與 `SKILL.md` 原本的 `file push --local ./firmware.bin` 改為 `./probe.sh`——原範例本身正是這條規則要避免的反面示範。

未採用 issue 提到的「CLI 對超過門檻的檔案 warn 或要求 `--force`」可選項：門檻與行為未定案，issue 也註明若要做請另開討論。

### `serialwrap remote` 的責任邊界與拓樸模型（#185）

- 新增**責任邊界**宣告：`serialwrap remote` 不實作 NAT traversal，只在一個**本來就可達**的 SSH target 上建立／驗證／管理 forward lifecycle；附責任分層圖（serialwrap RPC → serialwrap remote → reachability provider → physical network）。
- **拓樸重新分級**：overlay／private network（Cloudflare Zero Trust、Tailscale、WireGuard、ZeroTier、VPN）已提供互相可達性時，`UART host -R→ agent` 為 **preferred**——即使兩端皆在 NAT 後也不需要 relay、不需要成對的 `-L`；public relay 的 `-R/-L` 鏈降級為兩端**完全**互不可達時的 **fallback**，不再被描述成雙 NAT 的唯一解法。附最小範例（`serialwrap remote --autossh agent:7777`）。
- 明文記錄刻意**不提供** `--cloudflare` / `--tailscale` 之類 provider-specific 旗標、不引入任何 provider SDK 或執行期依賴——provider 的 auth／routing／DNS／device policy 本就在 serialwrap 之外，且既有 `ssh_config` alias／`ProxyJump`／`--ssh-opt` 已足以承載；更換 provider 時不應需要改 code。
- 既有 loopback bind 不變量、`--remote-socket` 硬化、單租戶 relay 要求、readiness 語意在所有拓樸下**維持不變**。

依 #185 的驗收條件「若實作確認現有行為已完整支援，則本 issue 可純 docs/skill/spec 變更完成」——已確認 `sw_core/remote_tunnel.py` 無需改動（三種拓樸共用同一套指令與同一組信任邊界規則），故本 PR 不含實作變更。

### 改動檔案

| 檔案 | 內容 |
|---|---|
| `sw_core/assets/skill/SKILL.md` | file push 大小／通道界線、base64 inline 規則改寫、remote 責任邊界與 preferred/fallback 拓樸 |
| `README.md` | 英文與繁中兩段對稱更新（File Transfer scope、Remote Support 責任邊界與拓樸分級） |
| `docs/superpowers/specs/2026-07-19-remote-tunnel-cli-design.md` | §2 非目標新增「不實作 NAT traversal、不綁 provider」，並附拓樸模型補充表（標註為 2026-09-05 事後補充，不改寫原設計紀錄） |
| `changelog.d/188-185-docs-file-push-boundary-and-remote-topology.md` | fragment |

## Test Plan

- [x] 執行 `python3 -m pytest -q tests/` — **1638 passed, 16 skipped, 44 subtests passed**（0 failed，無新增失敗）
- [x] 執行 `python3 -m policy_check --repo .` — 通過

## Policy Checklist (R-11)

- [x] 分支不是 `main`（不可直接 commit 到 main）
- [x] 變更已記錄：新增 `changelog.d/188-185-docs-file-push-boundary-and-remote-topology.md` fragment（本 PR 未動 `code_paths`（`**/*.py`／`**/*.sh`／`scripts/**`），R-09 不觸發，此 fragment 為自願記錄以利 release 收斂）
- [x] `VERSION` 已更新（若有版本號變動）— 無版本號變動，不適用
- [x] `python3 -m pytest -q tests/` 通過（無新失敗）
- [x] `python3 -m policy_check --repo .` 通過
- [x] 四份 agent 檔案已同步（若有修改 `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` / `.github/copilot-instructions.md`）— 本 PR 未修改，不適用
- [x] 已標記適用 label（無需豁免 label）
- [x] 回歸 case 評估已記錄（見下）

**回歸 case 評估**：本 PR 為純文件變更，不改任何 production code path，無行為可回歸；既有 pytest 全綠即為充分驗證，不新增 pytest 亦不新增 `regression/` case。

## Issue Reference

Closes #188
Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMLyQNsN4hTHBzngEm7WYL
