### PR TITLE
test(remote): 新增 agent-pull 拓樸實機驗證，補 BatchMode 與 --remote-socket 配對敘述缺漏 (#193)

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,7 +677,29 @@ serialwrap --endpoint tcp://127.0.0.1:7777 session list
 `--autossh` keeps the ssh transport alive across drops; the overlay's own
 reconnect is the provider's business, not serialwrap's.
 
-#### Topology 2 (fallback): double NAT with no reachability provider — public relay
+#### Topology 2: the UART host is reachable — the agent pulls with `-L` (no `-R`, no relay)
+
+The mirror image of topology 1, and usually the right shape for "a developer wants
+to reach a bench that sits behind NAT": whatever provides reachability lets the
+**agent** ssh **into** the UART host, so the agent pulls the daemon socket back to
+its own loopback. The UART host runs no `serialwrap remote` at all.
+
+```bash
+# agent host (the developer's machine) — nothing runs on the UART host
+serialwrap remote -L --remote-socket /run/serialwrap/serialwrapd.sock tester@dut:7777
+serialwrap --endpoint tcp://127.0.0.1:7777 session list
+```
+
+Take the `--remote-socket` path from `serialwrap daemon status` on the UART host
+(`<run-dir>/serialwrapd.sock`); it is that daemon's own socket, so the ssh user must
+be in the group that owns it (0660) or the forward comes up while `health.ping`
+never succeeds and readiness stays `starting`. Combined with an SSH-over-overlay
+provider this gives an outbound-only path on both ends — the shape remote-desktop
+tools use — without operating a relay of your own. Verified end to end by the
+`agent_pull` docker topology (`tools/docker/remote_tunnel_test.sh`, realhw case
+`rm-topo-agent-pull`).
+
+#### Topology 3 (fallback): double NAT with no reachability provider — public relay
 
 When neither side can reach the other at all, both dial out to a relay both can
 reach: the UART host pushes with `-R`, the agent pulls with `-L` (below).
@@ -744,7 +766,10 @@ the relay is a **multi-tenant shared host**, other local users could in
 principle still reach that loopback port. Adding `--remote-socket
 /path/to.sock` instead creates a **unix socket** on the peer, gated by file
 permissions (extending the local daemon socket's 0660 semantics to the
-relay). Both `-R` and `-L` must point at the same path:
+relay). In the **relay** shapes, `-R` and `-L` are two ends of one hop and must
+point at the same path — this pairing requirement does **not** apply to topology 2
+above, where `-L` alone targets the UART host's own daemon socket and there is no
+`-R` to pair with:
 
 ```bash
 # UART host (-R)
@@ -770,6 +795,15 @@ serialwrap remote -L --remote-socket /tmp/sw-relay.sock tester@RELAY:7777
 
 #### Limitations and caveats
 
+- **`BatchMode=yes` is forced and cannot be overridden.** The readiness/safety
+  defaults are emitted *before* your `--ssh-opt` values and OpenSSH honours the
+  first occurrence of a given key, so `BatchMode`, `ExitOnForwardFailure` and the
+  `ControlPath` settings are authoritative by design. Consequence: **no
+  interactive authentication of any kind**. Authentication must already be
+  non-interactive when the tunnel is opened — with a reachability provider whose
+  credentials expire (Cloudflare Access tokens, for instance), an expired token
+  makes ssh fail immediately with no useful diagnostic, so unattended use needs a
+  service token or a refresh performed beforehand.
 - `daemon start` does **not support** `--endpoint` (the daemon can only be
   started locally; it returns `REMOTE_NOT_SUPPORTED`).
 - **`file.push` / `file.pull`'s `local_path` is a path on the daemon side
@@ -2176,7 +2210,21 @@ serialwrap --endpoint tcp://127.0.0.1:7777 session list
 
 `--autossh` 負責 ssh transport 的連線續命；overlay 自身的 reconnect 由 provider 處理，不是 serialwrap 的事。
 
-### 拓樸二（fallback）：無可達性 provider 的雙 NAT——public relay
+### 拓樸二：UART host 可達——agent 用 `-L` 直接拉（無 `-R`、無 relay）
+
+拓樸一的鏡像，也是「開發機想連一台在 NAT 後的 bench」通常該用的形狀：由 reachability provider 讓 **agent 主動 ssh 進 UART host**，agent 把對方的 daemon socket 拉回自己的 loopback。**UART host 端完全不需要跑 `serialwrap remote`。**
+
+```bash
+# agent 端（開發機）——UART host 端什麼都不用做
+serialwrap remote -L --remote-socket /run/serialwrap/serialwrapd.sock tester@dut:7777
+serialwrap --endpoint tcp://127.0.0.1:7777 session list
+```
+
+`--remote-socket` 的路徑取自 UART host 上 `serialwrap daemon status` 回報的值（`<run-dir>/serialwrapd.sock`）。那是該 daemon 自己的 socket，因此 ssh 登入的帳號必須在擁有它的群組內（0660）——否則 forward 建得起來但 `health.ping` 不通，readiness 會停在 `starting`。
+
+搭配把 SSH 架在 overlay 上的 provider，這個形狀讓**兩端都只有出站連線**（遠端桌面工具用的就是這個模型），而且不必自己營運 relay。已由 `agent_pull` docker 拓樸端到端驗證（`tools/docker/remote_tunnel_test.sh`，realhw case `rm-topo-agent-pull`）。
+
+### 拓樸三（fallback）：無可達性 provider 的雙 NAT——public relay
 
 兩端完全互不可達時，才各自對一台雙方都連得到的 relay 撥出：UART host 用 `-R` 推上去，agent 用 `-L` 拉回來（見下）。
 
@@ -2231,7 +2279,7 @@ serialwrap remote close all         # 拆除全部
 
 ### `--remote-socket` 硬化（共享 relay 建議必開）
 
-預設 `-R` 在對端開 `127.0.0.1:<port>` 的 TCP loopback bind；relay 若為**多租戶共享主機**，同機其他使用者理論上仍可能連到該 loopback port。加 `--remote-socket /path/to.sock` 後改在對端建 **unix socket**，以檔案權限把關（等同把本機 daemon socket 的 0660 語意延伸到 relay）；`-R`／`-L` 兩端須成對指定同一路徑：
+預設 `-R` 在對端開 `127.0.0.1:<port>` 的 TCP loopback bind；relay 若為**多租戶共享主機**，同機其他使用者理論上仍可能連到該 loopback port。加 `--remote-socket /path/to.sock` 後改在對端建 **unix socket**，以檔案權限把關（等同把本機 daemon socket 的 0660 語意延伸到 relay）。在 **relay 類**形狀中，`-R` 與 `-L` 是同一跳的兩端，須成對指定同一路徑；此配對要求**不適用於上面的拓樸二**——該形狀只有 `-L`，指向的是 UART host 自己的 daemon socket，沒有 `-R` 可配對：
 
 ```bash
 # UART host（-R）
