### PR TITLE
fix(wal): WAL 檔案不存在時不再靜默回空，daemon 自癒重建目錄，doctor 新增 wal_writable (#189)

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,22 @@ latest mode may return fewer than `--limit` records with `truncated=false`;
 read the archive files directly if you need older records (`log tail-*` and
 `wal export` both read the current file only).
 
+`WAL_MISSING` (#189): if the WAL file is gone while `current_seq > 0` — records
+were written and the audit trail has since been removed, typically because an
+external tool deleted the WAL directory — `log tail-raw` / `log tail-text` /
+`wal export` return `ok: false` with `error_code: "WAL_MISSING"` and the actual
+`wal_path`, instead of `ok: true` plus an empty array. Every response (success
+or not) carries `wal_path` and `wal_file_exists` so a caller can tell "queried
+fine, no matching records" apart from "the audit file is gone". A brand-new
+daemon that has not written anything yet (`current_seq == 0`) is not an error.
+The daemon recreates a deleted WAL directory on its next append and logs a
+warning; records written while it was missing are unrecoverable. `wal export`
+additionally reports `available_from_seq` and `rotated_out`, so a range that
+predates the current file is stated explicitly rather than coming back empty.
+`serialwrap doctor`'s `wal_writable` check verifies the directory really exists
+and is writable — unlike `wal_dir`, which only compares the shell and daemon
+values and is advisory.
+
 `~/b-log` is **not** the WAL — it only holds agent-triggered on-demand session
 captures. The authoritative WAL always lives under `SERIALWRAP_WAL_DIR`
 (default `~/.local/state/serialwrap/wal/`). A shell-exported
@@ -1766,6 +1782,12 @@ serialwrap wal export --from-seq 0 --limit 500
 兩者回應皆附 metadata 欄位：`from_seq`（實際使用值，latest 模式為 `null`）、`last_seq`（回傳紀錄的最大 seq，無紀錄為 `null`，可作下次 `--from-seq` 增量起點）、`current_seq`（WAL 目前 seq 計數）、`returned`（回傳筆數：`tail-raw` 計 WAL records、`tail-text` 計文字行數）、`truncated`（是否還有符合但被 `--limit` 截掉的紀錄：latest 模式指視窗**之前**還有更舊紀錄、range 模式指視窗**之後**還有更新紀錄）。
 
 注意：查詢與 `truncated` 判定**僅涵蓋現行 `raw.wal.ndjson`**。WAL 輪替（rotation）後更舊紀錄保存在 `raw.wal.ndjson.<時戳>` 歸檔檔，不列入判定——rotation 剛發生時 latest 模式可能回不足 `--limit` 筆且 `truncated=false`；需要歸檔紀錄請直接讀取歸檔檔（`log tail-*` 與 `wal export` 皆僅讀現行檔）。
+
+**WAL 檔案不存在時不再靜默回空（`WAL_MISSING`，#189）**：若 `current_seq > 0`（已寫過紀錄）而現行 WAL 檔不存在——代表稽核紀錄在 daemon 運行期間被移除，常見於外部工具刪掉整個 WAL 目錄——`log tail-raw` / `log tail-text` / `wal export` 一律回 `ok: false` ＋ `error_code: "WAL_MISSING"` ＋ 實際 `wal_path`，而不是 `ok: true` ＋ 空陣列 ＋ rc=0。所有回應（成功與否）都帶 `wal_path` 與 `wal_file_exists`，讓呼叫端分辨「查得到但沒有符合的紀錄」與「稽核檔案不見了」。全新 daemon 尚未寫過任何紀錄（`current_seq == 0`）時檔案不存在屬正常，不誤報。
+
+daemon 在下一次 append 時會**自動重建**被刪掉的 WAL 目錄並輸出告警，但消失期間的紀錄無法復原。`wal export` 另回 `available_from_seq`（現行檔最小 seq）與 `rotated_out`（請求區間是否落在已輪替掉的範圍），使「這個區間本來就沒紀錄」與「曾經存在但已被 rotate 掉」不再都只是空陣列。
+
+`serialwrap doctor` 的 **`wal_writable`** 檢查會實際驗證該目錄存在且可寫，**非 advisory**（稽核紀錄整個消失會拉低 doctor 整體 ok）；既有的 `wal_dir` 檢查只比對 shell/daemon 的 WAL_DIR 是否一致、維持 advisory WARN，兩者各司其職。
 
 ### WAL 管理
 

--- a/changelog.d/189-wal-missing-detection.md
+++ b/changelog.d/189-wal-missing-detection.md
@@ -1,0 +1,53 @@
+---
+type: fix
+issue: 189
+scope: wal
+---
+WAL 檔案不存在時不再靜默回 `ok:true` ＋ 空陣列；daemon 會自癒重建被刪掉的 WAL 目錄。
+
+- **事故**：daemon 同一 PID 連續運行六天，`log tail-raw` / `log tail-text` /
+  `wal export` 全部回 `ok:true` ＋ 空陣列 ＋ rc=0，而 `current_seq` 已累加到
+  1,261,000——WAL 目錄被外部工具 rmtree 掉了（testpilot 的 `clean_wal()`，已於
+  hamanpaul/testpilot-core#36 追蹤），服務對此毫無所覺、也不告訴任何人。該 bench
+  六天的 console 紀錄因此無法回溯，兩輪事故取證落空。`doctor` 的 `wal_dir` 檢查
+  當時回的是 ok:true——它只比對 shell/daemon 的 WAL_DIR 是否一致並印出路徑，
+  **從不檢查該路徑是否存在**。
+- **機制修正**：issue 原文推測是「daemon 對著已 unlink 的 fd 續寫」。實際不是——
+  `append()` 每筆都重新 `open(path, "a")`，被刪掉的是**整個目錄**，於是每次 append
+  都以 `FileNotFoundError` 失敗、被既有的 `except OSError` best-effort 分支吞掉
+  （#79 STA-1 的「稽核寫入失敗不得讓 RX thread 崩潰」），而 `_seq` 照常累加。
+  告警確實有發，但走 `logging` 而沒有任何 log 落地（正是 #171 的論點）。
+- **自癒**：`append()` 撞到 `OSError` 時先 `os.makedirs(wal_dir, exist_ok=True)`
+  並重試一次；成功即續寫並告警（記 `recreated_count`），重試仍失敗才維持既有的
+  best-effort 標 loss 行為（記 `write_failures` / `last_write_error`）。因為每筆
+  append 都重開檔，目錄被刪之後**下一筆寫入**就會偵測到並修好，不需要另開週期性
+  自檢執行緒。
+- **讀取路徑誠實化**：`WalWriter.health()` 攤開 `wal_dir` / `wal_path` /
+  `wal_dir_exists` / `wal_file_exists` / `wal_dir_writable` / `current_seq` /
+  `write_failures` / `last_write_error` / `recreated_count` / `healthy`。
+  `log.tail_raw` / `log.tail_text` / `wal.range`（＝`serialwrap wal export`）在
+  「`current_seq > 0` 但現行檔不存在」時回 `ok:false` ＋
+  `error_code: "WAL_MISSING"` ＋ 實際 `wal_path` ＋ 可行動 hint。
+  **`current_seq == 0` 不誤報**——全新 daemon 尚無 UART 流量時檔案本來就還沒建立。
+  成功路徑也一律帶 `wal_path` / `wal_file_exists`，讓呼叫端分辨「查得到但沒有符合
+  的紀錄」與「稽核檔案不見了」。
+- **輪替可分辨**：`wal.range` 另回 `available_from_seq`（現行檔最小 seq）與
+  `rotated_out`（請求區間是否落在已輪替掉的範圍），使「這個區間本來就沒有紀錄」與
+  「曾經存在但已被 rotate 掉」不再都只是空陣列。
+- **`doctor` 新增 `wal_writable` 檢查**（消費 `health.status` 新增的 `wal` 欄位）：
+  實際驗證目錄存在且可寫，**非 advisory**——稽核紀錄整個消失必須拉低 doctor 整體
+  ok。既有 `wal_dir`（shell/daemon 一致性）維持 advisory WARN，兩者各司其職。
+  `tests/test_doctor.py` 的兩份 pinned 清單同步更新。
+
+**契約變更**：WAL 檔案缺失時三條讀取路徑由 `ok:true` 改為 `ok:false` ＋
+`WAL_MISSING`。這是本 issue 的核心訴求（先前的靜默成功正是讓事故延續六天的原因）。
+只讀 `records` / `lines` 的呼叫端行為不變（仍是空的）；檢查 `ok` 的呼叫端會開始看到
+失敗——那正是期望的行為。
+
+**regression-case 評估**：新增 `tests/test_wal_missing_detection.py`（19 個 pytest，
+修復前 18 個可重現地 FAIL）——涵蓋 health 欄位、rmtree 後自癒重建並告警、重建後可再
+讀、重建失敗時標 loss 且不崩、`available_from_seq`、三條讀取路徑回 `WAL_MISSING`、
+全新 daemon 不誤報、成功路徑帶 `wal_path`/`wal_file_exists`、`rotated_out` 判定、
+`health.status` 暴露 wal 健康，以及 doctor `wal_writable` 的四種情形與非 advisory
+性質。全部可用 tmpdir ＋ `shutil.rmtree` 精確模擬，**不需**新增 `regression/`
+（TestPilot 實機）case——本修復不依賴真板時序或外部工具。

--- a/sw_core/assets/skill/SKILL.md
+++ b/sw_core/assets/skill/SKILL.md
@@ -37,6 +37,7 @@ description: 透過 serialwrap broker + CLI 進行多 agent UART 存取，提供
 7. `background` 命令：`serialwrap cmd result-tail --cmd-id <cmd_id> --from-chunk 0 --limit 100` 增量取回 chunk。
 8. `interactive` 任務：用 `session interactive-open/-send/-status/-close`，不要拿 `cmd submit` 硬跑全螢幕互動程式。
 9. 需要完整證據時：`serialwrap log tail-raw --selector COM0`（預設 latest 模式回最新 N 筆；要增量讀取帶 `--from-seq N`，回應附 `last_seq`/`current_seq`/`truncated` 等 metadata，#124。注意 `truncated` 僅以現行 WAL 檔為範圍——輪替歸檔 `raw.wal.ndjson.<ts>` 不列入，需要更舊紀錄直接讀歸檔檔）／`serialwrap wal export`；只要查目前 WAL seq 用 `serialwrap wal current-seq`。
+   - **`error_code: WAL_MISSING`（#189）**：已寫過紀錄但現行 WAL 檔不存在＝稽核紀錄在 daemon 運行期間被刪掉（常見於外部工具 rmtree 掉 WAL 目錄），該區段**無法復原**。不要當成「這段時間沒有輸出」。daemon 會在下一次寫入自動重建目錄續寫；用 `serialwrap doctor` 的 `wal_writable` 檢查確認目錄狀態。所有回應都帶 `wal_path` / `wal_file_exists`，可據此分辨「查得到但沒資料」與「檔案不見了」。
 
 ## command_capable 與 READY 判定（#51）
 - 一個 session 是否「可下命令」由其 profile 的 `ready_probe` 是否非空決定（`command_capable = bool(profile.ready_probe.strip())`），**與底層是 OS shell 或 bootloader 無關**——只要 `prompt_regex` 對得上、`ready_probe` 能 round-trip 即可進 `READY`（含 U-Boot 之類 bootloader command profile，如 `uboot-template`）。

--- a/sw_core/doctor_cmd.py
+++ b/sw_core/doctor_cmd.py
@@ -289,6 +289,72 @@ def _check_devices_windows() -> dict:
     }
 
 
+def _check_wal_writable() -> dict:
+    """WAL 可寫性（#189）：daemon 回報的 WAL 目錄是否**真的存在且可寫**。
+
+    #148 的 ``wal_dir`` 檢查只比對 shell/daemon 的 WAL_DIR 是否一致並印出路徑，
+    **從不檢查該路徑是否存在**——實地事故中它對著一個已被 rmtree 的目錄回 ok:true，
+    而 daemon 已經對著虛空累加 seq 六天、該 bench 的 console 紀錄全部無法回溯。
+    這一項本可以在六天前就抓到。
+
+    本檢查**非 advisory**：稽核紀錄整個消失必須拉低 doctor 整體 ok（``wal_dir``
+    的一致性提醒維持 advisory WARN，兩者各司其職）。daemon 未在跑／連不上／舊版
+    daemon 不回 ``wal`` 欄位時降級為 informational（ok=True），與 ``wal_dir`` 同
+    哲學——doctor 常在啟動 daemon 前執行，「連不到」不是這項要抓的錯誤。
+    """
+    from sw_core.cli import _local_default_endpoint, _safe_runtime_config  # 延遲匯入避免循環
+    from sw_core.client import rpc_call
+
+    rc = _safe_runtime_config()
+    cfg_sock = None
+    if rc is not None:
+        try:
+            cfg_sock = rc.socket_path()
+        except Exception:  # noqa: BLE001
+            cfg_sock = None
+    endpoint = cfg_sock or _local_default_endpoint()
+
+    resp = rpc_call(endpoint, "health.status", {}, timeout_s=0.5)
+    wal = resp.get("wal") if isinstance(resp, dict) else None
+    if not resp.get("ok") or not isinstance(wal, dict):
+        return {
+            "check": "wal_writable",
+            "ok": True,
+            "detail": "daemon 未在跑、無法連線，或為不回報 wal 健康欄位的舊版 daemon；略過",
+            "fix": "",
+        }
+    if wal.get("healthy"):
+        detail = f"WAL 目錄可寫：{wal.get('wal_dir')}（current_seq={wal.get('current_seq')}）"
+        if wal.get("recreated_count"):
+            detail += f"；曾自癒重建 {wal['recreated_count']} 次（消失期間的紀錄無法復原）"
+        return {"check": "wal_writable", "ok": True, "detail": detail, "fix": ""}
+
+    reasons: list[str] = []
+    if not wal.get("wal_dir_exists"):
+        reasons.append("目錄不存在")
+    elif not wal.get("wal_dir_writable"):
+        reasons.append("目錄不可寫")
+    if int(wal.get("current_seq") or 0) > 0 and not wal.get("wal_file_exists"):
+        reasons.append(f"已寫過 {wal.get('current_seq')} 筆紀錄但現行 WAL 檔不存在")
+    if wal.get("write_failures"):
+        reasons.append(
+            f"append 失敗 {wal['write_failures']} 次（最後一次：{wal.get('last_write_error')}）"
+        )
+    return {
+        "check": "wal_writable",
+        "ok": False,
+        "detail": f"WAL 目錄 {wal.get('wal_dir')} 異常：{'；'.join(reasons) or '未知'}",
+        "fix": (
+            "確認沒有外部工具刪除該目錄（已知案例：testpilot 的 clean_wal() 會 rmtree "
+            "硬編路徑 /tmp/serialwrap/wal，見 hamanpaul/testpilot-core#36）。daemon 會在"
+            "下一次寫入時自動重建目錄續寫，但消失期間的紀錄無法復原；需要持久稽核請把 "
+            "WAL_DIR 指向非 /tmp 的路徑（systemd 模式在 unit 加 "
+            "Environment=SERIALWRAP_WAL_DIR=<path> 後 systemctl daemon-reload 並 "
+            "`serialwrap service restart`）"
+        ),
+    }
+
+
 def _check_wal_dir() -> dict:
     """WAL 目錄一致性（#148）：印出 daemon 實際生效的 WAL_DIR；shell 端顯式覆寫
     ``SERIALWRAP_WAL_DIR`` 但與 daemon 回報不一致時 WARN（ok=False，advisory，
@@ -550,6 +616,7 @@ def run_doctor(fx=None, home=None, *, platform: str | None = None) -> list[dict]
             _check_supervision_mode(home),
             _check_daemon_endpoint(),
             _check_wal_dir(),
+            _check_wal_writable(),
             _check_profile_bootloader_prompts(),
             _check_devices_windows(),
         ])
@@ -578,6 +645,7 @@ def run_doctor(fx=None, home=None, *, platform: str | None = None) -> list[dict]
         _check_single_daemon(),
         _check_endpoint_reachable(),
         _check_wal_dir(),
+        _check_wal_writable(),
         _check_profile_bootloader_prompts(),
         _check_devices(),
         _check_wsl_systemd(fx),

--- a/sw_core/service.py
+++ b/sw_core/service.py
@@ -989,7 +989,11 @@ class SerialwrapService:
             meta: dict[str, Any] = {
                 "from_seq": from_seq,
                 "last_seq": rows[-1]["seq"] if rows else None,
-                "current_seq": self._wal.current_seq,
+                # current_seq 取自上面同一份 wal_health 快照：`WalWriter.current_seq`
+                # property 會取 WAL 寫鎖（append 全程持有），在此讀等於讓診斷路徑被
+                # 資料平面的寫入節奏拖住、凍結單執行緒的 RPC loop；用快照亦保證回應
+                # 內的 WAL 狀態彼此一致（Copilot review）。
+                "current_seq": wal_health["current_seq"],
                 "truncated": truncated,
                 "wal_path": wal_health["wal_path"],
                 "wal_file_exists": wal_health["wal_file_exists"],

--- a/sw_core/service.py
+++ b/sw_core/service.py
@@ -531,7 +531,34 @@ class SerialwrapService:
         except OSError:
             pass
 
+    def _wal_missing_response(self, health: dict[str, Any]) -> dict[str, Any] | None:
+        """WAL 已寫過紀錄但現行檔不存在 → 明確錯誤，不用空陣列 + ok:true 帶過（#189）。
+
+        ``current_seq == 0`` 代表這個 daemon 從來沒寫過任何紀錄（全新啟動、尚無 UART
+        流量），此時檔案不存在是正常的，不誤報。
+        """
+        if health["wal_file_exists"] or health["current_seq"] <= 0:
+            return None
+        return {
+            "ok": False,
+            "error_code": "WAL_MISSING",
+            "wal_path": health["wal_path"],
+            "wal_dir": health["wal_dir"],
+            "wal_dir_exists": health["wal_dir_exists"],
+            "wal_file_exists": False,
+            "current_seq": health["current_seq"],
+            "hint": (
+                f"WAL 已寫過 {health['current_seq']} 筆紀錄，但現行 WAL 檔不存在——稽核紀錄"
+                "在 daemon 運行期間被移除（常見於外部工具 rmtree WAL 目錄）。消失期間的"
+                "紀錄無法復原；daemon 會在下一次寫入時自動重建目錄續寫。以 "
+                "`serialwrap doctor` 的 wal_writable 檢查確認目錄狀態。"
+            ),
+        }
+
     def health(self) -> dict[str, Any]:
+        # WAL 健康在 self._lock 之外先取（含 stat/access 等檔案系統呼叫），不在
+        # RPC 路由層持鎖期間做 I/O。
+        wal_health = self._wal.health()
         with self._lock:
             sessions = self._sessions.list_sessions()
             devices = self._sessions.list_devices()
@@ -551,6 +578,9 @@ class SerialwrapService:
                 "commands": len(self._arbiter.snapshot()),
                 "wal_path": self._wal.wal_path,
                 "mirror_path": self._wal.mirror_path,
+                # #189：稽核紀錄的活體健康（目錄／檔案存在性、可寫性、寫入失敗與自癒
+                # 重建次數）。doctor 的 wal_writable 檢查即消費此欄位。
+                "wal": wal_health,
                 # #129：暴露可查詢的命令長度上限，讓 client 執行期查詢而非硬編碼。
                 # 上限值與錯誤碼／警告碼字串皆直接引用 sw_core.arbiter 常數（單一
                 # 事實來源）；此為 broker 對 command.submit 單一 --cmd 參數的 UTF-8
@@ -939,6 +969,10 @@ class SerialwrapService:
                 if not state.get("ok"):
                     return state
                 target_com = str(state["session"]["com"])
+            wal_health = self._wal.health()
+            missing = self._wal_missing_response(wal_health)
+            if missing is not None:
+                return missing
             rows, truncated = self._wal.tail_raw_with_meta(
                 from_seq=from_seq, com=target_com, limit=limit
             )
@@ -950,11 +984,15 @@ class SerialwrapService:
             # - truncated：latest 模式＝視窗前還有更舊符合紀錄；range 模式＝視窗後還有更新符合紀錄
             #   scope：僅以現行 WAL 檔為範圍——輪替歸檔 raw.wal.ndjson.<ts> 不列入判定
             #  （rotation 剛發生時 latest 模式可能回不足 limit 筆且 truncated=False，#124 review）
+            # - wal_path / wal_file_exists（#189）：讓呼叫端一眼分辨「查得到但沒資料」
+            #   與「稽核檔案不見了」——先前兩者都只是 ok:true + 空陣列
             meta: dict[str, Any] = {
                 "from_seq": from_seq,
                 "last_seq": rows[-1]["seq"] if rows else None,
                 "current_seq": self._wal.current_seq,
                 "truncated": truncated,
+                "wal_path": wal_health["wal_path"],
+                "wal_file_exists": wal_health["wal_file_exists"],
             }
             if method == "log.tail_raw":
                 return {"ok": True, "records": rows, "returned": len(rows), **meta}
@@ -965,10 +1003,25 @@ class SerialwrapService:
             from_seq = int(params.get("from_seq") or 0)
             to_seq = int(params.get("to_seq") or 0)
             limit = int(params.get("limit") or 1000)
+            wal_health = self._wal.health()
+            missing = self._wal_missing_response(wal_health)
+            if missing is not None:
+                return missing
             rows = self._wal.tail_raw(from_seq=from_seq, com=None, limit=limit)
             if to_seq > 0:
                 rows = [r for r in rows if int(r.get("seq", 0)) <= to_seq]
-            return {"ok": True, "records": rows}
+            # #189：請求區間落在已輪替掉的範圍時明確標示。先前「這個區間本來就沒有
+            # 紀錄」與「曾經存在但已被 rotate 掉」都只回空陣列 + ok:true + rc=0，
+            # 呼叫端無從分辨，事故回溯就是在這裡斷掉的。
+            available = self._wal.available_from_seq()
+            return {
+                "ok": True,
+                "records": rows,
+                "wal_path": wal_health["wal_path"],
+                "wal_file_exists": wal_health["wal_file_exists"],
+                "available_from_seq": available,
+                "rotated_out": bool(available is not None and from_seq + 1 < available),
+            }
 
         if method == "wal.reset":
             return self._wal.reset()

--- a/sw_core/wal.py
+++ b/sw_core/wal.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 import os
 import threading
 import time
@@ -12,6 +13,10 @@ from typing import Any
 
 from .constants import DEFAULT_WAL_ROTATE_BYTES, WAL_DIR
 from .util import dumps_stable, monotonic_ns, now_iso, to_printable
+
+# 模組層 logger：append 的頻率等同 UART RX，而 logging.getLogger() 每次呼叫都會
+# 進 logging.Manager 取全域鎖——不可放在這條熱路徑上（#189）。
+_LOG = logging.getLogger("serialwrap")
 
 
 class WalWriter:
@@ -24,6 +29,10 @@ class WalWriter:
         self._mirror_path = os.path.join(self._wal_dir, "raw.mirror.log")
         self._lock = threading.Lock()
         self._seq = 0
+        # 稽核健康計數（#189）：WAL 目錄可能被外部工具整個刪掉，而服務先前對此毫無所覺。
+        self._write_failures = 0
+        self._last_write_error: str | None = None
+        self._recreated_count = 0
         os.makedirs(self._wal_dir, exist_ok=True)
         self._load_last_seq()
 
@@ -126,18 +135,95 @@ class WalWriter:
                 # 輪替失敗不丟資料（仍寫入既有檔），但標記供觀測；conditional key 維持常態 record 向後相容。
                 record["rotation_failed"] = True
             try:
-                with open(self._wal_path, "a", encoding="utf-8") as wal_fp:
-                    wal_fp.write(dumps_stable(record))
-                    wal_fp.write("\n")
-                with open(self._mirror_path, "a", encoding="utf-8") as mirror_fp:
-                    mirror_fp.write(to_printable(payload))
+                self._write_record_locked(record, payload)
             except OSError as exc:
-                # 稽核寫入失敗（ENOSPC/EROFS/權限/fd 耗盡）不得讓資料平面（RX reader thread）崩潰（#79 STA-1）。
-                # best-effort：標記 loss、告警，仍回傳 record 讓上游照常 fan-out 給 console、續處理後續 RX。
-                record["loss_flag"] = True
-                import logging
-                logging.getLogger("serialwrap").warning("WAL append 寫入失敗（best-effort 略過）：%s", exc)
+                # #189：稽核目錄可能在 daemon 運行期間被外部工具整個刪掉（實地事故：
+                # testpilot 的 clean_wal() rmtree 硬編路徑 /tmp/serialwrap/wal）。append
+                # 每次都重開檔，故下一筆寫入立刻撞到 ENOENT——在這裡自癒重建目錄並重試
+                # 一次，而不是連續六天安靜地把稽核紀錄寫進虛空、seq 一路累加到 126 萬。
+                try:
+                    os.makedirs(self._wal_dir, exist_ok=True)
+                    self._write_record_locked(record, payload)
+                except OSError as retry_exc:
+                    # 重建也失敗（ENOSPC/EROFS/權限/fd 耗盡）不得讓資料平面（RX reader
+                    # thread）崩潰（#79 STA-1）。best-effort：標記 loss、告警，仍回傳
+                    # record 讓上游照常 fan-out 給 console、續處理後續 RX。
+                    record["loss_flag"] = True
+                    self._write_failures += 1
+                    self._last_write_error = f"{type(retry_exc).__name__}: {retry_exc}"
+                    _LOG.warning("WAL append 寫入失敗（best-effort 略過）：%s", retry_exc)
+                else:
+                    self._recreated_count += 1
+                    self._last_write_error = f"{type(exc).__name__}: {exc}"
+                    _LOG.warning(
+                        "WAL 目錄 %s 消失，已重建並續寫（原因：%s）；消失期間的紀錄無法復原",
+                        self._wal_dir, exc,
+                    )
         return record
+
+    def _write_record_locked(self, record: dict[str, Any], payload: bytes) -> None:
+        """雙軌 append：權威 ndjson ＋ 人類可讀鏡像。須在 ``self._lock`` 內呼叫。"""
+        with open(self._wal_path, "a", encoding="utf-8") as wal_fp:
+            wal_fp.write(dumps_stable(record))
+            wal_fp.write("\n")
+        with open(self._mirror_path, "a", encoding="utf-8") as mirror_fp:
+            mirror_fp.write(to_printable(payload))
+
+    def health(self) -> dict[str, Any]:
+        """稽核紀錄的活體健康（#189）。
+
+        先前唯一能問的只有 ``current_seq``，而它在 WAL 目錄被刪掉之後仍會繼續累加——
+        於是 ``current_seq=1261000`` 與 ``records=[]`` 可以同時出現在同一個回應裡，
+        沒有任何欄位指出檔案不見了。這裡把檔案系統的實況一次攤開。
+
+        ``healthy`` 的判準：目錄存在且可寫，且不出現「已寫過紀錄但現行檔不存在」。
+        ``current_seq == 0`` 時檔案尚未建立是正常的（全新 daemon、還沒有 UART 流量），
+        不算故障。
+        """
+        wal_dir_exists = os.path.isdir(self._wal_dir)
+        wal_file_exists = os.path.exists(self._wal_path)
+        wal_dir_writable = wal_dir_exists and os.access(self._wal_dir, os.W_OK)
+        # 刻意**不取 self._lock**：該鎖在每一筆 append 的檔案寫入全程持有，而 append
+        # 的頻率等同 UART RX。health() 由 health.status / log.tail_* / wal.range 呼叫，
+        # 這些都在 daemon 單執行緒 asyncio dispatcher 內同步執行——在此等 WAL 寫鎖等於
+        # 讓診斷查詢被資料平面的寫入節奏拖住，凍結整個 RPC loop。這裡讀的是四個
+        # int/str 欄位的診斷快照，GIL 下各自的讀取為原子；快照內部略有時間差對
+        # 「稽核檔在不在」的判定無影響。
+        seq = self._seq
+        failures = self._write_failures
+        last_error = self._last_write_error
+        recreated = self._recreated_count
+        return {
+            "wal_dir": self._wal_dir,
+            "wal_path": self._wal_path,
+            "wal_dir_exists": wal_dir_exists,
+            "wal_file_exists": wal_file_exists,
+            "wal_dir_writable": wal_dir_writable,
+            "current_seq": seq,
+            "write_failures": failures,
+            "last_write_error": last_error,
+            "recreated_count": recreated,
+            "healthy": bool(
+                wal_dir_exists
+                and wal_dir_writable
+                and not (seq > 0 and not wal_file_exists)
+            ),
+        }
+
+    def available_from_seq(self) -> int | None:
+        """現行 WAL 檔中最小的 seq；檔案不存在或無有效紀錄時回 ``None``（#189）。
+
+        用來分辨「這個區間本來就沒有紀錄」與「這個區間曾經存在，但已被輪替掉」——
+        對呼叫端是完全不同的結論，先前兩者都只是空陣列 ＋ ``ok:true``。
+        """
+        if not os.path.exists(self._wal_path):
+            return None
+        try:
+            for obj in self._iter_matching(None):
+                return int(obj["seq"])
+        except OSError:
+            return None
+        return None
 
     def reset(self) -> dict[str, Any]:
         """輪替現有 WAL 檔案並重設 seq 計數器。不需重啟 daemon。"""

--- a/sw_core/wal.py
+++ b/sw_core/wal.py
@@ -182,7 +182,10 @@ class WalWriter:
         """
         wal_dir_exists = os.path.isdir(self._wal_dir)
         wal_file_exists = os.path.exists(self._wal_path)
-        wal_dir_writable = wal_dir_exists and os.access(self._wal_dir, os.W_OK)
+        # 目錄要能建立/開啟檔案，需同時具備寫入（W_OK）與 traverse（X_OK）權限——
+        # 只驗 W_OK 會把 0600 這類「寫得進 inode 但進不去」的目錄誤判為可寫，
+        # 使 healthy / doctor 的 wal_writable 漏報（Copilot review）。
+        wal_dir_writable = wal_dir_exists and os.access(self._wal_dir, os.W_OK | os.X_OK)
         # 刻意**不取 self._lock**：該鎖在每一筆 append 的檔案寫入全程持有，而 append
         # 的頻率等同 UART RX。health() 由 health.status / log.tail_* / wal.range 呼叫，
         # 這些都在 daemon 單執行緒 asyncio dispatcher 內同步執行——在此等 WAL 寫鎖等於

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -7,6 +7,8 @@
 - #154：`serialwrapd_on_path` 後新增 `other_serialwrap_installs`（同機多份安裝
   版本一致性診斷），Linux／Windows 兩份清單皆刻意更新（非誤傷）。
 - #148：新增 `wal_dir` 檢查，兩份清單同步更新。
+- #189：新增 `wal_writable` 檢查（非 advisory；`wal_dir` 只比對一致性、從不檢查路徑
+  是否存在，實地事故中對著已被 rmtree 的目錄回 ok:true），兩份清單同步更新。
 - #149：Linux 清單於 `dialout` 之後新增 human console 就緒檢查組
   `serialwrap_minicom_on_path`／`jq_on_path`／`minicom_on_path`（皆 advisory）。
 - #162：新增 `profile_bootloader_prompts`（線上 profile 是否漏了出貨資產有的
@@ -41,6 +43,7 @@ LINUX_CHECKS = [
     # #173：本 client 解析到的 endpoint 是否與實際執行中 daemon 一致且可連。
     "endpoint_reachable",
     "wal_dir",
+    "wal_writable",
     "profile_bootloader_prompts",
     "devices",
     "wsl_systemd",
@@ -56,6 +59,7 @@ WINDOWS_CHECKS = [
     "supervision_mode",
     "daemon_endpoint",
     "wal_dir",
+    "wal_writable",
     "profile_bootloader_prompts",
     "devices",
 ]

--- a/tests/test_wal_missing_detection.py
+++ b/tests/test_wal_missing_detection.py
@@ -1,0 +1,269 @@
+"""WAL 檔案不存在時不得靜默回空（#189，自 #171 拆出）。
+
+實地事故：daemon 同一 PID 連續運行六天，`log tail-raw` / `log tail-text` /
+`wal export` 全部回 ``ok:true`` + 空陣列，而 ``current_seq`` 已累加到 1,261,000——
+WAL 目錄被外部工具 rmtree 掉了，服務對此毫無所覺，也不告訴任何人。該 bench 六天的
+console 紀錄因此無法回溯，兩輪事故取證落空。
+
+本檔驗證三件事：讀取路徑會誠實回報檔案不見了（``WAL_MISSING``）、回應帶得出
+``wal_path`` / ``wal_file_exists`` 讓呼叫端分辨「查得到但沒資料」vs「檔案不見了」、
+以及 daemon 會自癒重建被刪掉的 WAL 目錄而非繼續寫進虛空。
+"""
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from sw_core.wal import WalWriter
+
+
+class _WalBase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.wal_dir = str(Path(self._tmp.name) / "wal")
+        self.wal = WalWriter(wal_dir=self.wal_dir)
+
+    def _append(self, payload=b"hello"):
+        return self.wal.append(com="COM0", direction="rx", source="test", payload=payload)
+
+
+class TestWalHealth(_WalBase):
+    def test_fresh_wal_is_healthy_with_no_file_yet(self):
+        """全新 daemon 還沒有任何 UART 流量：檔案尚未建立不是故障。"""
+        health = self.wal.health()
+        self.assertEqual(health["wal_dir"], self.wal_dir)
+        self.assertEqual(health["wal_path"], self.wal.wal_path)
+        self.assertTrue(health["wal_dir_exists"])
+        self.assertFalse(health["wal_file_exists"])
+        self.assertEqual(health["current_seq"], 0)
+        self.assertTrue(health["healthy"])
+
+    def test_health_flags_vanished_wal_after_writes(self):
+        """寫過紀錄之後檔案消失＝真故障，必須看得出來。"""
+        self._append()
+        self.assertTrue(os.path.exists(self.wal.wal_path))
+        shutil.rmtree(self.wal_dir)
+
+        health = self.wal.health()
+        self.assertFalse(health["wal_dir_exists"])
+        self.assertFalse(health["wal_file_exists"])
+        self.assertGreater(health["current_seq"], 0)
+        self.assertFalse(health["healthy"])
+
+    def test_append_recreates_deleted_wal_dir(self):
+        """#189 驗收：daemon 偵測到 WAL 被刪除後重建並告警，而不是安靜地寫進虛空。"""
+        self._append()
+        shutil.rmtree(self.wal_dir)
+
+        with self.assertLogs("serialwrap", level="WARNING") as captured:
+            record = self._append(b"after-rmtree")
+
+        self.assertTrue(os.path.isdir(self.wal_dir))
+        self.assertTrue(os.path.exists(self.wal.wal_path))
+        self.assertFalse(record["loss_flag"], "自癒成功的 append 不該標 loss")
+        self.assertEqual(self.wal.health()["recreated_count"], 1)
+        self.assertTrue(self.wal.health()["healthy"])
+        self.assertTrue(any("WAL" in line for line in captured.output))
+
+    def test_recreated_wal_is_readable_again(self):
+        self._append()
+        shutil.rmtree(self.wal_dir)
+        self._append(b"after-rmtree")
+
+        rows = self.wal.tail_raw()
+        self.assertEqual(len(rows), 1)
+        import base64
+        self.assertEqual(base64.b64decode(rows[0]["payload_b64"]), b"after-rmtree")
+
+    def test_append_records_failure_when_recreate_fails(self):
+        """重建也失敗（ENOSPC/EROFS/權限）時：標 loss、記錄錯誤，但不得讓 RX thread 崩潰。"""
+        self._append()
+        shutil.rmtree(self.wal_dir)
+        with mock.patch("sw_core.wal.os.makedirs", side_effect=OSError("EROFS")):
+            with self.assertLogs("serialwrap", level="WARNING"):
+                record = self._append(b"doomed")
+
+        self.assertTrue(record["loss_flag"])
+        health = self.wal.health()
+        self.assertGreaterEqual(health["write_failures"], 1)
+        self.assertIsNotNone(health["last_write_error"])
+        self.assertFalse(health["healthy"])
+
+    def test_available_from_seq_tracks_current_file(self):
+        for _ in range(3):
+            self._append()
+        self.assertEqual(self.wal.available_from_seq(), 1)
+        self.wal.reset()          # 輪替：現行檔清空、seq 歸零
+        self.assertIsNone(self.wal.available_from_seq())
+        self._append()
+        self.assertEqual(self.wal.available_from_seq(), 1)
+
+
+class _ServiceBase(_WalBase):
+    def _service(self):
+        from sw_core.service import SerialwrapService
+
+        with (
+            mock.patch("sw_core.service.WalWriter"),
+            mock.patch("sw_core.service.DeviceWatcher"),
+        ):
+            svc = SerialwrapService([])
+        svc._wal = self.wal
+        return svc
+
+
+class TestReadPathsReportMissing(_ServiceBase):
+    def test_tail_raw_reports_wal_missing(self):
+        self._append()
+        shutil.rmtree(self.wal_dir)
+        resp = self._service().rpc("log.tail_raw", {})
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error_code"], "WAL_MISSING")
+        self.assertEqual(resp["wal_path"], self.wal.wal_path)
+        self.assertFalse(resp["wal_file_exists"])
+        self.assertGreater(resp["current_seq"], 0)
+
+    def test_tail_text_reports_wal_missing(self):
+        self._append()
+        shutil.rmtree(self.wal_dir)
+        resp = self._service().rpc("log.tail_text", {})
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error_code"], "WAL_MISSING")
+
+    def test_wal_range_reports_wal_missing(self):
+        """`serialwrap wal export` 走的就是這條——事故當下它回 ok:true + [] + rc=0。"""
+        self._append()
+        shutil.rmtree(self.wal_dir)
+        resp = self._service().rpc("wal.range", {"from_seq": 0, "limit": 100})
+        self.assertFalse(resp["ok"])
+        self.assertEqual(resp["error_code"], "WAL_MISSING")
+        self.assertEqual(resp["wal_path"], self.wal.wal_path)
+
+    def test_fresh_daemon_without_traffic_is_not_an_error(self):
+        """seq 為 0＝從來沒寫過，檔案不存在是正常的，不得誤報 WAL_MISSING。"""
+        svc = self._service()
+        for method, key in (("log.tail_raw", "records"), ("log.tail_text", "lines")):
+            resp = svc.rpc(method, {})
+            self.assertTrue(resp["ok"], method)
+            self.assertEqual(resp[key], [], method)
+            self.assertFalse(resp["wal_file_exists"], method)
+        resp = svc.rpc("wal.range", {"from_seq": 0, "limit": 100})
+        self.assertTrue(resp["ok"])
+        self.assertEqual(resp["records"], [])
+
+    def test_normal_read_carries_wal_path_and_existence(self):
+        """「查得到但沒資料」與「檔案不見了」必須能分辨——正常路徑也要帶這兩個欄位。"""
+        self._append()
+        resp = self._service().rpc("log.tail_raw", {})
+        self.assertTrue(resp["ok"])
+        self.assertEqual(resp["returned"], 1)
+        self.assertEqual(resp["wal_path"], self.wal.wal_path)
+        self.assertTrue(resp["wal_file_exists"])
+
+    def test_wal_range_marks_rotated_out_range(self):
+        """請求區間落在已輪替掉的範圍：明確標示，不要用空陣列 + ok 帶過。"""
+        for _ in range(3):
+            self._append()
+        self.wal.reset()
+        for _ in range(2):
+            self._append()
+        svc = self._service()
+
+        resp = svc.rpc("wal.range", {"from_seq": 0, "limit": 100})
+        self.assertTrue(resp["ok"])
+        self.assertEqual(resp["available_from_seq"], 1)
+        self.assertFalse(resp["rotated_out"])
+
+    def test_wal_range_rotated_out_when_request_precedes_current_file(self):
+        for _ in range(3):
+            self._append()
+        svc = self._service()
+        # 人為把現行檔的最小 seq 推高：模擬輪替後只剩較新的紀錄
+        rows = [json.loads(line) for line in
+                open(self.wal.wal_path, encoding="utf-8").read().splitlines() if line.strip()]
+        with open(self.wal.wal_path, "w", encoding="utf-8") as fh:
+            for row in rows[-1:]:
+                fh.write(json.dumps(row) + "\n")
+
+        resp = svc.rpc("wal.range", {"from_seq": 0, "limit": 100})
+        self.assertTrue(resp["ok"])
+        self.assertEqual(resp["available_from_seq"], 3)
+        self.assertTrue(resp["rotated_out"])
+
+
+class TestHealthStatusExposesWal(_ServiceBase):
+    def test_health_status_carries_wal_health(self):
+        self._append()
+        shutil.rmtree(self.wal_dir)
+        resp = self._service().rpc("health.status", {})
+        self.assertIn("wal", resp)
+        self.assertFalse(resp["wal"]["healthy"])
+        self.assertFalse(resp["wal"]["wal_dir_exists"])
+
+
+class TestDoctorWalWritable(unittest.TestCase):
+    """doctor 的 wal_dir 檢查在事故當下回的是 ok:true——它只印路徑、從不檢查存在性。
+    新增非 advisory 的 wal_writable 檢查把這一項補上。"""
+
+    def _run_check(self, health_resp):
+        from sw_core import doctor_cmd
+
+        with mock.patch("sw_core.client.rpc_call", return_value=health_resp):
+            return doctor_cmd._check_wal_writable()
+
+    def test_fails_when_daemon_reports_unhealthy_wal(self):
+        result = self._run_check({
+            "ok": True,
+            "wal_path": "/tmp/serialwrap/wal/raw.wal.ndjson",
+            "wal": {
+                "wal_dir": "/tmp/serialwrap/wal", "wal_dir_exists": False,
+                "wal_file_exists": False, "wal_dir_writable": False,
+                "current_seq": 1261000, "write_failures": 3,
+                "last_write_error": "ENOENT", "recreated_count": 0, "healthy": False,
+            },
+        })
+        self.assertEqual(result["check"], "wal_writable")
+        self.assertFalse(result["ok"])
+        self.assertIn("/tmp/serialwrap/wal", result["detail"])
+        self.assertTrue(result["fix"])
+
+    def test_passes_when_wal_healthy(self):
+        result = self._run_check({
+            "ok": True,
+            "wal_path": "/tmp/serialwrap/wal/raw.wal.ndjson",
+            "wal": {
+                "wal_dir": "/tmp/serialwrap/wal", "wal_dir_exists": True,
+                "wal_file_exists": True, "wal_dir_writable": True,
+                "current_seq": 42, "write_failures": 0,
+                "last_write_error": None, "recreated_count": 0, "healthy": True,
+            },
+        })
+        self.assertTrue(result["ok"])
+
+    def test_informational_when_daemon_unreachable(self):
+        """doctor 常在啟動 daemon 前執行——連不到不是這項要抓的錯。"""
+        result = self._run_check({"ok": False, "error_code": "SOCKET_ERROR"})
+        self.assertTrue(result["ok"])
+
+    def test_wal_writable_is_not_advisory(self):
+        """稽核紀錄整個消失必須拉低 doctor 整體 ok，不能只是 WARN。"""
+        from sw_core.doctor_cmd import DOCTOR_ADVISORY_CHECKS, DOCTOR_ADVISORY_CHECKS_WIN
+
+        self.assertNotIn("wal_writable", DOCTOR_ADVISORY_CHECKS)
+        self.assertNotIn("wal_writable", DOCTOR_ADVISORY_CHECKS_WIN)
+
+    def test_run_doctor_includes_wal_writable(self):
+        from sw_core.doctor_cmd import run_doctor
+
+        with mock.patch("sw_core.client.rpc_call", return_value={"ok": False}):
+            names = {row["check"] for row in run_doctor()}
+        self.assertIn("wal_writable", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wal_missing_detection.py
+++ b/tests/test_wal_missing_detection.py
@@ -94,6 +94,17 @@ class TestWalHealth(_WalBase):
         self.assertIsNotNone(health["last_write_error"])
         self.assertFalse(health["healthy"])
 
+    @unittest.skipIf(os.geteuid() == 0, "root 繞過權限檢查，此案在 root 下無意義")
+    def test_non_traversable_dir_is_not_writable(self):
+        """目錄只有 W_OK 沒有 X_OK 時進不去、建不了檔，不得判為可寫。"""
+        self._append()
+        os.chmod(self.wal_dir, 0o600)          # rw- but no traverse
+        self.addCleanup(os.chmod, self.wal_dir, 0o700)
+
+        health = self.wal.health()
+        self.assertFalse(health["wal_dir_writable"])
+        self.assertFalse(health["healthy"])
+
     def test_available_from_seq_tracks_current_file(self):
         for _ in range(3):
             self._append()
@@ -155,6 +166,19 @@ class TestReadPathsReportMissing(_ServiceBase):
         resp = svc.rpc("wal.range", {"from_seq": 0, "limit": 100})
         self.assertTrue(resp["ok"])
         self.assertEqual(resp["records"], [])
+
+    def test_current_seq_comes_from_the_same_snapshot(self):
+        """回應內的 current_seq 必須與同一份 wal_health 快照一致（且不再取 WAL 寫鎖）。"""
+        for _ in range(3):
+            self._append()
+        with mock.patch.object(
+            type(self.wal), "current_seq",
+            new=property(lambda _self: (_ for _ in ()).throw(
+                AssertionError("不得經 current_seq property 取 WAL 寫鎖"))),
+        ):
+            resp = self._service().rpc("log.tail_raw", {})
+        self.assertTrue(resp["ok"])
+        self.assertEqual(resp["current_seq"], 3)
 
     def test_normal_read_carries_wal_path_and_existence(self):
         """「查得到但沒資料」與「檔案不見了」必須能分辨——正常路徑也要帶這兩個欄位。"""


### PR DESCRIPTION
## Summary

WAL 檔案不存在時不再靜默回 `ok:true` ＋ 空陣列；daemon 會自癒重建被刪掉的 WAL 目錄；`doctor` 新增會**實際檢查**的 `wal_writable`。

### 事故

daemon 同一 PID 連續運行六天，三條讀取路徑全部回 `ok:true` ＋ 空陣列 ＋ rc=0，而 `current_seq` 已累加到 1,261,000：

```
$ serialwrap log tail-raw --selector COM1 --limit 400
{"current_seq":1261000,...,"records":[],"returned":0,"truncated":false,"ok":true}
$ serialwrap doctor      # wal_dir
"daemon 實際生效 WAL_DIR=/tmp/serialwrap/wal"   ← ok:true，而該目錄根本不存在
```

WAL 目錄被外部工具 rmtree 掉了（testpilot 的 `clean_wal()`，已於 hamanpaul/testpilot-core#36 追蹤），而**服務對此毫無所覺，也不告訴任何人**。該 bench 六天的 console 紀錄因此無法回溯，兩輪事故取證落空，唯一倖存的證據來源是外部 minicom 的 capture log。

### 機制修正（issue 原文的推測不準）

issue 推測是「daemon 對著已 unlink 的 fd 續寫」。實際不是——`append()` 每筆都重新 `open(path, "a")`；被刪掉的是**整個目錄**，於是每次 append 都以 `FileNotFoundError` 失敗、被既有的 `except OSError` best-effort 分支吞掉（#79 STA-1 的「稽核寫入失敗不得讓 RX thread 崩潰」），而 `_seq` 照常累加。告警其實有發，只是走 `logging` 而沒有任何 log 落地——正是 #171 的論點。

這個更正讓修法比 issue 建議的更簡單：因為每筆 append 都重開檔，**目錄被刪之後下一筆寫入就會偵測到**，不需要另開週期性自檢執行緒。

### 修法

- **自癒**：`append()` 撞到 `OSError` 時先 `os.makedirs(wal_dir, exist_ok=True)` 並重試一次；成功即續寫並告警（記 `recreated_count`），重試仍失敗才維持既有 best-effort 標 loss 行為（記 `write_failures` / `last_write_error`）。
- **`WalWriter.health()`**：攤開 `wal_dir` / `wal_path` / `wal_dir_exists` / `wal_file_exists` / `wal_dir_writable` / `current_seq` / `write_failures` / `last_write_error` / `recreated_count` / `healthy`。
- **讀取路徑誠實化**：`log.tail_raw` / `log.tail_text` / `wal.range`（＝`serialwrap wal export`）在「`current_seq > 0` 但現行檔不存在」時回 `ok:false` ＋ `error_code: "WAL_MISSING"` ＋ 實際 `wal_path` ＋ 可行動 hint。**`current_seq == 0` 不誤報**——全新 daemon 尚無 UART 流量時檔案本來就還沒建立，那是正常狀態而非故障。成功路徑也一律帶 `wal_path` / `wal_file_exists`，讓呼叫端分辨「查得到但沒有符合的紀錄」與「稽核檔案不見了」。
- **輪替可分辨**：`wal.range` 另回 `available_from_seq`（現行檔最小 seq）與 `rotated_out`。
- **`doctor` 新增 `wal_writable`**（消費 `health.status` 新增的 `wal` 欄位）：實際驗證目錄存在且可寫，**非 advisory**——稽核紀錄整個消失必須拉低 doctor 整體 ok。既有 `wal_dir`（shell/daemon 一致性）維持 advisory WARN，兩者各司其職。`tests/test_doctor.py` 的兩份 pinned 清單同步更新。

### 兩個在實作中抓到、與 daemon 熱路徑有關的自我修正

1. `health()` 原本取 `WalWriter._lock`——該鎖在每筆 append 的檔案寫入全程持有，而 append 頻率等同 UART RX。`health()` 由 `health.status` / `log.tail_*` / `wal.range` 呼叫，這些都在 daemon **單執行緒 asyncio dispatcher** 內同步執行，等 WAL 寫鎖等於讓診斷查詢被資料平面拖住、凍結整個 RPC loop。改為不取鎖（讀四個 int/str 的診斷快照，GIL 下各自原子）。
2. 第一版把 `logging.getLogger("serialwrap")` 放進 `append()`——CPython 的 `logging.Manager.getLogger` **每次呼叫都會取全域 logging 鎖**，等於在 daemon 最熱的路徑上多一次全域鎖。這在全套測試中以 `test_human_agent_coexist.py::test_t6_human_sees_agent_commands`（20s 內未達 READY）現形；改為模組層 `_LOG` 後全套恢復全綠。

### 契約變更（刻意）

WAL 檔案缺失時三條讀取路徑由 `ok:true` 改為 `ok:false` ＋ `WAL_MISSING`。這是本 issue 的核心訴求——先前的靜默成功正是讓事故延續六天的原因。只讀 `records` / `lines` 的呼叫端行為不變（仍是空的）；檢查 `ok` 的呼叫端會開始看到失敗，那正是期望的行為。

### 未納入本 PR

issue 期望第 3 點提到「daemon 應該**週期性**自檢 WAL 可寫性」。刻意不加獨立的週期執行緒：`append()` 每筆都重開檔，目錄消失在下一筆寫入即被偵測並自癒；完全沒有 UART 流量、因而不會 append 的情形，`health.status` / `doctor` 的 `wal_writable` 都是即時查檔案系統，一問就知道。多一條週期執行緒只會增加 daemon 的活動部件而不增加偵測能力。

## Test Plan

- [x] 執行 `python3 -m pytest -q tests/` — **1657 passed, 16 skipped, 44 subtests passed**（0 failed）
- [x] 執行 `python3 -m policy_check --repo .` — 通過

## Policy Checklist (R-11)

- [x] 分支不是 `main`（不可直接 commit 到 main）
- [x] 變更已記錄：新增 `changelog.d/189-wal-missing-detection.md` fragment
- [x] `VERSION` 已更新（若有版本號變動）— 無版本號變動，不適用
- [x] `python3 -m pytest -q tests/` 通過（無新失敗）
- [x] `python3 -m policy_check --repo .` 通過
- [x] 四份 agent 檔案已同步（若有修改 `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` / `.github/copilot-instructions.md`）— 本 PR 未修改，不適用
- [x] 已標記適用 label（無需豁免 label）
- [x] 回歸 case 評估已記錄（見下）

**回歸 case 評估（#155 政策）**：新增 `tests/test_wal_missing_detection.py`（19 個 pytest，修復前 18 個可重現地 FAIL）——涵蓋 health 欄位、rmtree 後自癒重建並告警、重建後可再讀、重建失敗時標 loss 且不崩、`available_from_seq`、三條讀取路徑回 `WAL_MISSING`、全新 daemon 不誤報、成功路徑帶 `wal_path`/`wal_file_exists`、`rotated_out` 判定、`health.status` 暴露 wal 健康，以及 doctor `wal_writable` 的四種情形與非 advisory 性質。事故情境可用 tmpdir ＋ `shutil.rmtree` 精確模擬，**不需**新增 `regression/`（TestPilot 實機）case——本修復不依賴真板 boot 時序、USB 列舉順序或外部工具搶 tty。

## Issue Reference

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMLyQNsN4hTHBzngEm7WYL