@@ -2247,6 +2295,7 @@ serialwrap remote -L --remote-socket /tmp/sw-relay.sock tester@RELAY:7777
 
 ### 限制與注意事項
 
+- **`BatchMode=yes` 為強制、無法覆寫。** readiness／安全預設 `-o` 置於使用者 `--ssh-opt` **之前**，而 OpenSSH 對同一個 key 取第一個出現的值，因此 `BatchMode`、`ExitOnForwardFailure` 與 `ControlPath` 這組設定是刻意設計成權威、使用者蓋不掉的。後果是**不接受任何互動式認證**：開隧道當下認證就必須已經是非互動的。若 reachability provider 的憑證會過期（例如 Cloudflare Access 的 token），過期時 ssh 會直接失敗且**不會給出有用的診斷訊息**——無人值守情境需改用 service token，或事先完成 refresh。
 - `daemon start` **不支援** `--endpoint`（daemon 只能在本機啟動，會回 `REMOTE_NOT_SUPPORTED`）。
 - **`file.push` / `file.pull` 的 `local_path` 是 daemon 端（UART host）的路徑**，不是 agent 本機路徑；agent 若要傳輸本機檔案，需先透過 scp/rsync 傳到 UART host，再由 daemon 執行 file transfer。WAL、mirror log 等路徑回傳值同理。
 - **native Windows 本期不支援** `serialwrap remote`：執行會回 `REMOTE_NOT_SUPPORTED`（見下方手動等價）。

--- a/changelog.d/188-185-docs-file-push-boundary-and-remote-topology.md
+++ b/changelog.d/188-185-docs-file-push-boundary-and-remote-topology.md
@@ -1,5 +1,5 @@
 ---
-type: docs
+type: change
 issue: 188
 scope: docs
 ---

--- a/changelog.d/193-remote-agent-pull-topology.md
+++ b/changelog.d/193-remote-agent-pull-topology.md
@@ -1,0 +1,42 @@
+---
+type: change
+issue: 193
+scope: remote
+---
+補上 `serialwrap remote` 的 **agent-pull** 形狀：測試覆蓋、文件範例，以及兩處會誤導的敘述。
+不改 `sw_core/` 任何實作——現行程式碼本來就支援，缺的是驗證與文件。
+
+- **agent-pull 形狀**（`serialwrap remote -L --remote-socket <UART host 的 socket> user@dut:7777`）：
+  agent 主動 ssh 進 UART host、把對方的 `serialwrapd.sock` 拉回自己的 loopback，
+  **UART host 端不需跑 `-R`、不需任何 relay**。這是「開發機要連一台在 NAT 後的 bench」
+  最自然的形狀，搭配把 SSH 架在 overlay 上的 provider 即得到兩端皆只有出站連線的路徑
+  （遠端桌面工具用的模型），且不必自己營運 relay。
+  `sw_core/remote_tunnel.py` 早已支援——`_direction_args()` 的 connect 分支對「對端是誰」
+  無任何假設，全檔亦無強制 `-L` 必須配 `-R` 的檢核——但三個既有 docker 拓樸
+  （`direct`／`nat_host`／`dual_nat`）**全是 UART host 用 `-R` 推出去**，方向相反的
+  agent-pull 從未被測過，README／SKILL 也沒有任何範例。
+- **新增第 4 個 docker 拓樸 `agent_pull`**（`tools/docker/remote_tunnel_test.sh`）：
+  方向反轉，sshd 改跑在 uart 容器、agent 容器主動連入。斷言粒度比照 `topology_direct()`
+  ——①預設不啟用 ②session list＋cmd submit/status ③daemon pid 全程不變
+  ④close all 後乾淨復歸 ⑤loopback 不變量＋獨立 attacker 容器連不到。
+  `realhw/cases/remote.py` 註冊 `rm-topo-agent-pull`（`remote` tier ×7 → ×8）。
+  - 兩個新 helper：`uart_sshd_up()` 強制以 `-u root` 在 uart 容器起 sshd
+    （`start_uart` 用 `docker run -u tester`，`docker exec` 不帶 `-u` 會繼承該非 root
+    使用者、讀不到 0600 的 host key 而 `no hostkeys available -- exiting`；既有
+    `sshd_up()` 只用在 `start_plain`/`start_role` 建的 root 容器上，未踩過此坑）；
+    `uart_socket_path()` 讀 uart 容器的 `sw-uart.env` 推算 `RUN_DIR/serialwrapd.sock`
+    （`DaemonHarness` 用 tempdir，路徑每次啟動都不同，不能寫死）。
+- **`BatchMode=yes` 為強制且不可覆寫**（README 中英雙語＋SKILL.md）：readiness／安全預設
+  `-o` 置於使用者 `--ssh-opt` 之前，OpenSSH 取同鍵第一個值，故蓋不掉（刻意如此）。
+  後果是不接受任何互動式認證；provider 憑證會過期時（如 Cloudflare Access token），
+  過期會讓 ssh 直接失敗且無有用診斷，無人值守需用 service token 或事先 refresh。
+  此限制先前完全沒有記載。
+- **修正 `--remote-socket` 的配對敘述**：原文「`-R`／`-L` 兩端須成對指定同一路徑」的脈絡
+  是共享 relay 的硬化情境，但照字面讀會讓人以為 agent-pull 不合法。改為明確界定該配對
+  要求只適用 relay 類形狀。
+- 順帶修掉 `role_exec` 一段「connect 端（-L，僅拓樸 3 用）」的過期註解（拓樸 4 也用它）。
+
+**regression-case 評估**：本變更的驗證面**就是** `regression/`／realhw 這一側——新增的
+`rm-topo-agent-pull` 即為回歸 case，涵蓋 pytest 無法覆蓋的部分（真 sshd、真 ssh forward、
+真 unix socket 轉發、跨容器隔離）。不需另加 pytest：`sw_core/` 零改動，無新的 in-process
+行為可測；既有 `tests/test_remote_tunnel.py`／`test_remote_cli.py` 已覆蓋 argv 組裝與 CLI 解析。

--- a/realhw/cases/__init__.py
+++ b/realhw/cases/__init__.py
@@ -1,6 +1,6 @@
 """realhw case 模組——import 各子模組觸發 register()。
 
-P0×8＋P1×20＋remote×7＋longrun×1。
+P0×8＋P1×20＋remote×8＋longrun×1。
 """
 from __future__ import annotations
 

--- a/realhw/cases/remote.py
+++ b/realhw/cases/remote.py
@@ -92,6 +92,12 @@ def rm_topo_dual_nat(ctx):
     return _run_topology(ctx, "dual_nat")
 
 
+@_case("rm-topo-agent-pull", "方向反轉：agent 端 -L 拉 uart 的 serialwrapd.sock（無 -R、無 relay）",
+       hints=_TOPO_HINTS, requires=("docker",))
+def rm_topo_agent_pull(ctx):
+    return _run_topology(ctx, "agent_pull")
+
+
 @_case("rm-topo-gwports", "GatewayPorts/--remote-socket fail-closed＋teardown 複查",
        hints=_TOPO_HINTS, requires=("docker",))
 def rm_topo_gwports(ctx):

--- a/sw_core/assets/skill/SKILL.md
+++ b/sw_core/assets/skill/SKILL.md
@@ -111,14 +111,23 @@ Agent 要從遠端操作本機 UART 時：**在 UART host（daemon 所在機）*
 serialwrap remote tester@AGENT_OR_RELAY:7777
 ```
 
-Agent 端連線（依拓樸擇一）：
+Agent 端連線（依「誰連得到誰」擇一）：
 
-- **direct（preferred）**（agent host 就是上面 ssh 的對端）：直接
+- **direct**（agent host 就是上面 ssh 的對端）：直接
   `serialwrap --endpoint tcp://127.0.0.1:7777 session list`。
   兩端已有 overlay／private network 互相可達時，**即使都在 NAT 後也走這條**——`-R` 直接落在 agent 的 loopback，不需要 relay、不需要成對的 `-L`。
+- **agent-pull**（反過來：**agent 連得到 UART host**，例如開發機要連一台在 NAT 後的 bench）：
+  **UART host 端什麼都不用跑**，由 agent 主動把對方的 daemon socket 拉回自己的 loopback：
+  ```bash
+  serialwrap remote -L --remote-socket <UART host 的 serialwrapd.sock> tester@dut:7777
+  serialwrap --endpoint tcp://127.0.0.1:7777 session list
+  ```
+  socket 路徑取自 UART host 上 `serialwrap daemon status` 的值；ssh 帳號要在擁有該 socket 的群組內（0660），否則 forward 建得起來但 `health.ping` 不通、readiness 停在 `starting`。此形狀**只有 `-L`、沒有 `-R`**，不適用「兩端須成對指定同一 `--remote-socket` 路徑」那條（那是 relay 硬化情境的規則）。
 - **relay / 雙 NAT（fallback）**（兩端**完全**互不可達，各自對 relay 撥出）：agent 端先
   `serialwrap remote -L tester@RELAY:7777`（回傳 `endpoint`），再用該 endpoint。
   這是「無 overlay、無路由」時的退路，不是跨雙 NAT 的唯一解法。
+
+**`BatchMode=yes` 為強制、`--ssh-opt` 蓋不掉**：不接受任何互動式認證，開隧道當下認證就必須已是非互動的。provider 憑證會過期時（如 Cloudflare Access token），過期會讓 ssh 直接失敗且無有用診斷——無人值守需用 service token 或事先 refresh。
 
 管理：`serialwrap remote`（列隧道）、`serialwrap remote close 7777|all`（拆除）。
 回傳 `status`：`active`＝就緒可用；`starting`＝尚未確認（慢速認證／上游未就緒），需再 `remote status` 或重試。

--- a/tools/docker/remote_tunnel_test.sh
+++ b/tools/docker/remote_tunnel_test.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
-# serialwrap remote 隧道 docker 三拓樸驗收（設計 spec §11.2）。
+# serialwrap remote 隧道 docker 四拓樸驗收（設計 spec §11.2；agent_pull 為後補，#見 CLAUDE.md 任務）。
 #
-# 以真 sshd + 真 `serialwrap remote`（外包系統 ssh）跑三種拓樸，全過才算通過：
-#   拓樸 1 direct        uart + agent 同網段
-#   拓樸 2 NAT→host      uart（NAT）+ relay 同網段，agent CLI colocate 在 relay
-#   拓樸 3 NAT←client    net_a=uart+relay、net_b=agent+relay，雙 NAT，僅能經 relay
+# 以真 sshd + 真 `serialwrap remote`（外包系統 ssh）跑四種拓樸，全過才算通過：
+#   拓樸 1 direct        uart + agent 同網段（uart 端 -R expose）
+#   拓樸 2 NAT→host      uart（NAT）+ relay 同網段，agent CLI colocate 在 relay（uart 端 -R expose）
+#   拓樸 3 NAT←client    net_a=uart+relay、net_b=agent+relay，雙 NAT，僅能經 relay（uart -R + agent -L）
+#   拓樸 4 agent_pull    uart + agent 同網段，方向反轉：agent 端主動 -L 拉 uart 的 serialwrapd.sock，
+#                        uart 端不需 -R、不需第三方 relay（sshd 改跑在 uart 容器上）
 # 另跑一組額外驗收（GatewayPorts yes fail-closed）覆蓋斷言⑦。
 #
-# 每個拓樸驗證（缺一不可，對照 spec §11.2 / task-12-brief）：
+# 每個拓樸驗證（缺一不可，對照 spec §11.2 / task-12-brief；拓樸4 沿用同一組①-⑤，無 NAT/relay 故不適用⑥⑦⑧）：
 #   ① 預設不啟用：remote status 空、無 state 檔、無 ssh/autossh 行程、--endpoint 連線失敗（SOCKET_ERROR）
 #   ② 手動啟動後：agent 端 session list 有 READY、cmd submit→cmd status 得 done 且輸出正確
 #   ③ serialwrapd 不重啟：daemon pid 全程不變
@@ -187,7 +189,27 @@ uart_state_files() {
   docker exec -u tester "${UART_ENV_ARGS[@]}" "$1" bash -c 'ls "$SERIALWRAP_RUN_DIR"/remote/*.json 2>/dev/null'
 }
 
-# ── connect 端（-L，僅拓樸 3 用）：固定 RUN_DIR，無 daemon，不需動態 env 檔 ──
+# ── 拓樸4／agent_pull 專用：uart 容器上跑 sshd + 推算其 serialwrapd.sock 路徑 ──
+uart_sshd_up() {  # uart_sshd_up <container>
+  # start_uart 以 `docker run -u tester` 起主行程；docker exec 不帶 -u 會繼承該
+  # 預設使用者（非 root），讀不到 0600 的 host key（"no hostkeys available -- exiting"）。
+  # 其他拓樸的 sshd_up() 用在 start_plain/start_role（無 -u，預設 root）建的容器上
+  # 不受影響，此處對 uart 容器強制 -u root。
+  docker exec -u root "$1" bash -c "mkdir -p /run/sshd && /usr/sbin/sshd -f /etc/ssh/sshd_config" \
+    || fail "$1：sshd 啟動失敗（拓樸4 agent_pull 需要 uart 端跑 sshd）"
+}
+uart_socket_path() {  # uart_socket_path <container> — daemon harness 的 socket_path = RUN_DIR/serialwrapd.sock
+                      # （func-test/lib/daemon_harness.py 的 self._socket_path = self._root/"run"/"serialwrapd.sock"），
+                      # 供拓樸4 --remote-socket 用；RUN_DIR 為 tempfile 動態路徑，須讀 sw-uart.env 取得。
+  local c=$1 content run_dir
+  content=$(docker exec -u tester "$c" cat /home/tester/sw-uart.env 2>/dev/null) \
+    || fail "$c：讀不到 sw-uart.env（harness 未就緒？）"
+  run_dir=$(printf '%s\n' "$content" | sed -n 's/^export SERIALWRAP_RUN_DIR=//p' | head -n1)
+  [[ -n "$run_dir" ]] || fail "$c：sw-uart.env 缺 SERIALWRAP_RUN_DIR：$content"
+  echo "${run_dir}/serialwrapd.sock"
+}
+
+# ── connect 端（-L，拓樸 3 dual_nat 與拓樸 4 agent_pull 用）：固定 RUN_DIR，無 daemon，不需動態 env 檔 ──
 ROLE_RUN_DIR=/home/tester/.sw-run
 role_exec() { local c=$1; shift; docker exec -u tester -e SERIALWRAP_RUN_DIR="${ROLE_RUN_DIR}" "$c" serialwrap "$@"; }
 role_open() { local c=$1; shift; role_exec "$c" remote "$@"; }
@@ -494,6 +516,53 @@ except OSError:
   log "=== 拓樸 3／NAT←client：PASS ==="
 }
 
+# ══════════════════════════ 拓樸 4／agent_pull（方向反轉：agent -L 拉 uart）══════════════════════════
+topology_agent_pull() {
+  log "=== 拓樸 4／agent_pull：uart + agent 同網段，agent 端主動 -L 拉 uart 的 serialwrapd.sock（無 -R、無 relay）==="
+  local net="net_agent_pull_${SUFFIX}"
+  local uart="sw-rt-uartap-${SUFFIX}" agent="sw-rt-agentap-${SUFFIX}" attacker="sw-rt-attackerap-${SUFFIX}"
+  local ep="tcp://127.0.0.1:7777"
+
+  mk_net "$net"
+  start_uart "$uart" "$net"
+  start_plain "$agent" "$net"     # 只需 ssh client（image 內建），不需 sshd
+  start_plain "$attacker" "$net"
+  wait_uart_ready "$uart"
+  uart_sshd_up "$uart"            # 方向反轉：sshd 改跑在 uart 容器上，agent 主動連進來
+
+  # 斷言①：agent 尚未 -L 前，其自身 remote 狀態應為空；uart 從未呼叫 remote，順帶驗證同型別檢查
+  assert_default_off "$uart" "$agent" "$ep" root
+  assert_role_default_off "$agent"
+  local pid_before; pid_before=$(uart_daemon_pid "$uart")
+  local uart_sock; uart_sock=$(uart_socket_path "$uart")
+  log "  uart serialwrapd.sock = ${uart_sock}"
+
+  local open_json; open_json=$(role_open "$agent" -L --remote-socket "$uart_sock" "tester@${uart}:7777")
+  assert_ok_true "$open_json" "拓樸4 agent -L pull connect"
+  assert_field_eq "$open_json" status active "拓樸4 agent -L pull connect"
+
+  assert_session_and_cmd "$agent" root "$ep"
+  assert_pid_unchanged "$uart" "$pid_before" "拓樸4 -L pull 後"
+
+  # 斷言⑤：loopback 不變量（-L 轉發只綁 agent 自身 127.0.0.1）+ 獨立 attacker 容器連不到
+  assert_loopback_bind "$agent" 7777
+  local atk_out; atk_out=$(endpoint_exec "$attacker" root "tcp://${agent}:7777" daemon status)
+  assert_ok_false "$atk_out" "拓樸4 attacker 應無法連 ${agent}:7777"
+  [[ "$(jpath "$atk_out" error_code)" == "SOCKET_ERROR" ]] \
+    || fail "拓樸4 attacker：預期 error_code=SOCKET_ERROR，實得：$atk_out"
+  log "assertion⑤（loopback+attacker 隔離）PASS：拓樸4"
+
+  local closed; closed=$(role_close_all "$agent")
+  assert_ok_true "$closed" "拓樸4 remote close all"
+  sleep 1
+  assert_default_off "$uart" "$agent" "$ep" root
+  assert_role_default_off "$agent"
+  assert_pid_unchanged "$uart" "$pid_before" "拓樸4 close 後（assertion④）"
+
+  teardown_now "$uart" "$agent" "$attacker" -- "$net"
+  log "=== 拓樸 4／agent_pull：PASS ==="
+}
+
 # ══════════════════════════ 額外／斷言⑦：GatewayPorts yes fail-closed ══════════════════════════
 topology_gatewayports_failclosed() {
   log "=== 額外／斷言⑦：GatewayPorts yes relay 的 fail-closed 驗證 ==="
@@ -552,22 +621,24 @@ topology_gatewayports_failclosed() {
 main() {
   local sel="${1:-all}"
   case "$sel" in
-    direct|nat_host|dual_nat|gwports|all) : ;;
-    *) fail "未知拓樸參數：${sel}（可用：direct|nat_host|dual_nat|gwports|all）" ;;
+    direct|nat_host|dual_nat|agent_pull|gwports|all) : ;;
+    *) fail "未知拓樸參數：${sel}（可用：direct|nat_host|dual_nat|agent_pull|gwports|all）" ;;
   esac
 
   log "build image: ${IMAGE_TAG}"
   DOCKER_BUILDKIT=1 docker build --progress=plain -t "${IMAGE_TAG}" "${ROOT_DIR}" || fail "docker build 失敗"
 
   case "$sel" in
-    direct)   topology_direct ;;
-    nat_host) topology_nat_host ;;
-    dual_nat) topology_dual_nat ;;
-    gwports)  topology_gatewayports_failclosed ;;
+    direct)     topology_direct ;;
+    nat_host)   topology_nat_host ;;
+    dual_nat)   topology_dual_nat ;;
+    agent_pull) topology_agent_pull ;;
+    gwports)    topology_gatewayports_failclosed ;;
     all)
       topology_direct
       topology_nat_host
       topology_dual_nat
+      topology_agent_pull
       topology_gatewayports_failclosed
       ;;
   esac

--- a/tools/docker/remote_tunnel_test.sh
+++ b/tools/docker/remote_tunnel_test.sh
@@ -201,11 +201,15 @@ uart_sshd_up() {  # uart_sshd_up <container>
 uart_socket_path() {  # uart_socket_path <container> — daemon harness 的 socket_path = RUN_DIR/serialwrapd.sock
                       # （func-test/lib/daemon_harness.py 的 self._socket_path = self._root/"run"/"serialwrapd.sock"），
                       # 供拓樸4 --remote-socket 用；RUN_DIR 為 tempfile 動態路徑，須讀 sw-uart.env 取得。
-  local c=$1 content run_dir
-  content=$(docker exec -u tester "$c" cat /home/tester/sw-uart.env 2>/dev/null) \
-    || fail "$c：讀不到 sw-uart.env（harness 未就緒？）"
-  run_dir=$(printf '%s\n' "$content" | sed -n 's/^export SERIALWRAP_RUN_DIR=//p' | head -n1)
-  [[ -n "$run_dir" ]] || fail "$c：sw-uart.env 缺 SERIALWRAP_RUN_DIR：$content"
+  local c=$1 run_dir
+  # 在容器內 source 後再取值，而非自行 sed 取右值：uart_harness.py 是以
+  # shlex.quote() 寫出（tools/docker/uart_harness.py:87），sed 會把引號一併帶進路徑，
+  # 使 --remote-socket 指向不存在的 socket。目前 tempfile 路徑不含需引號的字元故
+  # 看不出差異，但那是會靜默壞掉的脆弱寫法（Copilot review）。
+  run_dir=$(docker exec -u tester "$c" bash -c \
+    'set -a; . /home/tester/sw-uart.env; printf "%s" "$SERIALWRAP_RUN_DIR"') \
+    || fail "$c：讀不到／source 不了 sw-uart.env（harness 未就緒？）"
+  [[ -n "$run_dir" ]] || fail "$c：sw-uart.env 缺 SERIALWRAP_RUN_DIR"
   echo "${run_dir}/serialwrapd.sock"
 }
 


### PR DESCRIPTION
## Summary

補上 `serialwrap remote` 的 **agent-pull** 形狀：測試覆蓋、文件範例，以及兩處會誤導的敘述。**`sw_core/` 零改動**——現行程式碼本來就支援，缺的是驗證與文件。

### 起因

#185 把 remote 重整為 reachability provider 模型，把 `UART host -R→ agent` 列為 preferred。實際被追問「要怎麼用 Cloudflare 達成類似 AnyDesk 的遠端開發存取」時，才發現 #185 漏掉了**對這個情境最直接的那個形狀**。

### agent-pull：agent 主動拉，UART host 什麼都不用跑

```bash
# agent 端（開發機）—— UART host 端不需要跑 serialwrap remote
serialwrap remote -L --remote-socket /run/serialwrap/serialwrapd.sock tester@dut:7777
serialwrap --endpoint tcp://127.0.0.1:7777 session list
```

拓樸一的鏡像：由 reachability provider 讓 **agent 連得到 UART host**，agent 把對方的 daemon socket 拉回自己的 loopback。**不需要 `-R`，也不需要任何 relay 第三方主機。** 搭配把 SSH 架在 overlay 上的 provider（Cloudflare Tunnel + Access、WARP private network、VPN、jump host），兩端都只有出站連線——遠端桌面工具用的就是這個模型——而且不必自己營運 relay。

實作面本來就通：`_direction_args()` 的 connect 分支是 `dest = spec.remote_socket if spec.remote_socket else f"localhost:{spec.port}"`，對「對端是誰」無任何假設；全檔也沒有強制 `-L` 必須配 `-R` 的檢核。**但三個既有 docker 拓樸（`direct`／`nat_host`／`dual_nat`）全是 UART host 用 `-R` 推出去**，方向相反的 agent-pull 從未被測過，README／SKILL 也沒有任何範例——等於是「讀 code 推論可行」而非實證。本 PR 把它變成實證。

### 新增 docker 拓樸 4 `agent_pull`

`tools/docker/remote_tunnel_test.sh` 新增 `topology_agent_pull()`：方向反轉，**sshd 改跑在 uart 容器**、agent 容器主動連入。斷言粒度比照 `topology_direct()`：

| | 涵蓋 |
|---|---|
| ① | 預設不啟用（無 state／行程、`--endpoint` 回 `SOCKET_ERROR`） |
| ② | `session list` 有 READY ＋ `cmd submit`→`cmd status` 得正確輸出 |
| ③ | uart serialwrapd pid 全程不變 |
| ④ | `close all` 後乾淨復歸 |
| ⑤ | loopback 不變量（`ss` 驗 127.0.0.1）＋ 獨立 attacker 容器連不到 |

`realhw/cases/remote.py` 註冊 `rm-topo-agent-pull`（`remote` tier ×7 → ×8）。

兩個新 helper，都是實作時真的踩到才需要的：

- `uart_sshd_up()`：強制以 `-u root` 在 uart 容器起 sshd。`start_uart` 用 `docker run -u tester` 起主行程，而 `docker exec` 不帶 `-u` 會**繼承該非 root 使用者**、讀不到 0600 的 host key 而 `no hostkeys available -- exiting`。既有 `sshd_up()` 只用在 `start_plain`／`start_role` 建的 root 容器上，所以從沒踩過這個坑。
- `uart_socket_path()`：讀 uart 容器的 `sw-uart.env` 推算 `RUN_DIR/serialwrapd.sock`。`DaemonHarness` 用 `tempfile.TemporaryDirectory()`，路徑每次啟動都不同，不能寫死。

`role_exec`／`role_open`／`role_close_all`／`assert_role_default_off` 皆沿用既有 helper（拓樸 3 dual_nat 已在用），未另造一套；順帶修掉其「僅拓樸 3 用」的過期註解。

### 文件：兩處缺漏

1. **`BatchMode=yes` 為強制且不可覆寫**（README 中英雙語＋SKILL.md）。readiness／安全預設 `-o` 置於使用者 `--ssh-opt` **之前**，OpenSSH 取同鍵第一個值，故蓋不掉（`default_ssh_opts()` 的 docstring 本來就這樣寫，但對外文件完全沒提）。後果是**不接受任何互動式認證**；provider 憑證會過期時（如 Cloudflare Access token），過期會讓 ssh 直接失敗且**無有用診斷**，無人值守需用 service token 或事先 refresh。#185 寫的「既有 `ssh_config`／`ProxyJump`／`--ssh-opt` 已足以」少了這個前提。
2. **`--remote-socket` 的配對敘述**。原文「`-R`／`-L` 兩端須成對指定同一路徑」的脈絡是共享 relay 的硬化情境，但照字面讀會讓人以為 agent-pull 不合法。改為明確界定該配對要求**只適用 relay 類形狀**。

README 的拓樸編號同步調整（中英雙語）：拓樸一 direct／**拓樸二 agent-pull（新）**／拓樸三 relay fallback。

### 順帶修掉一個會炸 release 的 fragment 型別

`changelog.d/188-185-...md`（已隨 #190 進 main）與本 PR 的 fragment 原本都寫 `type: docs`，但 `docs` **不在** policy engine 允許的 fragment 型別內（`change`／`deprecate`／`feat`／`fix`／`perf`／`refactor`／`remove`／`security`）。`render_section()` 對未知型別是 `raise FragmentError`，因此下一次 `python3 -m policy_check.changelog collate` 會直接失敗。R-09 只驗「有沒有 direct fragment」不驗型別，所以 #190 的 CI 沒抓到。兩個 fragment 都改成 `change`（→ Keep a Changelog 的 `Changed` 區），已本機模擬 collate 確認可正常產出。

### 未納入

不實測 Cloudflare／Tailscale 本身——需要 tenant，容器內做不到。本 PR 只把 **serialwrap 這一側**從「讀 code 推論」變成實證；provider 那側維持文件敘述。也不引入任何 provider-specific CLI 或 SDK（維持 #185 的決定）。

## Test Plan

- [x] `bash tools/docker/remote_tunnel_test.sh agent_pull` — PASS（真 sshd／真 ssh forward／真 unix socket 轉發／跨容器隔離）
- [x] `bash tools/docker/remote_tunnel_test.sh direct` — PASS（確認未弄壞既有拓樸）
- [x] `python3 -m pytest -q tests/` — **1684 passed, 16 skipped, 44 subtests passed**（0 failed）
- [x] `python3 -m policy_check --repo .` — 通過

## Policy Checklist (R-11)

- [x] 分支不是 `main`（不可直接 commit 到 main）
- [x] 變更已記錄：新增 `changelog.d/193-remote-agent-pull-topology.md` fragment
- [x] `VERSION` 已更新（若有版本號變動）— 無版本號變動，不適用
- [x] `python3 -m pytest -q tests/` 通過（無新失敗）
- [x] `python3 -m policy_check --repo .` 通過
- [x] 四份 agent 檔案已同步（若有修改 `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` / `.github/copilot-instructions.md`）— 本 PR 未修改，不適用
- [x] 已標記適用 label（無需豁免 label）
- [x] 回歸 case 評估已記錄（見下）

**回歸 case 評估（#155 政策）**：本變更的驗證面**就是** `regression/`／realhw 這一側——新增的 `rm-topo-agent-pull` 即為回歸 case，覆蓋 pytest 無法覆蓋的部分（真 sshd、真 ssh forward、真 unix socket 轉發、跨容器隔離斷言）。不需另加 pytest：`sw_core/` 零改動、無新的 in-process 行為可測，既有 `tests/test_remote_tunnel.py`／`tests/test_remote_cli.py` 已覆蓋 argv 組裝與 CLI 解析。

## Issue Reference

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMLyQNsN4hTHBzngEm7WYL
